### PR TITLE
Fix Read the Docs Build Failing

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
       - poetry config virtualenvs.create false
 
     post_install:
-      - source "$READTHEDOCS_VIRTUALENV_PATH/bin/activate" && poetry install --extras docs
+      - . "$READTHEDOCS_VIRTUALENV_PATH/bin/activate" && poetry install --extras docs
 
   tools:
     python: "3.10"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,12 +5,16 @@ version: 2
 
 build:
   os: "ubuntu-22.04"
-  commands:
-    - apt install pipx
-    - pipx ensurepath
-    - pipx install --user poetry
-    - poetry config virtualenvs.create false
-    - poetry install --extras docs
+  jobs:
+    pre_create_environment:
+      - asdf plugin add poetry
+      - asdf install poetry latest
+      - asdf global poetry latest
+      - poetry config virtualenvs.create false
+
+    post_install:
+      - source "$READTHEDOCS_VIRTUALENV_PATH/bin/activate" && poetry install --extras docs
+
   tools:
     python: "3.10"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,8 @@
 # Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for detail
+#
+# This configuration uses poetry to install dependencies because pip has trouble handling
+# package-mode = false in the pyproject.toml file.
 
 version: 2
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,15 +5,14 @@ version: 2
 
 build:
   os: "ubuntu-22.04"
+  commands:
+    - apt install pipx
+    - pipx ensurepath
+    - pipx install --user poetry
+    - poetry config virtualenvs.create false
+    - poetry install --extras docs
   tools:
     python: "3.10"
 
 sphinx:
   configuration: docs/conf.py
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs


### PR DESCRIPTION
Uses poetry instead of pip to install dependencies, since `package-mode = false` in `pyproject.toml` can't be handled with pip.

The working build can be seen here:

https://secure-record-transfer.readthedocs.io/en/273-fix-read-the-docs-build-failing/