### PR TITLE
Allow user to update their first and last name

### DIFF
--- a/bagitobjecttransfer/recordtransfer/constants.py
+++ b/bagitobjecttransfer/recordtransfer/constants.py
@@ -1,4 +1,6 @@
 # User Profile Form Field IDs
+ID_FIRST_NAME = "id_first_name"
+ID_LAST_NAME = "id_last_name"
 ID_GETS_NOTIFICATION_EMAILS = "id_gets_notification_emails"
 ID_CURRENT_PASSWORD = "id_current_password"
 ID_NEW_PASSWORD = "id_new_password"

--- a/bagitobjecttransfer/recordtransfer/forms/user_forms.py
+++ b/bagitobjecttransfer/recordtransfer/forms/user_forms.py
@@ -57,7 +57,7 @@ class UserProfileForm(forms.ModelForm):
         """Meta class for UserProfileForm."""
 
         model = User
-        fields = ("gets_notification_emails",)
+        fields = ("gets_notification_emails", "first_name", "last_name")
 
     def __init__(self, *args, **kwargs):
         user:User = kwargs.pop("user", None)

--- a/bagitobjecttransfer/recordtransfer/forms/user_forms.py
+++ b/bagitobjecttransfer/recordtransfer/forms/user_forms.py
@@ -60,13 +60,7 @@ class UserProfileForm(forms.ModelForm):
         fields = ("gets_notification_emails", "first_name", "last_name")
 
     def __init__(self, *args, **kwargs):
-        user:User = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
-        if user:
-            self.fields["first_name"].initial = user.first_name
-            self.fields["last_name"].initial = user.last_name
-            self.fields["gets_notification_emails"].initial = user.gets_notification_emails
-
 
     def clean(self) -> "dict[str, Any]":
         """Clean the form data."""
@@ -180,3 +174,14 @@ class UserProfileForm(forms.ModelForm):
         if commit:
             user.save()
         return user
+
+    def reset_form(self):
+        """Reset form fields to initial values from instance."""
+        if self.instance:
+            self.data = self.data.copy()
+            self.data['first_name'] = self.instance.first_name
+            self.data['last_name'] = self.instance.last_name
+            self.data['gets_notification_emails'] = self.instance.gets_notification_emails
+            self.data['current_password'] = ''
+            self.data['new_password'] = ''
+            self.data['confirm_new_password'] = ''

--- a/bagitobjecttransfer/recordtransfer/forms/user_forms.py
+++ b/bagitobjecttransfer/recordtransfer/forms/user_forms.py
@@ -17,8 +17,10 @@ from recordtransfer.models import User
 
 import re
 
+
 class UserProfileForm(forms.ModelForm):
     """Form for editing user profile."""
+
     first_name = forms.CharField(
         widget=forms.TextInput(attrs={"id": ID_FIRST_NAME}),
         label=_("First Name"),
@@ -52,6 +54,9 @@ class UserProfileForm(forms.ModelForm):
     )
 
     NAME_PATTERN = re.compile(r"^(?!.*[.\s']{2})[A-Za-z\s.'-]+$")
+    NAME_VALIDATION_MESSAGE = _(
+        "Name must contain only letters and may include these symbols: ' - . \n"
+    )
 
     class Meta:
         """Meta class for UserProfileForm."""
@@ -76,22 +81,10 @@ class UserProfileForm(forms.ModelForm):
         last_name = cleaned_data.get("last_name")
 
         if first_name and not self.NAME_PATTERN.match(first_name):
-            raise ValidationError(
-            {
-                "first_name": [
-                _("Invalid first name."),
-                ]
-            }
-            )
+            raise ValidationError({"first_name": [self.NAME_VALIDATION_MESSAGE]})
 
         if last_name and not self.NAME_PATTERN.match(last_name):
-            raise ValidationError(
-            {
-                "last_name": [
-                _("Invalid last name."),
-                ]
-            }
-            )
+            raise ValidationError({"last_name": [self.NAME_VALIDATION_MESSAGE]})
 
         password_change = False
 
@@ -134,7 +127,9 @@ class UserProfileForm(forms.ModelForm):
                 raise ValidationError(
                     {
                         "new_password": [
-                            _("The new password must be different from the current password."),
+                            _(
+                                "The new password must be different from the current password."
+                            ),
                         ]
                     }
                 )
@@ -148,7 +143,7 @@ class UserProfileForm(forms.ModelForm):
                     }
                 )
 
-            password_change = True           
+            password_change = True
 
         if not self.has_changed() and not password_change:
             raise ValidationError(_("No fields have been changed."))
@@ -166,7 +161,7 @@ class UserProfileForm(forms.ModelForm):
         gets_notification_emails = self.cleaned_data.get("gets_notification_emails")
         if gets_notification_emails is not None:
             user.gets_notification_emails = gets_notification_emails
-        
+
         # First and last name always get updated since they are required fields
         user.first_name = self.cleaned_data.get("first_name", user.first_name)
         user.last_name = self.cleaned_data.get("last_name", user.last_name)
@@ -179,9 +174,11 @@ class UserProfileForm(forms.ModelForm):
         """Reset form fields to initial values from instance."""
         if self.instance:
             self.data = self.data.copy()
-            self.data['first_name'] = self.instance.first_name
-            self.data['last_name'] = self.instance.last_name
-            self.data['gets_notification_emails'] = self.instance.gets_notification_emails
-            self.data['current_password'] = ''
-            self.data['new_password'] = ''
-            self.data['confirm_new_password'] = ''
+            self.data["first_name"] = self.instance.first_name
+            self.data["last_name"] = self.instance.last_name
+            self.data["gets_notification_emails"] = (
+                self.instance.gets_notification_emails
+            )
+            self.data["current_password"] = ""
+            self.data["new_password"] = ""
+            self.data["confirm_new_password"] = ""

--- a/bagitobjecttransfer/recordtransfer/forms/user_forms.py
+++ b/bagitobjecttransfer/recordtransfer/forms/user_forms.py
@@ -163,9 +163,19 @@ class UserProfileForm(forms.ModelForm):
     def save(self, commit: bool = True) -> User:
         """Save the form data."""
         user: User = super().save(commit=False)
+        
         new_password = self.cleaned_data.get("new_password")
         if new_password:
             user.set_password(new_password)
+
+        gets_notification_emails = self.cleaned_data.get("gets_notification_emails")
+        if gets_notification_emails:
+            user.gets_notification_emails = gets_notification_emails
+        
+        # First and last name always get updated since they are required fields
+        user.first_name = self.cleaned_data.get("first_name", user.first_name)
+        user.last_name = self.cleaned_data.get("last_name", user.last_name)
+
         if commit:
             user.save()
         return user

--- a/bagitobjecttransfer/recordtransfer/forms/user_forms.py
+++ b/bagitobjecttransfer/recordtransfer/forms/user_forms.py
@@ -158,14 +158,6 @@ class UserProfileForm(forms.ModelForm):
         if new_password:
             user.set_password(new_password)
 
-        gets_notification_emails = self.cleaned_data.get("gets_notification_emails")
-        if gets_notification_emails is not None:
-            user.gets_notification_emails = gets_notification_emails
-
-        # First and last name always get updated since they are required fields
-        user.first_name = self.cleaned_data.get("first_name", user.first_name)
-        user.last_name = self.cleaned_data.get("last_name", user.last_name)
-
         if commit:
             user.save()
         return user

--- a/bagitobjecttransfer/recordtransfer/forms/user_forms.py
+++ b/bagitobjecttransfer/recordtransfer/forms/user_forms.py
@@ -67,6 +67,7 @@ class UserProfileForm(forms.ModelForm):
             self.fields["last_name"].initial = user.last_name
             self.fields["gets_notification_emails"].initial = user.gets_notification_emails
 
+
     def clean(self) -> "dict[str, Any]":
         """Clean the form data."""
         if not self.data:
@@ -163,13 +164,13 @@ class UserProfileForm(forms.ModelForm):
     def save(self, commit: bool = True) -> User:
         """Save the form data."""
         user: User = super().save(commit=False)
