### PR TITLE
Fix missing stylesheet for submission detail page

### DIFF
--- a/bagitobjecttransfer/recordtransfer/templates/includes/submission_detail_css.html
+++ b/bagitobjecttransfer/recordtransfer/templates/includes/submission_detail_css.html
@@ -1,0 +1,9 @@
+{% if DEBUG %}
+    {% load static %}
+    <link rel="stylesheet"
+          type="text/css"
+          href="{% static 'recordtransfer/css/submission_detail/submission_detail.css' %}">
+{% else %}
+    {% load pipeline %}
+    {% stylesheet 'recordtransfer_submission_detail_styles' %}
+{% endif %}

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/base.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/base.html
@@ -1,51 +1,50 @@
 {% load static %}
 {% load i18n %}
-
 <html>
-<head>
-    <!-- JS -->
-    {% block javascript %}
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.1/dropzone.min.js"></script>
-    
-    {% if FILE_UPLOAD_ENABLED %}
-        {% include 'includes/dropzone_js.html' %}
-    {% endif %}
-    {% include 'includes/base_js.html' %}
-
-    {% endblock %}
-
-    <!-- CSS -->
-    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css">
-    {% include 'includes/base_css.html' %}
-
-    <!-- Favicon -->
-    <link rel="shortcut icon" type="image/png" href="{% static 'recordtransfer/img/favicon.ico' %}"/>
-
-    <title>{% block title %}{% endblock %}</title>
-</head>
-<body>
-    <div class="flex-wrapper">
-        {% block banner %}
-            {% include "recordtransfer/banner.html" %}
-        {% endblock %}
-        {% block header %}
-            {% include "recordtransfer/header.html" %}
-        {% endblock %}
-        <div class="main-container">
-            <div class="focused-content">
-                {% block focused_content %}{% endblock %}
+    <head>
+        <!-- JS -->
+        {% block javascript %}
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.1/dropzone.min.js"></script>
+            {% if FILE_UPLOAD_ENABLED %}
+                {% include "includes/dropzone_js.html" %}
+            {% endif %}
+            {% include "includes/base_js.html" %}
+        {% endblock javascript %}
+        <!-- CSS -->
+        <link rel="stylesheet"
+              type="text/css"
+              href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css">
+        {% include "includes/base_css.html" %}
+        <!-- Favicon -->
+        <link rel="shortcut icon"
+              type="image/png"
+              href="{% static "recordtransfer/img/favicon.ico" %}" />
+        <title>
+            {% block title %}{% endblock title %}
+        </title>
+    </head>
+    <body>
+        <div class="flex-wrapper">
+            {% block banner %}
+                {% include "recordtransfer/banner.html" %}
+            {% endblock banner %}
+            {% block header %}
+                {% include "recordtransfer/header.html" %}
+            {% endblock header %}
+            <div class="main-container">
+                <div class="focused-content">
+                    {% block focused_content %}{% endblock focused_content %}
+                </div>
+                <div class="main-content">
+                    {% block content %}{% endblock content %}
+                </div>
             </div>
-            <div class="main-content">
-                {% block content %}{% endblock %}
-            </div>
+            {% block footer %}
+                {% include "recordtransfer/footer.html" %}
+            {% endblock footer %}
         </div>
-        {% block footer %}
-            {% include "recordtransfer/footer.html" %}
-        {% endblock %}
-    </div>
-</body>
+    </body>
 </html>

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/submission_detail.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/submission_detail.html
@@ -1,9 +1,12 @@
 {% load i18n %}
 {% load static %}
 
-<html>
+<html lang="en">
 <head>
-    {% stylesheet 'recordtransfer_submission_detail_styles' %}
+    <title>Transfer Report for "{{ metadata.accession_title }}"</title>
+    <meta name="description" content="Automatically generated report for the transfer submission.">
+    <meta name="keywords" content="transfer, report, submission, metadata">
+    {% include "includes/submission_detail_css.html" %}
 </head>
 <body>
     <div class="main-title">Transfer Report for "{{ metadata.accession_title }}"</div>


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/201

### Notes:

I've opted to create a similar template to `base_css.html`, called `submission_detail_css.html`, which I load into `submission_detail.html`.

I think this would be better than to include that stylesheet in `base_css.html`, since only one template will be using `recordtransfer_submission_detail_styles`. 