### PR TITLE
Remove redundant migrate instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,6 @@ To start up the application, run the following command:
 podman-compose -f compose.dev.yml up -d
 ```
 
-The database will not be populated at first. To migrate the database, run this command:
-
-```shell
-podman-compose -f compose.dev.yml exec app python manage.py migrate
-```
-
 After the containers are built and running, the application should now be accessible at http://localhost:8000. Any emails that are sent by the application are intercepted by the mail application running at http://localhost:8025. For example, if you sign up using the sign-up form, you can find those at http://localhost:8025.
 
 To restart the application, run these commands:

--- a/docs/running/index.rst
+++ b/docs/running/index.rst
@@ -46,15 +46,7 @@ Visit http://localhost:8000 to see the application running.
 If you are using `Podman Desktop <https://podman-desktop.io/>`_, you should now see the application
 and all of its services running there, too.
 
-The application will not work at first, since the database is not populated. To populate the
-database, you can run the following command.
-
-.. code-block:: bash
-
-    podman-compose -f compose.dev.yml exec app python manage.py migrate --no-input
-
-
-You will also find that you cannot log in to the application. You can create a new administrator
+You will find that you cannot log in to the application. You can create a new administrator
 user by running the following command.
 
 .. code-block:: bash


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/272