### PR TITLE
Set up webpack --watch

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -62,6 +62,36 @@ Use this `launch.json` configuration in VSCode to debug the application:
 }
 ```
 
+## Javascript Development
+
+If you're editing any of the `.js` files in this repo, add these settings to your [local VSCode settings.json](https://code.visualstudio.com/docs/getstarted/settings#_settings-json-file) for this project to set your environment up.
+
+```json
+{
+    "[javascript]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "vscode.typescript-language-features",
+        "editor.rulers": [
+            99
+        ]
+    }
+}
+```
+
+### Re-build JS as Changes are Made
+
+After you run the dev container (`compose.dev.yml`), you can automatically re-build the JS files any time they change with this command:
+
+```shell
+# Using Docker:
+docker compose -f compose.dev.yml exec app npm run watch
+
+# Using Podman:
+podman-compose -f compose.dev.yml exec app npm run watch
+```
+
+This will re-build the bundled JS files any time you save a change to a `.js` file which is useful while you're writing Javascript. This command does not exit until you press CTRL-C, so make sure to run it in a separate terminal.
+
 ## Testing Setup
 
 Ensure that you've installed the `dev` dependencies locally (preferably in a virtual environment):

--- a/README.md
+++ b/README.md
@@ -58,3 +58,7 @@ If you'd like to be able to log in to the record transfer app as an administrato
 ```shell
 podman-compose -f compose.dev.yml exec app python manage.py createsuperuser
 ```
+
+## Developers
+
+See the [DEVELOPERS.md](DEVELOPERS.md) file for more info on setting your development environment up to work on this application.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "2024.10.22",
   "description": "The secure record transfer application has been designed for the purpose of transferring files and standardized metadata over the internet to an institution.",
   "scripts": {
-    "build": "webpack --config webpack.config.js"
+    "build": "webpack --config webpack.config.js",
+    "watch": "webpack --watch --config webpack.config.js"
   },
   "dependencies": {
     "css-loader": "^7.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,11 @@ console.log("CURRENT MODE IN WEBPACK: ", process.env.WEBPACK_MODE)
 module.exports = {
     mode: process.env.WEBPACK_MODE === 'production' ? 'production' : 'development',
     devtool: false,
+    watchOptions: {
+        aggregateTimeout: 500,
+        poll: 1000,
+        ignored: /node_modules/,
+    },
     entry: {
         base: [
             ...glob.sync('./bagitobjecttransfer/recordtransfer/static/recordtransfer/js/base/*.js')


### PR DESCRIPTION
Adds an `npm run watch` command which can be ran in the development container to re-build assets when they change.