-        
+
         new_password = self.cleaned_data.get("new_password")
         if new_password:
             user.set_password(new_password)
 
         gets_notification_emails = self.cleaned_data.get("gets_notification_emails")
-        if gets_notification_emails:
+        if gets_notification_emails is not None:
             user.gets_notification_emails = gets_notification_emails
         
         # First and last name always get updated since they are required fields

--- a/bagitobjecttransfer/recordtransfer/forms/user_forms.py
+++ b/bagitobjecttransfer/recordtransfer/forms/user_forms.py
@@ -21,15 +21,33 @@ import re
 class UserProfileForm(forms.ModelForm):
     """Form for editing user profile."""
 
-    first_name = forms.CharField(
+    NAME_PATTERN = re.compile(
+        r"""^[a-zA-Z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u01FF]+([ \-']{0,1}[a-zA-Z\u00C0-\u00D6
+    \u00D8-\u00F6\u00F8-\u01FF]+){0,2}[.]{0,1}$"""
+    )
+    NAME_VALIDATION_MESSAGE = _(
+        "Name must contain only letters and may include these symbols: ' - . \n"
+    )
+
+    first_name = forms.RegexField(
+        regex=NAME_PATTERN,
         widget=forms.TextInput(attrs={"id": ID_FIRST_NAME}),
         label=_("First Name"),
         required=True,
+        error_messages={
+            "required": _("First name is required."),
+            "invalid": _(NAME_VALIDATION_MESSAGE),
+        },
     )
-    last_name = forms.CharField(
+    last_name = forms.RegexField(
+        regex=NAME_PATTERN,
         widget=forms.TextInput(attrs={"id": ID_LAST_NAME}),
         label=_("Last Name"),
         required=True,
+        error_messages={
+            "required": _("Last name is required."),
+            "invalid": _(NAME_VALIDATION_MESSAGE),
+        },
     )
     gets_notification_emails = forms.BooleanField(
         widget=forms.CheckboxInput(attrs={"id": ID_GETS_NOTIFICATION_EMAILS}),
@@ -53,11 +71,6 @@ class UserProfileForm(forms.ModelForm):
         required=False,
     )
 
-    NAME_PATTERN = re.compile(r"^(?!.*[.\s']{2})[A-Za-z\s.'-]+$")
-    NAME_VALIDATION_MESSAGE = _(
-        "Name must contain only letters and may include these symbols: ' - . \n"
-    )
-
     class Meta:
         """Meta class for UserProfileForm."""
 
@@ -76,15 +89,6 @@ class UserProfileForm(forms.ModelForm):
         current_password = cleaned_data.get("current_password")
         new_password = cleaned_data.get("new_password")
         confirm_new_password = cleaned_data.get("confirm_new_password")
-
-        first_name = cleaned_data.get("first_name")
-        last_name = cleaned_data.get("last_name")
-
-        if first_name and not self.NAME_PATTERN.match(first_name):
-            raise ValidationError({"first_name": [self.NAME_VALIDATION_MESSAGE]})
-
-        if last_name and not self.NAME_PATTERN.match(last_name):
-            raise ValidationError({"last_name": [self.NAME_VALIDATION_MESSAGE]})
 
         password_change = False
 

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/base/messages.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/base/messages.js
@@ -1,0 +1,7 @@
+$(() => {
+    $(document).ready(function () {
+        $("button.close[data-dismiss=alert]").on("click", function (evt) {
+            $(evt.currentTarget).parents(".alert-dismissible").hide();
+        });
+    });
+})

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/profile/profile.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/profile/profile.js
@@ -1,27 +1,38 @@
 document.addEventListener("DOMContentLoaded", function () {
+    const firstName = document.getElementById(ID_FIRST_NAME);
+    const lastName = document.getElementById(ID_LAST_NAME);
     const getsNotificationEmails = document.getElementById(ID_GETS_NOTIFICATION_EMAILS);
     const currentPassword = document.getElementById(ID_CURRENT_PASSWORD);
     const newPassword = document.getElementById(ID_NEW_PASSWORD);
     const confirmNewPassword = document.getElementById(ID_CONFIRM_NEW_PASSWORD);
 
-    const inputFields = [getsNotificationEmails, currentPassword, newPassword, confirmNewPassword];
+    const inputFields = [
+        firstName,
+        lastName,
+        getsNotificationEmails,
+        currentPassword,
+        newPassword,
+        confirmNewPassword
+    ];
 
     const saveButton = document.getElementById("id_save_button");
 
     const initialValues = {
+        firstName: firstName.value,
+        lastName: lastName.value,
         getsNotificationEmails: getsNotificationEmails.checked,
-        currentPassword: currentPassword.value,
-        newPassword: newPassword.value,
-        confirmNewPassword: confirmNewPassword.value
     };
 
     function checkForChanges() {
+        const firstNameChanged = firstName.value !== initialValues.firstName;
+        const lastNameChanged = lastName.value !== initialValues.lastName;
         const notificationChanged = getsNotificationEmails.checked !== initialValues.getsNotificationEmails;
-        const passwordFieldsChanged = currentPassword.value !== initialValues.currentPassword &&
-            newPassword.value !== initialValues.newPassword &&
-            confirmNewPassword.value !== initialValues.confirmNewPassword;
 
-        const hasChanged = notificationChanged || passwordFieldsChanged;
+        const passwordFieldsPopulated = currentPassword.value !== "" &&
+            newPassword.value !== "" &&
+            confirmNewPassword.value !== "";
+
+        const hasChanged = firstNameChanged || lastNameChanged || notificationChanged || passwordFieldsPopulated;
         saveButton.disabled = !hasChanged;
     }
 

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/profile/profile.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/profile/profile.js
@@ -1,4 +1,4 @@
-document.addEventListener("DOMContentLoaded", function () {
+document.addEventListener("DOMContentLoaded", () => {
     const firstName = document.getElementById(ID_FIRST_NAME);
     const lastName = document.getElementById(ID_LAST_NAME);
     const getsNotificationEmails = document.getElementById(ID_GETS_NOTIFICATION_EMAILS);
@@ -23,34 +23,30 @@ document.addEventListener("DOMContentLoaded", function () {
         getsNotificationEmails: getsNotificationEmails.checked,
     };
 
-    function checkForChanges() {
-        const firstNameChanged = firstName.value !== initialValues.firstName;
-        const lastNameChanged = lastName.value !== initialValues.lastName;
-        const notificationChanged = getsNotificationEmails.checked !== initialValues.getsNotificationEmails;
+    const checkForChanges = () => {
+        const hasChanged = firstName.value !== initialValues.firstName ||
+            lastName.value !== initialValues.lastName ||
+            getsNotificationEmails.checked !== initialValues.getsNotificationEmails ||
+            (currentPassword.value && newPassword.value && confirmNewPassword.value);
 
-        const passwordFieldsPopulated = currentPassword.value !== "" &&
-            newPassword.value !== "" &&
-            confirmNewPassword.value !== "";
-
-        const hasChanged = firstNameChanged || lastNameChanged || notificationChanged || passwordFieldsPopulated;
         saveButton.disabled = !hasChanged;
-    }
+    };
 
-    Array.from(inputFields).forEach(input => {
+    inputFields.forEach(input => {
         input.addEventListener(input.type === "checkbox" ? "change" : "input", checkForChanges);
     });
 
     checkForChanges();
 
     // Save scroll position before page unload
-    window.addEventListener('beforeunload', function () {
+    window.addEventListener('beforeunload', () => {
         localStorage.setItem('scrollPosition', window.scrollY);
     });
 
     // Restore scroll position after page load
-    window.addEventListener('load', function () {
+    window.addEventListener('load', () => {
         const scrollPosition = localStorage.getItem('scrollPosition');
-        if (scrollPosition !== null) {
+        if (scrollPosition) {
             window.scrollTo(0, parseInt(scrollPosition, 10));
             localStorage.removeItem('scrollPosition');
         }

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/profile/profile.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/profile/profile.js
@@ -1,10 +1,19 @@
 document.addEventListener("DOMContentLoaded", () => {
-    const firstName = document.getElementById(ID_FIRST_NAME);
-    const lastName = document.getElementById(ID_LAST_NAME);
-    const getsNotificationEmails = document.getElementById(ID_GETS_NOTIFICATION_EMAILS);
-    const currentPassword = document.getElementById(ID_CURRENT_PASSWORD);
-    const newPassword = document.getElementById(ID_NEW_PASSWORD);
-    const confirmNewPassword = document.getElementById(ID_CONFIRM_NEW_PASSWORD);
+    // Context passed from template to JS
+    const userProfileContextElement = document.getElementById("py_context_user_profile");
+
+    if (!userProfileContextElement) {
+        return;
+    }
+
+    const userProfileContext = JSON.parse(userProfileContextElement.textContent);
+
+    const firstName = document.getElementById(userProfileContext["ID_FIRST_NAME"]);
+    const lastName = document.getElementById(userProfileContext["ID_LAST_NAME"]);
+    const getsNotificationEmails = document.getElementById(userProfileContext["ID_GETS_NOTIFICATION_EMAILS"]);
+    const currentPassword = document.getElementById(userProfileContext["ID_CURRENT_PASSWORD"]);
+    const newPassword = document.getElementById(userProfileContext["ID_NEW_PASSWORD"]);
+    const confirmNewPassword = document.getElementById(userProfileContext["ID_CONFIRM_NEW_PASSWORD"]);
 
     const inputFields = [
         firstName,

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/forms.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/forms.js
@@ -531,12 +531,3 @@ $(() => {
         initializeModalMode();
     }
 })
-
-
-$(() => {
-    $(document).ready(function () {
-        $("button.close[data-dismiss=alert]").on("click", function (evt) {
-            $(evt.currentTarget).parents(".alert-dismissible").hide();
-        });
-    });
-})

--- a/bagitobjecttransfer/recordtransfer/templates/includes/profile_form.html
+++ b/bagitobjecttransfer/recordtransfer/templates/includes/profile_form.html
@@ -2,9 +2,29 @@
 {% include "includes/messages.html" %}
 <form method="post" action="{% url 'recordtransfer:userprofile' %}">
     {% csrf_token %}
-    <div class="flex-item margin-top-25px">
-        <label>{% trans "Name" %}</label>
-        <input disabled value="{{ user.get_full_name }}">
+    {% if form.first_name.errors %}
+        <div class="error-message">{% trans form.first_name.errors.0 %}</div>
+    {% endif %}
+    <div class="flex-item">
+        <label for="{{ form.first_name.id_for_label }}">{% trans form.first_name.label %}</label>
+        <input
+            type="text"
+            name="{{ form.first_name.name }}"
+            id="{{ form.first_name.id_for_label }}"
+            value="{{ form.first_name.value }}"
+        >
+    </div>
+    {% if form.last_name.errors %}
+        <div class="error-message">{% trans form.last_name.errors.0 %}</div>
+    {% endif %}
+    <div class="flex-item">
+        <label for="{{ form.last_name.id_for_label }}">{% trans form.last_name.label %}</label>
+        <input
+            type="text"
+            name="{{ form.last_name.name }}"
+            id="{{ form.last_name.id_for_label }}"
+            value="{{ form.last_name.value }}"
+        >
     </div>
     <div class="flex-item">
         <label>{% trans "Email" %}</label>

--- a/bagitobjecttransfer/recordtransfer/templates/includes/profile_form.html
+++ b/bagitobjecttransfer/recordtransfer/templates/includes/profile_form.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% include "includes/messages.html" %}
-<form method="post" action="{% url 'recordtransfer:userprofile' %}">
+<form method="post" action="{% url 'recordtransfer:userprofile' %}" class="margin-top-25px">
     {% csrf_token %}
     {% if form.first_name.errors %}
         <div class="error-message">{% trans form.first_name.errors.0 %}</div>

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/profile.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/profile.html
@@ -6,15 +6,7 @@
 {% endblock title %}
 {% block javascript %}
     {{ block.super }}
-    <script>
-        // Pass constants to JavaScript used by profile form
-        const ID_FIRST_NAME = "{{ ID_FIRST_NAME }}";
-        const ID_LAST_NAME = "{{ ID_LAST_NAME }}";
-        const ID_GETS_NOTIFICATION_EMAILS = "{{ ID_GETS_NOTIFICATION_EMAILS }}";
-        const ID_CURRENT_PASSWORD = "{{ ID_CURRENT_PASSWORD }}";
-        const ID_NEW_PASSWORD = "{{ ID_NEW_PASSWORD }}";
-        const ID_CONFIRM_NEW_PASSWORD = "{{ ID_CONFIRM_NEW_PASSWORD }}";
-    </script>
+    {{ js_context|json_script:"py_context_user_profile" }}
     <script src="{% static 'profile.bundle.js' %}"></script>
 {% endblock javascript %}
 {% block content %}

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/profile.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/profile.html
@@ -8,6 +8,8 @@
     {{ block.super }}
     <script>
         // Pass constants to JavaScript used by profile form
+        const ID_FIRST_NAME = "{{ ID_FIRST_NAME }}";
+        const ID_LAST_NAME = "{{ ID_LAST_NAME }}";
         const ID_GETS_NOTIFICATION_EMAILS = "{{ ID_GETS_NOTIFICATION_EMAILS }}";
         const ID_CURRENT_PASSWORD = "{{ ID_CURRENT_PASSWORD }}";
         const ID_NEW_PASSWORD = "{{ ID_NEW_PASSWORD }}";

--- a/bagitobjecttransfer/recordtransfer/tests/test_forms.py
+++ b/bagitobjecttransfer/recordtransfer/tests/test_forms.py
@@ -32,6 +32,17 @@ class UserProfileFormTest(TestCase):
         user = form.save()
         self.assertEqual(user.first_name, "New")
         self.assertEqual(user.last_name, "Name")
+
+    def test_form_accented_name_change(self):
+        form_data = {
+            "first_name": "Áccéntéd",
+            "last_name": "Námé",
+        }
+        form = UserProfileForm(data=form_data, instance=self.user)
+        self.assertTrue(form.is_valid())
+        user = form.save()
+        self.assertEqual(user.first_name, "Áccéntéd")
+        self.assertEqual(user.last_name, "Námé")
     
     def test_form_invalid_first_name(self):
         form_data = {

--- a/bagitobjecttransfer/recordtransfer/tests/test_forms.py
+++ b/bagitobjecttransfer/recordtransfer/tests/test_forms.py
@@ -22,7 +22,40 @@ class UserProfileFormTest(TestCase):
             gets_notification_emails=self.test_gets_notification_emails,
         )
 
-    def test_form_valid_data(self):
+    def test_form_valid_name_change(self):
+        form_data = {
+            "first_name": "New",
+            "last_name": "Name",
+            "gets_notification_emails": self.test_gets_notification_emails,
+            "current_password": "",
+            "new_password": "",
+            "confirm_new_password": "",
+        }
+        form = UserProfileForm(data=form_data, instance=self.user)
+        self.assertTrue(form.is_valid())
+        user = form.save()
+        self.assertEqual(user.first_name, "New")
+        self.assertEqual(user.last_name, "Name")
+    
+    def test_form_invalid_first_name(self):
+        form_data = {
+            "first_name": "123",
+            "last_name": self.test_last_name,
+        }
+        form = UserProfileForm(data=form_data, instance=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("first_name", form.errors)
+    
+    def test_form_invalid_last_name(self):
+        form_data = {
+            "first_name": self.test_first_name,
+            "last_name": "123",
+        }
+        form = UserProfileForm(data=form_data, instance=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("last_name", form.errors)
+
+    def test_form_valid_password_change(self):
         form_data = {
             "first_name": self.test_first_name,
             "last_name": self.test_last_name,
@@ -38,6 +71,8 @@ class UserProfileFormTest(TestCase):
 
     def test_form_invalid_current_password(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "gets_notification_emails": True,
             "current_password": "wrong_password",
             "new_password": "new_password123",
@@ -49,6 +84,8 @@ class UserProfileFormTest(TestCase):
 
     def test_form_new_passwords_do_not_match(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "current_password": self.test_password,
             "new_password": "new_password123",
             "confirm_new_password": "different_password",
@@ -59,6 +96,8 @@ class UserProfileFormTest(TestCase):
 
     def test_form_missing_current_password(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "new_password": "new_password123",
             "confirm_new_password": "new_password123",
         }
@@ -77,6 +116,8 @@ class UserProfileFormTest(TestCase):
 
     def test_form_missing_confirm_new_password(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "current_password": self.test_password,
             "new_password": "new_password123",
         }
@@ -86,6 +127,8 @@ class UserProfileFormTest(TestCase):
 
     def test_form_new_password_is_same_as_old_password(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "current_password": self.test_password,
             "new_password": self.test_password,
             "confirm_new_password": self.test_password,

--- a/bagitobjecttransfer/recordtransfer/tests/test_forms.py
+++ b/bagitobjecttransfer/recordtransfer/tests/test_forms.py
@@ -6,19 +6,30 @@ from recordtransfer.models import User
 
 class UserProfileFormTest(TestCase):
     def setUp(self):
+        self.test_username = "testuser"
+        self.test_first_name = "Test"
+        self.test_last_name = "User"
+        self.test_email = "testuser@example.com"
+        self.test_password = "old_password"
+        self.test_gets_notification_emails = True
+        self.test_new_password = "new_password123"
         self.user = User.objects.create_user(
-            username="testuser",
-            email="testuser@example.com",
-            password="old_password",
-            gets_notification_emails=True,
+            username=self.test_username,
+            first_name=self.test_first_name,
+            last_name=self.test_last_name,
+            email=self.test_email,
+            password=self.test_password,
+            gets_notification_emails=self.test_gets_notification_emails,
         )
 
     def test_form_valid_data(self):
         form_data = {
-            "gets_notification_emails": True,
-            "current_password": "old_password",
-            "new_password": "new_password123",
-            "confirm_new_password": "new_password123",
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
+            "gets_notification_emails": self.test_gets_notification_emails,
+            "current_password": self.test_password,
+            "new_password": self.test_new_password,
+            "confirm_new_password": self.test_new_password,
         }
         form = UserProfileForm(data=form_data, instance=self.user)
         self.assertTrue(form.is_valid())
@@ -38,7 +49,7 @@ class UserProfileFormTest(TestCase):
 
     def test_form_new_passwords_do_not_match(self):
         form_data = {
-            "current_password": "old_password",
+            "current_password": self.test_password,
             "new_password": "new_password123",
             "confirm_new_password": "different_password",
         }
@@ -57,7 +68,7 @@ class UserProfileFormTest(TestCase):
 
     def test_form_missing_new_password(self):
         form_data = {
-            "current_password": "old_password",
+            "current_password": self.test_password,
             "confirm_new_password": "new_password123",
         }
         form = UserProfileForm(data=form_data, instance=self.user)
@@ -66,7 +77,7 @@ class UserProfileFormTest(TestCase):
 
     def test_form_missing_confirm_new_password(self):
         form_data = {
-            "current_password": "old_password",
+            "current_password": self.test_password,
             "new_password": "new_password123",
         }
         form = UserProfileForm(data=form_data, instance=self.user)
@@ -75,9 +86,9 @@ class UserProfileFormTest(TestCase):
 
     def test_form_new_password_is_same_as_old_password(self):
         form_data = {
-            "current_password": "old_password",
-            "new_password": "old_password",
-            "confirm_new_password": "old_password",
+            "current_password": self.test_password,
+            "new_password": self.test_password,
+            "confirm_new_password": self.test_password,
         }
         form = UserProfileForm(data=form_data, instance=self.user)
         self.assertFalse(form.is_valid())
@@ -94,6 +105,8 @@ class UserProfileFormTest(TestCase):
         self.user.save()
 
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "gets_notification_emails": True,
         }
         form = UserProfileForm(data=form_data, instance=self.user)
@@ -103,6 +116,8 @@ class UserProfileFormTest(TestCase):
 
     def test_form_email_notification_initial_true(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "gets_notification_emails": False,
         }
         form = UserProfileForm(data=form_data, instance=self.user)
@@ -112,7 +127,9 @@ class UserProfileFormTest(TestCase):
 
     def test_form_no_changes(self):
         form_data = {
-            "gets_notification_emails": True,
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
+            "gets_notification_emails": self.test_gets_notification_emails,
             "current_password": "",
             "new_password": "",
             "confirm_new_password": "",

--- a/bagitobjecttransfer/recordtransfer/tests/test_forms.py
+++ b/bagitobjecttransfer/recordtransfer/tests/test_forms.py
@@ -26,10 +26,6 @@ class UserProfileFormTest(TestCase):
         form_data = {
             "first_name": "New",
             "last_name": "Name",
-            "gets_notification_emails": self.test_gets_notification_emails,
-            "current_password": "",
-            "new_password": "",
-            "confirm_new_password": "",
         }
         form = UserProfileForm(data=form_data, instance=self.user)
         self.assertTrue(form.is_valid())
@@ -59,7 +55,6 @@ class UserProfileFormTest(TestCase):
         form_data = {
             "first_name": self.test_first_name,
             "last_name": self.test_last_name,
-            "gets_notification_emails": self.test_gets_notification_emails,
             "current_password": self.test_password,
             "new_password": self.test_new_password,
             "confirm_new_password": self.test_new_password,
@@ -73,7 +68,6 @@ class UserProfileFormTest(TestCase):
         form_data = {
             "first_name": self.test_first_name,
             "last_name": self.test_last_name,
-            "gets_notification_emails": True,
             "current_password": "wrong_password",
             "new_password": "new_password123",
             "confirm_new_password": "new_password123",
@@ -107,6 +101,8 @@ class UserProfileFormTest(TestCase):
 
     def test_form_missing_new_password(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "current_password": self.test_password,
             "confirm_new_password": "new_password123",
         }

--- a/bagitobjecttransfer/recordtransfer/tests/test_views.py
+++ b/bagitobjecttransfer/recordtransfer/tests/test_views.py
@@ -578,7 +578,7 @@ class TestUserProfileView(TestCase):
         self.test_first_name = "Test"
         self.test_last_name = "User"
         self.test_email = "testuser@example.com"
-        self.test_password = "old_password"
+        self.test_current_password = "old_password"
         self.test_gets_notification_emails = True
         self.test_new_password = "new_password123"
         self.user = User.objects.create_user(
@@ -586,7 +586,7 @@ class TestUserProfileView(TestCase):
             first_name=self.test_first_name,
             last_name=self.test_last_name,
             email=self.test_email,
-            password=self.test_password,
+            password=self.test_current_password,
             gets_notification_emails=self.test_gets_notification_emails,
         )
         self.client.login(username="testuser", password="old_password")
@@ -648,9 +648,6 @@ class TestUserProfileView(TestCase):
             "first_name": self.test_first_name,
             "last_name": self.test_last_name,
             "gets_notification_emails": False,
-            "current_password": "",
-            "new_password": "",
-            "confirm_new_password": "",
         }
         response = self.client.post(self.url, data=form_data)
         self.assertRedirects(response, self.url)
@@ -661,10 +658,7 @@ class TestUserProfileView(TestCase):
         form_data = {
             "first_name": self.test_first_name,
             "last_name": self.test_last_name,
-            "gets_notification_emails": True,
-            "current_password": "",
-            "new_password": "",
-            "confirm_new_password": "",
+            "gets_notification_emails": self.test_gets_notification_emails,
         }
         response = self.client.post(self.url, data=form_data)
         self.assertEqual(response.status_code, 200)
@@ -679,8 +673,7 @@ class TestUserProfileView(TestCase):
         form_data = {
             "first_name": self.test_first_name,
             "last_name": self.test_last_name,
-            "gets_notification_emails": True,
-            "current_password": "old_password",
+            "current_password": self.test_current_password,
             "new_password": "new_password123",
             "confirm_new_password": "new_password123",
         }
@@ -695,7 +688,6 @@ class TestUserProfileView(TestCase):
         form_data = {
             "first_name": self.test_first_name,
             "last_name": self.test_last_name,
-            "gets_notification_emails": True,
             "current_password": "wrong_password",
             "new_password": "new_password123",
             "confirm_new_password": "new_password123",
@@ -713,8 +705,7 @@ class TestUserProfileView(TestCase):
         form_data = {
             "first_name": self.test_first_name,
             "last_name": self.test_last_name,
-            "gets_notification_emails": True,
-            "current_password": "old_password",
+            "current_password": self.test_current_password,
             "new_password": "new_password123",
             "confirm_new_password": "different_password",
         }
@@ -731,10 +722,9 @@ class TestUserProfileView(TestCase):
         form_data = {
             "first_name": self.test_first_name,
             "last_name": self.test_last_name,
-            "gets_notification_emails": True,
-            "current_password": "old_password",
-            "new_password": "old_password",
-            "confirm_new_password": "old_password",
+            "current_password": self.test_current_password,
+            "new_password": self.test_current_password,
+            "confirm_new_password": self.test_current_password,
         }
         response = self.client.post(self.url, data=form_data)
         self.assertEqual(response.status_code, 200)
@@ -749,7 +739,6 @@ class TestUserProfileView(TestCase):
         form_data = {
             "first_name": self.test_first_name,
             "last_name": self.test_last_name,
-            "gets_notification_emails": True,
             "new_password": "new_password123",
             "confirm_new_password": "new_password123",
         }
@@ -766,8 +755,7 @@ class TestUserProfileView(TestCase):
         form_data = {
             "first_name": self.test_first_name,
             "last_name": self.test_last_name,
-            "gets_notification_emails": True,
-            "current_password": "old_password",
+            "current_password": self.test_current_password,
             "confirm_new_password": "new_password123",
         }
         response = self.client.post(self.url, data=form_data)
@@ -784,7 +772,7 @@ class TestUserProfileView(TestCase):
             "first_name": self.test_first_name,
             "last_name": self.test_last_name,
             "gets_notification_emails": True,
-            "current_password": "old_password",
+            "current_password": self.test_current_password,
             "new_password": "new_password123",
         }
         response = self.client.post(self.url, data=form_data)
@@ -800,7 +788,7 @@ class TestUserProfileView(TestCase):
         form_data = {
             "first_name": self.test_first_name,
             "last_name": self.test_last_name,
-            "gets_notification_emails": True,
+            "gets_notification_emails": self.test_gets_notification_emails,
         }
         response = self.client.post(self.url, data=form_data)
         self.assertEqual(response.status_code, 200)

--- a/bagitobjecttransfer/recordtransfer/tests/test_views.py
+++ b/bagitobjecttransfer/recordtransfer/tests/test_views.py
@@ -605,6 +605,44 @@ class TestUserProfileView(TestCase):
         response = self.client.get(self.url)
         self.assertRedirects(response, f"{reverse('login')}?next={self.url}")
 
+    def test_valid_name_change(self):
+        form_data = {
+            "first_name": "New",
+            "last_name": "Name",
+        }
+        response = self.client.post(self.url, data=form_data)
+        self.assertRedirects(response, self.url)
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(str(messages[0]), self.success_message)
+
+    def test_invalid_first_name(self):
+        form_data = {
+            "first_name": "123",
+            "last_name": self.test_last_name,
+        }
+        response = self.client.post(self.url, data=form_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "recordtransfer/profile.html")
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(
+            str(messages[0]),
+            self.error_message,
+        )
+
+    def test_invalid_last_name(self):
+        form_data = {
+            "first_name": self.test_first_name,
+            "last_name": "123",
+        }
+        response = self.client.post(self.url, data=form_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "recordtransfer/profile.html")
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(
+            str(messages[0]),
+            self.error_message,
+        )
+
     def test_valid_notification_setting_change(self):
         form_data = {
             "first_name": self.test_first_name,
@@ -621,6 +659,8 @@ class TestUserProfileView(TestCase):
 
     def test_invalid_notification_setting_change(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "gets_notification_emails": True,
             "current_password": "",
             "new_password": "",
@@ -653,6 +693,8 @@ class TestUserProfileView(TestCase):
 
     def test_wrong_password(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "gets_notification_emails": True,
             "current_password": "wrong_password",
             "new_password": "new_password123",
@@ -669,6 +711,8 @@ class TestUserProfileView(TestCase):
 
     def test_passwords_do_not_match(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "gets_notification_emails": True,
             "current_password": "old_password",
             "new_password": "new_password123",
@@ -685,6 +729,8 @@ class TestUserProfileView(TestCase):
 
     def test_same_password(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "gets_notification_emails": True,
             "current_password": "old_password",
             "new_password": "old_password",
@@ -701,6 +747,8 @@ class TestUserProfileView(TestCase):
 
     def test_missing_current_password(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "gets_notification_emails": True,
             "new_password": "new_password123",
             "confirm_new_password": "new_password123",
@@ -716,6 +764,8 @@ class TestUserProfileView(TestCase):
 
     def test_missing_new_password(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "gets_notification_emails": True,
             "current_password": "old_password",
             "confirm_new_password": "new_password123",
@@ -731,6 +781,8 @@ class TestUserProfileView(TestCase):
 
     def test_missing_confirm_new_password(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "gets_notification_emails": True,
             "current_password": "old_password",
             "new_password": "new_password123",
@@ -746,6 +798,8 @@ class TestUserProfileView(TestCase):
 
     def test_no_changes(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "gets_notification_emails": True,
         }
         response = self.client.post(self.url, data=form_data)

--- a/bagitobjecttransfer/recordtransfer/tests/test_views.py
+++ b/bagitobjecttransfer/recordtransfer/tests/test_views.py
@@ -574,11 +574,20 @@ class TestAcceptFileView(TestCase):
 @patch("recordtransfer.emails.send_user_account_updated.delay", lambda a, b: None)
 class TestUserProfileView(TestCase):
     def setUp(self):
+        self.test_username = "testuser"
+        self.test_first_name = "Test"
+        self.test_last_name = "User"
+        self.test_email = "testuser@example.com"
+        self.test_password = "old_password"
+        self.test_gets_notification_emails = True
+        self.test_new_password = "new_password123"
         self.user = User.objects.create_user(
-            username="testuser",
-            email="testuser@example.com",
-            password="old_password",
-            gets_notification_emails=True,
+            username=self.test_username,
+            first_name=self.test_first_name,
+            last_name=self.test_last_name,
+            email=self.test_email,
+            password=self.test_password,
+            gets_notification_emails=self.test_gets_notification_emails,
         )
         self.client.login(username="testuser", password="old_password")
         self.url = reverse("recordtransfer:userprofile")
@@ -598,6 +607,8 @@ class TestUserProfileView(TestCase):
 
     def test_valid_notification_setting_change(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "gets_notification_emails": False,
             "current_password": "",
             "new_password": "",
@@ -626,6 +637,8 @@ class TestUserProfileView(TestCase):
 
     def test_valid_password_change(self):
         form_data = {
+            "first_name": self.test_first_name,
+            "last_name": self.test_last_name,
             "gets_notification_emails": True,
             "current_password": "old_password",
             "new_password": "new_password123",

--- a/bagitobjecttransfer/recordtransfer/tests/test_views.py
+++ b/bagitobjecttransfer/recordtransfer/tests/test_views.py
@@ -615,6 +615,16 @@ class TestUserProfileView(TestCase):
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(str(messages[0]), self.success_message)
 
+    def test_accented_name_change(self):
+        form_data = {
+            "first_name": "Áccéntéd",
+            "last_name": "Námé",
+        }
+        response = self.client.post(self.url, data=form_data)
+        self.assertRedirects(response, self.url)
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(str(messages[0]), self.success_message)
+
     def test_invalid_first_name(self):
         form_data = {
             "first_name": "123",

--- a/bagitobjecttransfer/recordtransfer/views.py
+++ b/bagitobjecttransfer/recordtransfer/views.py
@@ -1,7 +1,7 @@
 import logging
 import pickle
 import re
-from typing import Any, ClassVar, Optional, Union
+from typing import Any, ClassVar, Optional, Union, cast
 
 from caais.export import ExportVersion
 from caais.models import RightsType, SourceRole, SourceType
@@ -218,7 +218,9 @@ class UserProfile(UpdateView):
             self.request,
             self.error_message,
         )
-        return super().form_invalid(form)
+        profile_form = cast(UserProfileForm, form)
+        profile_form.reset_form()
+        return super().form_invalid(profile_form)
 
 
 class About(TemplateView):

--- a/bagitobjecttransfer/recordtransfer/views.py
+++ b/bagitobjecttransfer/recordtransfer/views.py
@@ -191,7 +191,7 @@ class UserProfile(UpdateView):
     def get_form_kwargs(self) -> dict[str, Any]:
         """Pass User instance to form to initialize it."""
         kwargs = super().get_form_kwargs()
-        kwargs["user"] = self.get_object()
+        kwargs["instance"] = self.get_object()
         return kwargs
 
     def form_valid(self, form: BaseModelForm) -> HttpResponse:

--- a/bagitobjecttransfer/recordtransfer/views.py
+++ b/bagitobjecttransfer/recordtransfer/views.py
@@ -33,7 +33,14 @@ from django.utils.http import urlsafe_base64_decode
 from django.utils.text import slugify
 from django.utils.translation import gettext
 from django.views.decorators.http import require_http_methods
-from django.views.generic import CreateView, DetailView, FormView, TemplateView, UpdateView, View
+from django.views.generic import (
+    CreateView,
+    DetailView,
+    FormView,
+    TemplateView,
+    UpdateView,
+    View,
+)
 from formtools.wizard.views import SessionWizardView
 
 from recordtransfer.caais import map_form_to_metadata
@@ -89,14 +96,18 @@ class Index(TemplateView):
 def media_request(request: HttpRequest, path: str) -> HttpResponse:
     """Respond to whether a media request is allowed or not."""
     if not request.user.is_authenticated:
-        return HttpResponseForbidden("You do not have permission to access this resource.")
+        return HttpResponseForbidden(
+            "You do not have permission to access this resource."
+        )
 
     if not path:
         return HttpResponseNotFound("The requested resource could not be found")
 
     user = request.user
     if not user.is_staff:
-        return HttpResponseForbidden("You do not have permission to access this resource.")
+        return HttpResponseForbidden(
+            "You do not have permission to access this resource."
+        )
 
     response = HttpResponse(
         headers={"X-Accel-Redirect": djangosettings.MEDIA_URL + path.lstrip("/")}
@@ -137,7 +148,9 @@ class UserProfile(UpdateView):
     success_url = reverse_lazy("recordtransfer:userprofile")
     success_message = gettext("Preferences updated")
     password_change_success_message = gettext("Password updated")
-    error_message = gettext("There was an error updating your preferences. Please try again.")
+    error_message = gettext(
+        "There was an error updating your preferences. Please try again."
+    )
 
     def get_object(self, queryset=None):
         return self.request.user
@@ -152,7 +165,9 @@ class UserProfile(UpdateView):
         ).order_by("-last_updated")
         in_progress_paginator = Paginator(in_progress_submissions, self.paginate_by)
         in_progress_page_number = self.request.GET.get(IN_PROGRESS_PAGE, 1)
-        context["in_progress_page_obj"] = in_progress_paginator.get_page(in_progress_page_number)
+        context["in_progress_page_obj"] = in_progress_paginator.get_page(
+            in_progress_page_number
+        )
 
         # Paginate Submission
         user_submissions = Submission.objects.filter(user=self.request.user).order_by(
@@ -160,25 +175,29 @@ class UserProfile(UpdateView):
         )
         submissions_paginator = Paginator(user_submissions, self.paginate_by)
         submissions_page_number = self.request.GET.get(SUBMISSIONS_PAGE, 1)
-        context["submissions_page_obj"] = submissions_paginator.get_page(submissions_page_number)
+        context["submissions_page_obj"] = submissions_paginator.get_page(
+            submissions_page_number
+        )
 
         # Paginate SubmissionGroup
-        submission_groups = SubmissionGroup.objects.filter(created_by=self.request.user).order_by(
-            "name"
-        )
+        submission_groups = SubmissionGroup.objects.filter(
+            created_by=self.request.user
+        ).order_by("name")
         groups_paginator = Paginator(submission_groups, self.paginate_by)
         groups_page_number = self.request.GET.get(GROUPS_PAGE, 1)
         context["groups_page_obj"] = groups_paginator.get_page(groups_page_number)
 
         context.update(
-            {   
+            {
                 # Form field element IDs
-                "ID_FIRST_NAME":  ID_FIRST_NAME,
-                "ID_LAST_NAME": ID_LAST_NAME,
-                "ID_GETS_NOTIFICATION_EMAILS": ID_GETS_NOTIFICATION_EMAILS,
-                "ID_CURRENT_PASSWORD": ID_CURRENT_PASSWORD,
-                "ID_NEW_PASSWORD": ID_NEW_PASSWORD,
-                "ID_CONFIRM_NEW_PASSWORD": ID_CONFIRM_NEW_PASSWORD,
+                "js_context": {
+                    "ID_FIRST_NAME": ID_FIRST_NAME,
+                    "ID_LAST_NAME": ID_LAST_NAME,
+                    "ID_GETS_NOTIFICATION_EMAILS": ID_GETS_NOTIFICATION_EMAILS,
+                    "ID_CURRENT_PASSWORD": ID_CURRENT_PASSWORD,
+                    "ID_NEW_PASSWORD": ID_NEW_PASSWORD,
+                    "ID_CONFIRM_NEW_PASSWORD": ID_CONFIRM_NEW_PASSWORD,
+                },
                 # Pagination
                 "IN_PROGRESS_PAGE": IN_PROGRESS_PAGE,
                 "SUBMISSIONS_PAGE": SUBMISSIONS_PAGE,
@@ -320,7 +339,9 @@ class TransferFormWizard(SessionWizardView):
         TransferStep.RECORD_DESCRIPTION: {
             TEMPLATEREF: "recordtransfer/transferform_standard.html",
             FORMTITLE: gettext("Record Description"),
-            INFOMESSAGE: gettext("Provide a brief description of the records you're transferring"),
+            INFOMESSAGE: gettext(
+                "Provide a brief description of the records you're transferring"
+            ),
         },
         TransferStep.RIGHTS: {
             TEMPLATEREF: "recordtransfer/transferform_rights.html",
@@ -357,7 +378,9 @@ class TransferFormWizard(SessionWizardView):
         TransferStep.FINAL_NOTES: {
             TEMPLATEREF: "recordtransfer/transferform_standard.html",
             FORMTITLE: gettext("Final Notes"),
-            INFOMESSAGE: gettext("Add any final notes that may not have fit in previous steps"),
+            INFOMESSAGE: gettext(
+                "Add any final notes that may not have fit in previous steps"
+            ),
         },
     }
 
@@ -426,13 +449,17 @@ class TransferFormWizard(SessionWizardView):
             return super().post(request, *args, **kwargs)
 
         past_data = self.storage.data
-        current_data = TransferFormWizard.format_step_data(self.current_step, request.POST)
+        current_data = TransferFormWizard.format_step_data(
+            self.current_step, request.POST
+        )
 
         title = None
         if isinstance(current_data, dict):
             title = current_data.get("accession_title")
         if not title:
-            title = self.get_form_value(TransferStep.RECORD_DESCRIPTION, "accession_title")
+            title = self.get_form_value(
+                TransferStep.RECORD_DESCRIPTION, "accession_title"
+            )
 
         data = {
             "save_form_step": self.current_step,
@@ -454,7 +481,9 @@ class TransferFormWizard(SessionWizardView):
         self.storage.current_step = transfer.current_step
 
     @classmethod
-    def format_step_data(cls, step: TransferStep, data: QueryDict) -> Union[dict, list[dict]]:
+    def format_step_data(
+        cls, step: TransferStep, data: QueryDict
+    ) -> Union[dict, list[dict]]:
         """Format form data for the current step to be saved for later.
 
         Args:
@@ -465,7 +494,9 @@ class TransferFormWizard(SessionWizardView):
             The formatted step data. If this step represents a formset, the return object will be a
             list of dicts, otherwise, it will be a dict.
         """
-        pattern = re.compile("^" + re.escape(step.value) + r"-(?:(?P<index>\d+)-)?(?P<field>.+)$")
+        pattern = re.compile(
+            "^" + re.escape(step.value) + r"-(?:(?P<index>\d+)-)?(?P<field>.+)$"
+        )
 
         formatted_data = []
         is_formset = False
@@ -479,7 +510,12 @@ class TransferFormWizard(SessionWizardView):
             field: str = match_obj.group("field")
             index: str = match_obj.group("index")
 
-            if field in {"MIN_NUM_FORMS", "MAX_NUM_FORMS", "TOTAL_FORMS", "INITIAL_FORMS"}:
+            if field in {
+                "MIN_NUM_FORMS",
+                "MAX_NUM_FORMS",
+                "TOTAL_FORMS",
+                "INITIAL_FORMS",
+            }:
                 continue
 
             if index:
@@ -556,13 +592,18 @@ class TransferFormWizard(SessionWizardView):
         """
         initial = self.initial_dict.get(step, {})
 
-        if self.in_progress_submission and step == self.in_progress_submission.current_step:
+        if (
+            self.in_progress_submission
+            and step == self.in_progress_submission.current_step
+        ):
             initial = pickle.loads(self.in_progress_submission.step_data)["current"]
 
         if step == TransferStep.CONTACT_INFO.value:
             curr_user = self.request.user
             if curr_user.first_name and curr_user.last_name:
-                initial["contact_name"] = f"{curr_user.first_name} {curr_user.last_name}"
+                initial["contact_name"] = (
+                    f"{curr_user.first_name} {curr_user.last_name}"
+                )
             initial["email"] = str(curr_user.email)
 
         return initial
@@ -587,7 +628,9 @@ class TransferFormWizard(SessionWizardView):
         context.update({"form_title": self._TEMPLATES[self.current_step][FORMTITLE]})
 
         if INFOMESSAGE in self._TEMPLATES[self.current_step]:
-            context.update({"info_message": self._TEMPLATES[self.current_step][INFOMESSAGE]})
+            context.update(
+                {"info_message": self._TEMPLATES[self.current_step][INFOMESSAGE]}
+            )
 
         if self.current_step == TransferStep.GROUP_TRANSFER:
             context.update(
@@ -605,7 +648,9 @@ class TransferFormWizard(SessionWizardView):
 
         elif self.current_step == TransferStep.RIGHTS:
             all_rights = RightsType.objects.all().exclude(name="Other")
-            context.update({"rights": all_rights, "NUM_EXTRA_FORMS": self.num_extra_forms})
+            context.update(
+                {"rights": all_rights, "NUM_EXTRA_FORMS": self.num_extra_forms}
+            )
 
         elif self.current_step == TransferStep.SOURCE_INFO:
             all_roles = SourceRole.objects.all().exclude(name="Other")
@@ -651,7 +696,9 @@ class TransferFormWizard(SessionWizardView):
         if not settings.FILE_UPLOAD_ENABLED:
             return
 
-        session = UploadSession.objects.filter(token=cleaned_data["session_token"]).first()
+        session = UploadSession.objects.filter(
+            token=cleaned_data["session_token"]
+        ).first()
 
         size = get_human_readable_size(session.upload_size, base=1024, precision=2)
 
@@ -661,9 +708,9 @@ class TransferFormWizard(SessionWizardView):
             LOGGER,
         )
 
-        cleaned_data["quantity_and_unit_of_measure"] = gettext("{0}, totalling {1}").format(
-            count, size
-        )
+        cleaned_data["quantity_and_unit_of_measure"] = gettext(
+            "{0}, totalling {1}"
+        ).format(count, size)
 
     def done(self, form_list, **kwargs):
         """Retrieve all of the form data, and creates a Submission from it.
@@ -684,7 +731,9 @@ class TransferFormWizard(SessionWizardView):
             if settings.FILE_UPLOAD_ENABLED:
                 token = form_data["session_token"]
                 LOGGER.info("Fetching session with the token %s", token)
-                submission.upload_session = UploadSession.objects.filter(token=token).first()
+                submission.upload_session = UploadSession.objects.filter(
+                    token=token
+                ).first()
             else:
                 LOGGER.info(
                     (
@@ -711,7 +760,9 @@ class TransferFormWizard(SessionWizardView):
 
             return HttpResponseRedirect(reverse("recordtransfer:systemerror"))
 
-    def get_submission_group(self, cleaned_form_data: dict) -> Optional[SubmissionGroup]:
+    def get_submission_group(
+        self, cleaned_form_data: dict
+    ) -> Optional[SubmissionGroup]:
         """Get a submission group to associate the submission with, depending on how the user
         filled out the submission group section of the form.
         """
@@ -720,11 +771,19 @@ class TransferFormWizard(SessionWizardView):
         group_id = cleaned_form_data["group_id"]
         if group_id:
             try:
-                group = SubmissionGroup.objects.get(uuid=group_id, created_by=self.request.user)
-                LOGGER.info('Associating Submission with "%s" SubmissionGroup', group.name)
+                group = SubmissionGroup.objects.get(
+                    uuid=group_id, created_by=self.request.user
+                )
+                LOGGER.info(
+                    'Associating Submission with "%s" SubmissionGroup', group.name
+                )
 
             except SubmissionGroup.DoesNotExist as exc:
-                LOGGER.error("Could not find SubmissionGroup with UUID %s", group_id, exc_info=exc)
+                LOGGER.error(
+                    "Could not find SubmissionGroup with UUID %s",
+                    group_id,
+                    exc_info=exc,
+                )
         else:
             LOGGER.info("Not associating submission with a group")
 
@@ -769,7 +828,9 @@ def uploadfiles(request):
             session = UploadSession.new_session()
             session.save()
         else:
-            session = UploadSession.objects.filter(token=headers["Upload-Session-Token"]).first()
+            session = UploadSession.objects.filter(
+                token=headers["Upload-Session-Token"]
+            ).first()
             if session is None:
                 session = UploadSession.new_session()
                 session.save()
@@ -792,7 +853,9 @@ def uploadfiles(request):
                 check_for_malware(_file)
 
             except ValidationError as exc:
-                LOGGER.error("Malware was found in the file %s", _file.name, exc_info=exc)
+                LOGGER.error(
+                    "Malware was found in the file %s", _file.name, exc_info=exc
+                )
                 _file.close()
                 issues.append(
                     {
@@ -809,10 +872,14 @@ def uploadfiles(request):
             new_file = UploadedFile(session=session, file_upload=_file, name=_file.name)
             new_file.save()
 
-        return JsonResponse({"uploadSessionToken": session.token, "issues": issues}, status=200)
+        return JsonResponse(
+            {"uploadSessionToken": session.token, "issues": issues}, status=200
+        )
 
     except Exception as exc:
-        LOGGER.error(msg=("Uncaught exception in uploadfiles view: {0}".format(str(exc))))
+        LOGGER.error(
+            msg=("Uncaught exception in uploadfiles view: {0}".format(str(exc)))
+        )
         return JsonResponse(
             {
                 "error": gettext("500 Internal Server Error"),
@@ -842,7 +909,9 @@ def accept_file(request):
             return JsonResponse(
                 {
                     "accepted": False,
-                    "error": gettext("Could not find {0} parameter in request").format(required),
+                    "error": gettext("Could not find {0} parameter in request").format(
+                        required
+                    ),
                 },
                 status=400,
             )
@@ -922,9 +991,9 @@ def _accept_file(filename: str, filesize: Union[str, int]) -> dict:
         return {
             "accepted": False,
             "error": gettext("File is missing an extension."),
-            "verboseError": gettext('The file "{0}" does not have a file extension').format(
-                filename
-            ),
+            "verboseError": gettext(
+                'The file "{0}" does not have a file extension'
+            ).format(filename),
         }
 
     # Check extension is allowed
@@ -939,10 +1008,12 @@ def _accept_file(filename: str, filesize: Union[str, int]) -> dict:
     if not extension_accepted:
         return {
             "accepted": False,
-            "error": gettext('Files with "{0}" extension are not allowed.').format(extension),
-            "verboseError": gettext('The file "{0}" has an invalid extension (.{1})').format(
-                filename, extension
+            "error": gettext('Files with "{0}" extension are not allowed.').format(
+                extension
             ),
+            "verboseError": gettext(
+                'The file "{0}" has an invalid extension (.{1})'
+            ).format(filename, extension),
         }
 
     # Check filesize is an integer
@@ -978,9 +1049,9 @@ def _accept_file(filename: str, filesize: Union[str, int]) -> dict:
     if size > max_single_size_bytes:
         return {
             "accepted": False,
-            "error": gettext("File is too big ({0:.2f}MiB). Max filesize: {1}MiB").format(
-                size_mib, max_single_size
-            ),
+            "error": gettext(
+                "File is too big ({0:.2f}MiB). Max filesize: {1}MiB"
+            ).format(size_mib, max_single_size),
             "verboseError": gettext(
                 'The file "{0}" is too big ({1:.2f}MiB). Max filesize: {2}MiB'
             ).format(filename, size_mib, max_single_size),
@@ -990,7 +1061,9 @@ def _accept_file(filename: str, filesize: Union[str, int]) -> dict:
     return {"accepted": True}
 
 
-def _accept_session(filename: str, filesize: Union[str, int], session: UploadSession) -> dict:
+def _accept_session(
+    filename: str, filesize: Union[str, int], session: UploadSession
+) -> dict:
     """Determine if a new file should be accepted as part of the session.
 
     These checks are applied:
@@ -1035,9 +1108,12 @@ def _accept_session(filename: str, filesize: Union[str, int], session: UploadSes
     if int(filesize) > max_remaining_size_bytes:
         return {
             "accepted": False,
-            "error": gettext("Maximum total upload size ({0} MiB) exceeded").format(max_size),
+            "error": gettext("Maximum total upload size ({0} MiB) exceeded").format(
+                max_size
+            ),
             "verboseError": gettext(
-                'The file "{0}" would push the total transfer size past the ' "{1}MiB max"
+                'The file "{0}" would push the total transfer size past the '
+                "{1}MiB max"
             ).format(filename, max_size),
         }
 
@@ -1047,9 +1123,9 @@ def _accept_session(filename: str, filesize: Union[str, int], session: UploadSes
         return {
             "accepted": False,
             "error": gettext("A file with the same name has already been uploaded."),
-            "verboseError": gettext('A file with the name "{0}" has already been uploaded').format(
-                filename
-            ),
+            "verboseError": gettext(
+                'A file with the name "{0}" has already been uploaded'
+            ).format(filename),
         }
 
     # All checks succeded
@@ -1137,7 +1213,9 @@ class SubmissionCsv(UserPassesTestMixin, View):
     def get(self, request, *args, **kwargs):
         queryset = self.get_queryset()
         prefix = slugify(queryset.first().user.username) + "_export-"
-        return queryset.export_csv(version=ExportVersion.CAAIS_1_0, filename_prefix=prefix)
+        return queryset.export_csv(
+            version=ExportVersion.CAAIS_1_0, filename_prefix=prefix
+        )
 
 
 class SubmissionGroupDetailView(UserPassesTestMixin, UpdateView):
@@ -1157,7 +1235,10 @@ class SubmissionGroupDetailView(UserPassesTestMixin, UpdateView):
 
     def test_func(self):
         """Check if the user is the creator of the submission group or is a staff member."""
-        return self.request.user.is_staff or self.get_object().created_by == self.request.user
+        return (
+            self.request.user.is_staff
+            or self.get_object().created_by == self.request.user
+        )
 
     def handle_no_permission(self) -> HttpResponseForbidden:
         return HttpResponseForbidden("You do not have permission to access this page.")
@@ -1165,7 +1246,9 @@ class SubmissionGroupDetailView(UserPassesTestMixin, UpdateView):
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         """Pass submissions associated with the group to the template."""
         context = super().get_context_data(**kwargs)
-        context["submissions"] = Submission.objects.filter(part_of_group=self.get_object())
+        context["submissions"] = Submission.objects.filter(
+            part_of_group=self.get_object()
+        )
         context["IS_NEW"] = False
         context["ID_SUBMISSION_GROUP_NAME"] = ID_SUBMISSION_GROUP_NAME
         context["ID_SUBMISSION_GROUP_DESCRIPTION"] = ID_SUBMISSION_GROUP_DESCRIPTION
@@ -1252,7 +1335,9 @@ class SubmissionGroupCreateView(UserPassesTestMixin, CreateView):
         referer = self.request.headers.get("referer", "")
         error_message = next(iter(form.errors.values()))[0]
         if "transfer" in referer:
-            return JsonResponse({"message": error_message, "status": "error"}, status=400)
+            return JsonResponse(
+                {"message": error_message, "status": "error"}, status=400
+            )
         messages.error(
             self.request,
             self.error_message,
@@ -1262,9 +1347,14 @@ class SubmissionGroupCreateView(UserPassesTestMixin, CreateView):
 
 def get_user_submission_groups(request: HttpRequest, user_id: int) -> JsonResponse:
     """Retrieve the groups associated with the current user."""
-    if request.user.pk != user_id and not request.user.is_staff and not request.user.is_superuser:
+    if (
+        request.user.pk != user_id
+        and not request.user.is_staff
+        and not request.user.is_superuser
+    ):
         return JsonResponse(
-            {"error": gettext("You do not have permission to view these groups.")}, status=403
+            {"error": gettext("You do not have permission to view these groups.")},
+            status=403,
         )
 
     submission_groups = SubmissionGroup.objects.filter(created_by=user_id)

--- a/bagitobjecttransfer/recordtransfer/views.py
+++ b/bagitobjecttransfer/recordtransfer/views.py
@@ -43,7 +43,9 @@ from recordtransfer.constants import (
     ID_CONFIRM_NEW_PASSWORD,
     ID_CURRENT_PASSWORD,
     ID_DISPLAY_GROUP_DESCRIPTION,
+    ID_FIRST_NAME,
     ID_GETS_NOTIFICATION_EMAILS,
+    ID_LAST_NAME,
     ID_NEW_PASSWORD,
     ID_SUBMISSION_GROUP_DESCRIPTION,
     ID_SUBMISSION_GROUP_NAME,
@@ -169,11 +171,15 @@ class UserProfile(UpdateView):
         context["groups_page_obj"] = groups_paginator.get_page(groups_page_number)
 
         context.update(
-            {
+            {   
+                # Form field element IDs
+                "ID_FIRST_NAME":  ID_FIRST_NAME,
+                "ID_LAST_NAME": ID_LAST_NAME,
                 "ID_GETS_NOTIFICATION_EMAILS": ID_GETS_NOTIFICATION_EMAILS,
                 "ID_CURRENT_PASSWORD": ID_CURRENT_PASSWORD,
                 "ID_NEW_PASSWORD": ID_NEW_PASSWORD,
                 "ID_CONFIRM_NEW_PASSWORD": ID_CONFIRM_NEW_PASSWORD,
+                # Pagination
                 "IN_PROGRESS_PAGE": IN_PROGRESS_PAGE,
                 "SUBMISSIONS_PAGE": SUBMISSIONS_PAGE,
                 "GROUPS_PAGE": GROUPS_PAGE,


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/251

Additional changes:
- Added a `reset` method to `UserProfileForm` to reset the form to original values after an invalid form submission
- Added tests for first and last name form fields
- Removed unnecessary form data for test cases, such as `get_email_notification` field when testing password changes or password fields when testing email notification changes.
- Fixed issue of messages not being dismissed after close button is clicked