### PR TITLE
Address Python version in compose file should be locked to major version

### DIFF
--- a/bagitobjecttransfer/Containerfile
+++ b/bagitobjecttransfer/Containerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.10
 
 # Set Work Directoy
 WORKDIR /app

--- a/bagitobjecttransfer/compose.dev.yml
+++ b/bagitobjecttransfer/compose.dev.yml
@@ -39,7 +39,9 @@ services:
       - mailhog:/home/mailhog/mail
 
   rq:
-    build: .
+    build:
+      context: .
+      dockerfile: Containerfile
     container_name: recordtransfer_rq_workers
     command: python manage.py rqworker default
     volumes:
@@ -60,7 +62,9 @@ services:
       - redis
 
   app:
-    build: .
+    build:
+      context: .
+      dockerfile: Containerfile
     container_name: recordtransfer_django_app
     command: python manage.py runserver 0.0.0.0:8000
     volumes:

--- a/bagitobjecttransfer/compose.prod.yml
+++ b/bagitobjecttransfer/compose.prod.yml
@@ -49,7 +49,9 @@ services:
       - ./docker/mysql/mysqld.cnf:/etc/mysql/mysqld.cnf:ro
 
   rq:
-    build: .
+    build:
+      context: .
+      dockerfile: Containerfile
     command: python manage.py rqworker default
     restart: unless-stopped
     networks:
@@ -65,7 +67,9 @@ services:
       - redis
 
   app:
-    build: .
+    build:
+      context: .
+      dockerfile: Containerfile
     command: gunicorn bagitobjecttransfer.wsgi:application --bind 0.0.0.0:8000 --enable-stdio-inheritance
     restart: unless-stopped
     networks:


### PR DESCRIPTION
Change python to 3.10 in Containerfile. Add changes to compose files so that they can be built in Docker, if needed.