### PR TITLE
Source type and source role are required fields

### DIFF
--- a/bagitobjecttransfer/recordtransfer/forms/transfer_forms.py
+++ b/bagitobjecttransfer/recordtransfer/forms/transfer_forms.py
@@ -254,7 +254,7 @@ class SourceInfoForm(TransferForm):
     )
 
     source_type = forms.ModelChoiceField(
-        required=False,
+        required=True,
         queryset=SourceType.objects.all()\
             .annotate(
                 sort_order_other_first=Case(
@@ -287,7 +287,7 @@ class SourceInfoForm(TransferForm):
     )
 
     source_role = forms.ModelChoiceField(
-        required=False,
+        required=True,
         queryset=SourceRole.objects.all()\
             .annotate(
                 sort_order_other_first=Case(


### PR DESCRIPTION
Cleaning up after #98 and realized that these two fields are required by validation but not marked as such (so not getting the red asterisk). 

I couldn't figure out a way to handle the "Other" text fields which are also required (short of making custom templates), but I think the current validation is sufficient.