### PR TITLE
Hide or disable the Save Form button

### DIFF
--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_base.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_base.html
@@ -39,10 +39,10 @@
                         {% trans "Previous Step" %}
                     </button>
                 {% endif %}
-                {% if wizard.steps.step1 > 1 and wizard.steps.step1 < wizard.steps.count and save_form_enabled %}
+                {% if wizard.steps.step1 > 1 and wizard.steps.step1 < wizard.steps.count and save_form_state|stringformat:'s' != 'off' %}
                 <button class="blue-button margin-left-20px margin-right-20px" formnovalidate="formnovalidate"
                         name="save_form_step"
-                        value="{{ wizard.steps.current }}">
+                        value="{{ wizard.steps.current }}" {% if save_form_state|stringformat:'s' == 'disabled' %}disabled="disabled"{% endif %}>
                     {% trans "Save form" %}
                 </button>
                 {% endif %}

--- a/bagitobjecttransfer/recordtransfer/views.py
+++ b/bagitobjecttransfer/recordtransfer/views.py
@@ -296,8 +296,19 @@ class TransferFormWizard(SessionWizardView):
                 'source_roles': all_roles,
                 'source_types': all_types,
             })
-        can_save_form = SavedTransfer.objects.filter(user=self.request.user).count() < MAX_SAVED_TRANSFER_COUNT
-        context.update({'save_form_enabled': can_save_form})
+        resume_id = self.request.GET.get('resume_transfer', None)
+        max_saves = SavedTransfer.objects.filter(user=self.request.user).count()
+        if MAX_SAVED_TRANSFER_COUNT == 0:
+            # If MAX_SAVED_TRANSFER_COUNT is 0, then don't show the save form button.
+            save_form_state = 'off'
+        elif resume_id is None and max_saves >= MAX_SAVED_TRANSFER_COUNT:
+            # if the count of saved transfers is equal to or more than the maximum and we are NOT editing an existing
+            # transfer, disable the save form button.
+            save_form_state = 'disabled'
+        else:
+            # else enable the button.
+            save_form_state = 'on'
+        context.update({'save_form_state': save_form_state})
         return context
 
     def get_all_cleaned_data(self):


### PR DESCRIPTION
Instead of hiding the button when you exceed the allowed number of transfers. This now hides the button if you set the `MAX_SAVED_TRANSFER_COUNT` to `0` (i.e. disable saved transfers) and shows a disabled button if you have exceeded the max count.