### PR TITLE
Switch from MailHog to Mailpit

### DIFF
--- a/bagitobjecttransfer/bagitobjecttransfer/settings/docker_dev.py
+++ b/bagitobjecttransfer/bagitobjecttransfer/settings/docker_dev.py
@@ -38,9 +38,9 @@ RQ_QUEUES = {
 RQ_SHOW_ADMIN_LINK = True
 
 
-# Emailing - Uses MailHog to intercept emails
-# MailHog web UI runs at localhost:8025
-# More information: https://github.com/mailhog/MailHog
+# Emailing - Uses Mailpit to intercept emails
+# Mailpit web UI runs at localhost:8025
+# More information: https://github.com/axllent/mailpit
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'email'

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -21,20 +21,21 @@ services:
     environment:
       REDIS_REPLICATION_MODE: master
 
+  # See: https://mailpit.axllent.org/docs/install/docker/
   email:
-    image: docker.io/mailhog/mailhog
-    user: root
-    container_name: recordtransfer_mailhog
-    logging:
-      driver: 'none' # disable saving logs
+    image: docker.io/axllent/mailpit:latest
+    container_name: recordtransfer_mailpit
+    restart: unless-stopped
     ports:
       - 1025:1025
       - 8025:8025
-    environment:
-      MH_STORAGE: maildir
-      MH_MAILDIR_PATH: '/home/mailhog/mail'
     volumes:
-      - mailhog:/home/mailhog/mail
+      - mailpit-data:/data
+    environment:
+      MP_MAX_MESSAGES: 5000
+      MP_DATABASE: /data/mailpit.db
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
 
   rq:
     build:
@@ -88,4 +89,4 @@ services:
 volumes:
   temp-directory:
   clamav-virusdb:
-  mailhog:
+  mailpit-data:

--- a/docs/howtouse/addingusers.rst
+++ b/docs/howtouse/addingusers.rst
@@ -70,7 +70,7 @@ After clicking Sign Up, an email will be sent to the email the user entered. The
 link in the email to activate their account.
 
 .. image:: images/activation_email.png
-    :alt: User activation email in MailHog
+    :alt: User activation email
 
 When the user clicks the link or copies and pastes the link into their browser, their account will
 now be activated, and they will be logged in.

--- a/docs/running/index.rst
+++ b/docs/running/index.rst
@@ -62,13 +62,13 @@ user by running the following command.
     podman-compose -f compose.dev.yml exec app python manage.py createsuperuser
 
 
-The development application uses a simple `MailHog <https://github.com/mailhog/MailHog>`_ server to
+The development application uses a simple `Mailpit <https://github.com/axllent/mailpit>`_ server to
 intercept messages coming from the application. Visiting http://localhost:8025 when the app is
-running allows you to visit the MailHog dashboard, which lets you view all of the emails sent by the
-app.
+running allows you to visit the Mailpit dashboard, which lets you view all of the emails sent by
+the app.
 
 If you would like to create new users via the sign-up page, you can find the account activation
-emails in MailHog.
+emails in Mailpit.
 
 
 Finding Logs in the Development Application


### PR DESCRIPTION
Substitutes the MailHog container for [Mailpit](https://github.com/axllent/mailpit). Relevant documentation has also been updated - there are no mentions of the word MailHog any more.

The easiest way to test that emails are being intercept by Mailpit is to submit a Sign Up form.

![mailpit_screenshot](https://github.com/user-attachments/assets/eab95514-e794-4ed0-83d4-c6382ecdb50a)