### PR TITLE
Address Issue 109 (Site ID issue)

### DIFF
--- a/bagitobjecttransfer/bagitobjecttransfer/settings/production.py
+++ b/bagitobjecttransfer/bagitobjecttransfer/settings/production.py
@@ -5,7 +5,7 @@ from .base import *
 
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 DEBUG = False
-SITE_ID = config('SITE_ID', default=2, cast=int)
+SITE_ID = config('SITE_ID', default=1, cast=int)
 
 ALLOWED_HOSTS = re.split(r'\s+', config('HOST_DOMAINS'))
 

--- a/bagitobjecttransfer/example.dev.env
+++ b/bagitobjecttransfer/example.dev.env
@@ -4,7 +4,6 @@
 DJANGO_SETTINGS_MODULE=bagitobjecttransfer.settings.docker_dev
 
 SIGN_UP_ENABLED=True
-ALLOW_BAG_CHANGES=True
 BAG_STORAGE_FOLDER=/app/media/bags
 UPLOAD_STORAGE_FOLDER=/app/media/uploaded_files
 ARCHIVIST_EMAIL=archivist@localhost

--- a/bagitobjecttransfer/example.prod.env
+++ b/bagitobjecttransfer/example.prod.env
@@ -5,7 +5,6 @@ DJANGO_SETTINGS_MODULE=bagitobjecttransfer.settings.docker_prod
 ALLOWED_HOSTS=127.0.0.1 localhost
 
 SIGN_UP_ENABLED=True
-ALLOW_BAG_CHANGES=True
 BAG_STORAGE_FOLDER=/app/media/bags
 UPLOAD_STORAGE_FOLDER=/app/media/uploaded_files
 ARCHIVIST_EMAIL=archivist@localhost


### PR DESCRIPTION
Change default SITE_ID to "1" globally. The only remaining configuration that had a site ID of 2 was the `production.py` configuration.