### PR TITLE
Make timezone configurable

### DIFF
--- a/bagitobjecttransfer/bagitobjecttransfer/settings/base.py
+++ b/bagitobjecttransfer/bagitobjecttransfer/settings/base.py
@@ -123,7 +123,7 @@ FILE_UPLOAD_HANDLERS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'America/Winnipeg'
+TIME_ZONE = config('TIME_ZONE', default='America/Winnipeg')
 
 USE_I18N = True
 


### PR DESCRIPTION
Closes [issue 183](https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/183)

I'm not sure how TIMEZONE, and other environment variables such as SECRET_KEY will be set since I could not find them in the `example.*.env` files. Perhaps these will be added later? 