### PR TITLE
Add "Maximum Transfer Size" to About page

### DIFF
--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/about.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/about.html
@@ -12,6 +12,17 @@
     is the preferred method of sending records to the NCTR Archives.
     {% endblocktrans %}
 </p>
+<div class="title-text margin-top-25px">{% trans "Maximum Transfer Size" %}</div>
+<p>
+    {% blocktrans %}
+    Transfers sent through the transfer portal are subject to the maximum transfer size.
+    You may upload a <b>maximum of {{ max_total_upload_count }} files</b>, and <b>at most
+    {{ max_total_upload_size }}MiB of files</b>. Any <b>one file may not exceed
+    {{ max_single_upload_size }} MiB</b>. If you would like to transfer <i>more</i> than this
+    amount, please split your transfer into multiple parts, and use the group form to group similar
+    transfers together so our archivists know your transfers are related.
+    {% endblocktrans %}
+</p>
 <div class="title-text margin-top-25px">{% trans "Accepted File Types" %}</div>
 <p>
     {% blocktrans %}

--- a/bagitobjecttransfer/recordtransfer/views.py
+++ b/bagitobjecttransfer/recordtransfer/views.py
@@ -56,6 +56,9 @@ class About(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['accepted_files'] = settings.ACCEPTED_FILE_FORMATS
+        context['max_total_upload_size'] = settings.MAX_TOTAL_UPLOAD_SIZE
+        context['max_single_upload_size'] = settings.MAX_SINGLE_UPLOAD_SIZE
+        context['max_total_upload_count'] = settings.MAX_TOTAL_UPLOAD_COUNT
         return context
 
 


### PR DESCRIPTION
This pull request does not include any information about "security" on the about page. I do not know if this should be included, but the maximum transfer size should obviously be included. If it is deemed necessary to have security info in the about page in the future, I will add it in.