### PR TITLE
Fix InvalidVersion error

### DIFF
--- a/bagitobjecttransfer/requirements.txt
+++ b/bagitobjecttransfer/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/NationalCentreTruthReconciliation/django-dbtemplates@3.0.1-nctr#egg=django-dbtemplates
+git+https://github.com/NationalCentreTruthReconciliation/django-dbtemplates@3.0.1#egg=django-dbtemplates
 asgiref==3.4.1
 bagit==1.8.1
 click==8.0.3


### PR DESCRIPTION
setuptools was complaining about the version name `3.0.1-nctr`, so I've changed the tag name to `3.0.1` and that seems to have fixed the issue.