### PR TITLE
Add .gitattributes to set *.sh files to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text=auto eol=lf


### PR DESCRIPTION
Closes #48. Ensures `*.sh` files are pushed and pulled with LF line terminators.