### PR TITLE
Addresses Issue 124 (Add Debugging Config)

### DIFF
--- a/bagitobjecttransfer/.dockerignore
+++ b/bagitobjecttransfer/.dockerignore
@@ -1,1 +1,7 @@
-db.sqlite3
+*.sqlite3
+**/__pycache__
+.dockerignore
+docker-compose*
+Dockerfile
+example.dev.env
+example.prod.env

--- a/bagitobjecttransfer/docker-compose.dev.yml
+++ b/bagitobjecttransfer/docker-compose.dev.yml
@@ -25,10 +25,16 @@ services:
       - temp-directory:/tmp
       - ./docker/logs/django-rq:/var/log/django-rq/
       - ./docker/logs/django:/var/log/django/
+    ports:
+      - 8010:8010
     env_file:
       - .dev.env
+    # See manage.py for debugger setup
     environment:
       - ENV=dev
+      - ENABLE_DEBUGPY=1
+      - ENABLE_DEBUGPY_ON_COMMAND=rqworker
+      - DEBUGPY_PORT=8010
     depends_on:
       - redis
 
@@ -50,6 +56,7 @@ services:
     environment:
       - ENV=dev
       - ENABLE_DEBUGPY=1
+      - ENABLE_DEBUGPY_ON_COMMAND=runserver
       - DEBUGPY_PORT=8009
     depends_on:
       - rq

--- a/bagitobjecttransfer/docker-compose.dev.yml
+++ b/bagitobjecttransfer/docker-compose.dev.yml
@@ -43,10 +43,14 @@ services:
       - ./docker/logs/django:/var/log/django/
     ports:
       - 8000:8000
+      - 8009:8009
     env_file:
       - .dev.env
+    # See manage.py for debugger setup
     environment:
       - ENV=dev
+      - ENABLE_DEBUGPY=1
+      - DEBUGPY_PORT=8009
     depends_on:
       - rq
       - email

--- a/bagitobjecttransfer/manage.py
+++ b/bagitobjecttransfer/manage.py
@@ -5,12 +5,36 @@ import sys
 from decouple import config
 
 
+def initialize_debugger():
+    ''' Start debugging if these conditions are met:
+
+    - The Django DEBUG setting is True
+    - The ENABLE_DEBUGPY environment variable is "1"
+    - This is the main Django process (i.e., this is not the reloader process
+      Django runs to check for code changes)
+
+    You may also set the port debugpy uses. Otherwise, the port 8009 is used.
+
+    See:
+    - https://stackoverflow.com/a/73437126
+    - https://stackoverflow.com/a/62944426
+    '''
+    from django.conf import settings
+
+    if settings.DEBUG and config('ENABLE_DEBUGPY', default='0') == '1' and not os.getenv('RUN_MAIN'):
+        import debugpy
+        port = config('DEBUGPY_PORT', default=8009, cast=int)
+        print(f'Attaching debugger to port {port}')
+        debugpy.listen(('0.0.0.0', port))
+
+
 def main():
     if 'DJANGO_SETTINGS_MODULE' not in os.environ:
         os.environ['DJANGO_SETTINGS_MODULE'] = config(
             'DJANGO_SETTINGS_MODULE',
             default='bagitobjecttransfer.settings.sphinx',
         )
+
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -19,6 +43,8 @@ def main():
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
         ) from exc
+
+    initialize_debugger()
     execute_from_command_line(sys.argv)
 
 

--- a/bagitobjecttransfer/manage.py
+++ b/bagitobjecttransfer/manage.py
@@ -11,21 +11,32 @@ def initialize_debugger():
     - The Django DEBUG setting is True
     - The ENABLE_DEBUGPY environment variable is "1"
     - This is the main Django process (i.e., this is not the reloader process
-      Django runs to check for code changes)
+      Django runs to check for code changes - RUN_MAIN is checked for this
+      condition)
+    - This is a "runserver" command or other command set by the variable
+      "ENABLE_DEBUGPY_ON_COMMAND". This is to avoid clashing with other
+      manage.py commands like migrate or shell or makemigrations.
 
     You may also set the port debugpy uses. Otherwise, the port 8009 is used.
 
-    See:
+    See below for info related to RUN_MAIN:
     - https://stackoverflow.com/a/73437126
     - https://stackoverflow.com/a/62944426
     '''
     from django.conf import settings
 
-    if settings.DEBUG and config('ENABLE_DEBUGPY', default='0') == '1' and not os.getenv('RUN_MAIN'):
-        import debugpy
-        port = config('DEBUGPY_PORT', default=8009, cast=int)
-        print(f'Attaching debugger to port {port}')
-        debugpy.listen(('0.0.0.0', port))
+    if settings.DEBUG and \
+        config('ENABLE_DEBUGPY', default='0') == '1' and \
+        not os.getenv('RUN_MAIN'):
+
+        print(sys.argv)
+        command = config('ENABLE_DEBUGPY_ON_COMMAND', default='runserver')
+
+        if command in sys.argv:
+            import debugpy
+            port = config('DEBUGPY_PORT', default=8009, cast=int)
+            print(f'Attaching debugger to port {port}')
+            debugpy.listen(('0.0.0.0', port))
 
 
 def main():

--- a/bagitobjecttransfer/manage.py
+++ b/bagitobjecttransfer/manage.py
@@ -29,7 +29,6 @@ def initialize_debugger():
         config('ENABLE_DEBUGPY', default='0') == '1' and \
         not os.getenv('RUN_MAIN'):
 
-        print(sys.argv)
         command = config('ENABLE_DEBUGPY_ON_COMMAND', default='runserver')
 
         if command in sys.argv:

--- a/bagitobjecttransfer/requirements.txt
+++ b/bagitobjecttransfer/requirements.txt
@@ -5,6 +5,7 @@ clamd==1.0.2
 click==8.0.3
 colorama==0.4.4
 dateparser==1.1.1
+debugpy==1.6.7
 Deprecated==1.2.13
 Django==3.2.19
 django-countries==7.2.1


### PR DESCRIPTION
Resolves #124 by starting up `debugpy` when the app is run in the development container environment. Two separate instances of `debugpy` are started, one for the Django app, and one for the async jobs run via Django RQ.