### PR TITLE
Add BAG_CHECKSUMS setting

### DIFF
--- a/bagitobjecttransfer/recordtransfer/apps.py
+++ b/bagitobjecttransfer/recordtransfer/apps.py
@@ -2,22 +2,42 @@ import logging
 import os
 
 from django.apps import AppConfig
+from django.core.exceptions import ImproperlyConfigured
 
-from recordtransfer.settings import BAG_STORAGE_FOLDER, UPLOAD_STORAGE_FOLDER
+from bagit import CHECKSUM_ALGOS
+
+from recordtransfer import settings
 
 
 LOGGER = logging.getLogger(__name__)
 
 
 class RecordTransferConfig(AppConfig):
+    ''' Top-level application config for the recordtransfer app
+    '''
+
     name = 'recordtransfer'
 
     def ready(self):
-        create_directories = [
-            ('BAG_STORAGE_FOLDER', BAG_STORAGE_FOLDER),
-            ('UPLOAD_STORAGE_FOLDER', UPLOAD_STORAGE_FOLDER),
-        ]
+        if not settings.BAG_CHECKSUMS:
+            raise ImproperlyConfigured(
+                'No checksums found in the BAG_CHECKSUMS setting! Choose one '
+                'or more checksum algorithms to generate checksums for when '
+                'creating a BagIt bag, separated by commas (i.e., "sha1,sha256")'
+            )
+        not_found = [a for a in settings.BAG_CHECKSUMS if a not in CHECKSUM_ALGOS]
+        if not_found:
+            not_supported = ', '.join(not_found)
+            supported = ', '.join(CHECKSUM_ALGOS)
+            raise ImproperlyConfigured((
+                'These algorithm(s) found in the BAG_CHECKSUMS setting are NOT '
+                'supported: {0}. The algorithms that ARE supported are: {1}.'
+            ).format(not_supported, supported))
 
+        create_directories = [
+            ('BAG_STORAGE_FOLDER', settings.BAG_STORAGE_FOLDER),
+            ('UPLOAD_STORAGE_FOLDER', settings.UPLOAD_STORAGE_FOLDER),
+        ]
         for name, directory in create_directories:
             if not os.path.exists(directory) or not os.path.isdir(directory):
                 os.mkdir(directory)

--- a/bagitobjecttransfer/recordtransfer/jobs.py
+++ b/bagitobjecttransfer/recordtransfer/jobs.py
@@ -17,7 +17,7 @@ from django.template.loader import render_to_string
 
 from recordtransfer.caais import convert_transfer_form_to_meta_tree
 from recordtransfer.models import Bag, BagGroup, UploadedFile, UploadSession, User, Job, Submission
-from recordtransfer.settings import DO_NOT_REPLY_USERNAME, ARCHIVIST_EMAIL
+from recordtransfer.settings import DO_NOT_REPLY_USERNAME, ARCHIVIST_EMAIL, BAG_CHECKSUMS
 from recordtransfer.tokens import account_activation_token
 from recordtransfer.utils import html_to_text, zip_directory
 
@@ -64,7 +64,7 @@ def bag_user_metadata_and_files(form_data: dict, user_submitted: User):
 
     LOGGER.info(msg='Creating bag on filesystem')
     bagging_result = new_bag.make_bag(
-        algorithms=['sha512'],
+        algorithms=BAG_CHECKSUMS,
         file_perms='644',
         move_files=True,
         logger=LOGGER,

--- a/bagitobjecttransfer/recordtransfer/settings.py
+++ b/bagitobjecttransfer/recordtransfer/settings.py
@@ -22,6 +22,12 @@ ALLOW_BAG_CHANGES = config('ALLOW_BAG_CHANGES', default=True, cast=bool)
 DO_NOT_REPLY_USERNAME = config('DO_NOT_REPLY_USERNAME', default='do-not-reply')
 ARCHIVIST_EMAIL = config('ARCHIVIST_EMAIL')
 
+# Checksum types
+
+BAG_CHECKSUMS = [
+    algorithm.strip() for algorithm in config('BAG_CHECKSUMS', default='sha512').split(',')
+]
+
 # Maximum upload thresholds
 
 MAX_TOTAL_UPLOAD_SIZE = config('MAX_TOTAL_UPLOAD_SIZE', default=256, cast=int)

--- a/docs/code/settings.rst
+++ b/docs/code/settings.rst
@@ -20,6 +20,10 @@ the :code:`.env` environment file. By category, these settings are:
 - :ref:`BAG_STORAGE_FOLDER`
 - :ref:`UPLOAD_STORAGE_FOLDER`
 
+**Checksums**
+
+- :ref:`BAG_CHECKSUMS`
+
 **Application Features**
 
 - :ref:`ALLOW_BAG_CHANGES`
@@ -206,6 +210,33 @@ UPLOAD_STORAGE_FOLDER
 
         #file: .env
         UPLOAD_STORAGE_FOLDER=/path/to/upload/folder
+
+
+BAG_CHECKSUMS
+-------------
+
+    *Choose the checksum algorithms used to create BagIt manifests*
+
+    .. table::
+
+        ========  =======  =========  ==================  =========================
+        Required  Default  Type       Can be set in .env  Can be set in settings.py
+        ========  =======  =========  ==================  =========================
+        NO        sha512   str        YES                 YES - Use with caution
+        ========  =======  =========  ==================  =========================
+
+    When BagIt is run, the selected algorithm(s) are used to generate manifests for the files as
+    well as the tag files in the Bag. Multiple algorithms can be used, separated by commas. Avoid
+    setting these algorithms directly in :code:`settings.py`, as there is some pre-processing of the
+    selected algorithms needed to make sure they're formatted correctly.
+
+
+    **.env Example:**
+
+    ::
+
+        #file: .env
+        BAG_CHECKSUMS=sha1,blake2b,md5
 
 
 ALLOW_BAG_CHANGES


### PR DESCRIPTION
Allows the BagIt checksums to be configured from the backend. Previously, sha512 was used all the time, but now this value can be changed. Multiple algorithms can be specified as well, if desired.