### PR TITLE
Address Issue 128 (Read the Docs builds are Failing)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,6 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: "3.11"
+  version: "3.8"
   install:
     - requirements: bagitobjecttransfer/requirements.txt


### PR DESCRIPTION
Fixed by reverting to Python 3.8. Python 3.11 is not available in readthedocs.org yet.

Documentation is verified to be working here:

https://secure-record-transfer.readthedocs.io/en/issue-128/index.html

The link above may be broken in the future.

Closes #128 