### PR TITLE
Add protection from clicking away from form

### DIFF
--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/css/base/base.css
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/css/base/base.css
@@ -66,6 +66,11 @@ body {
     -webkit-appearance: none;
 }
 
+.large-button {
+    font-size: 13pt;
+    padding: 8px 16px;
+}
+
 .less-padding {
     padding: 4px 6px 4px 6px !important;
 }

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/css/base/modal.css
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/css/base/modal.css
@@ -9,13 +9,13 @@
     height: 100%;
     background: rgba(0, 0, 0, 0.5);
     z-index: 1000;
-    visibility: visible;
-    opacity: 1;
-}
-
-.modal.hidden {
     visibility: hidden;
     opacity: 0;
+}
+
+.modal.visible {
+    visibility: visible;
+    opacity: 1;
 }
 
 .modal-content {

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/css/base/modal.css
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/css/base/modal.css
@@ -11,6 +11,7 @@
     z-index: 1000;
     visibility: hidden;
     opacity: 0;
+    padding: 0;
 }
 
 .modal.visible {
@@ -62,4 +63,27 @@
 
 .modal-footer button {
     margin-left: 15px;
+}
+
+/* Responsive styles for screens below 800px */
+@media (max-width: 800px) {
+    .modal-content {
+        max-width: 80%;
+        padding: 15px;
+        font-size: small;
+    }
+
+
+    .modal-footer {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+    }
+
+    .modal-footer button {
+        margin: 10px;
+        width: 100%;
+        border-radius: 8px;
+    }
 }

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/css/base/modal.css
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/css/base/modal.css
@@ -1,0 +1,58 @@
+.modal {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1000;
+}
+
+.modal-content {
+    background: white;
+    padding: 20px;
+    border-radius: 10px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px;
+    border-bottom: 1px solid #ddd;
+}
+
+.modal-header h3 {
+    margin: 0;
+    flex-grow: 1;
+    text-align: left;
+}
+
+.close-modal-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+.close-modal-button img {
+    display: block;
+}
+
+.modal-body {
+    padding: 10px;
+    text-align: left;
+}
+
+.modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    padding-top: 10px;
+}
+
+.modal-footer button {
+    margin-left: 15px;
+}

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/css/base/modal.css
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/css/base/modal.css
@@ -9,6 +9,13 @@
     height: 100%;
     background: rgba(0, 0, 0, 0.5);
     z-index: 1000;
+    visibility: visible;
+    opacity: 1;
+}
+
+.modal.hidden {
+    visibility: hidden;
+    opacity: 0;
 }
 
 .modal-content {

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/css/base/modal.css
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/css/base/modal.css
@@ -70,9 +70,7 @@
     .modal-content {
         max-width: 80%;
         padding: 15px;
-        font-size: small;
     }
-
 
     .modal-footer {
         flex-direction: row;

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
@@ -3,7 +3,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const saveButton = document.getElementById('modal-save-button');
     const closeButton = document.querySelector('.close-modal-button');
     const cancelButton = document.getElementById('unsaved-transferform-modal-cancel');
-    
+    const leaveButton = document.getElementById('unsaved-transferform-modal-leave');
+    let targetUrl = '';
+
+    // Add event listeners to all links on page to unhide modal if clicked
+    document.querySelectorAll('a').forEach(link => {
+        link.addEventListener('click', (event) => {
+            event.preventDefault();
+            targetUrl = event.currentTarget.href;
+            modal.classList.remove('hidden');
+        });
+    });
+
     saveButton.addEventListener('click', (event) => {
         event.preventDefault();
         // Save and submit the form using the form's save button
@@ -17,5 +28,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     cancelButton.addEventListener('click', () => {
         modal.classList.add('hidden');
+    });
+
+    leaveButton.addEventListener('click', () => {
+        window.location.href = targetUrl;
     });
 });

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const modal = document.getElementById('unsaved-transferform-modal');
+    const saveButton = document.getElementById('modal-save-button');
+    
+    saveButton.addEventListener('click', (event) => {
+        event.preventDefault();
+        // Find and click the form's save button
+        document.getElementById('form-save-button').click();
+        // Close the modal
+        modal.close();
+    });
+});

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const modal = document.getElementById('unsaved-transferform-modal');
     const saveButton = document.getElementById('modal-save-button');
-    const closeButton = document.querySelector('.close-modal-button');
+    const closeButton = document.getElementById('close-modal-button');
     const cancelButton = document.getElementById('unsaved-transferform-modal-cancel');
     const leaveButton = document.getElementById('unsaved-transferform-modal-leave');
     let targetUrl = '';

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
@@ -1,4 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {
+    if (currentFormStep <= 1) {
+        return;
+    }
+
     const modal = document.getElementById('unsaved-transferform-modal');
     const saveButton = document.getElementById('modal-save-button');
     const closeButton = document.querySelector('.close-modal-button');

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
@@ -1,5 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
-    if (currentFormStep <= 1) {
+    const urlParams = new URLSearchParams(window.location.search);
+    const transferUuid = urlParams.get('transfer_uuid');
+    
+    // Skip click-away protection if on the first step of a fresh form
+    if (currentFormStep <= 1 && !transferUuid) {
         return;
     }
 

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
         link.addEventListener('click', (event) => {
             event.preventDefault();
             targetUrl = event.currentTarget.href;
-            modal.classList.remove('hidden');
+            modal.classList.add('visible');
         });
     });
 
@@ -19,15 +19,15 @@ document.addEventListener('DOMContentLoaded', () => {
         event.preventDefault();
         // Save and submit the form using the form's save button
         document.getElementById('form-save-button').click();
-        modal.close();
+        modal.classList.remove('visible');
     });
 
     closeButton.addEventListener('click', () => {
-        modal.classList.add('hidden');
+        modal.classList.remove('visible');
     });
 
     cancelButton.addEventListener('click', () => {
-        modal.classList.add('hidden');
+        modal.classList.remove('visible');
     });
 
     leaveButton.addEventListener('click', () => {

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
@@ -12,11 +12,10 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     closeButton.addEventListener('click', () => {
-        console.log('close button clicked');
-        modal.close();
+        modal.classList.add('hidden');
     });
 
     cancelButton.addEventListener('click', () => {
-        modal.close();
+        modal.classList.add('hidden');
     });
 });

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/modal.js
@@ -1,12 +1,22 @@
 document.addEventListener('DOMContentLoaded', () => {
     const modal = document.getElementById('unsaved-transferform-modal');
     const saveButton = document.getElementById('modal-save-button');
+    const closeButton = document.querySelector('.close-modal-button');
+    const cancelButton = document.getElementById('unsaved-transferform-modal-cancel');
     
     saveButton.addEventListener('click', (event) => {
         event.preventDefault();
-        // Find and click the form's save button
+        // Save and submit the form using the form's save button
         document.getElementById('form-save-button').click();
-        // Close the modal
+        modal.close();
+    });
+
+    closeButton.addEventListener('click', () => {
+        console.log('close button clicked');
+        modal.close();
+    });
+
+    cancelButton.addEventListener('click', () => {
         modal.close();
     });
 });

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/unsavedChanges.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/unsavedChanges.js
@@ -7,19 +7,18 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
+    const beforeUnloadListener = (event) => {
+        event.preventDefault();
+        event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', beforeUnloadListener);
+
     const modal = document.getElementById('unsaved-transferform-modal');
     const modalSaveButton = document.getElementById('modal-save-button');
     const closeButton = document.getElementById('close-modal-button');
     const cancelButton = document.getElementById('unsaved-transferform-modal-cancel');
     const leaveButton = document.getElementById('unsaved-transferform-modal-leave');
     let targetUrl = '';
-
-    // Elements that should not trigger the modal and the browser warning dialog
-    const safeElements = [
-        document.getElementById('form-next-or-submit-button'),
-        document.getElementById('form-previous-button'),
-        document.getElementById('form-save-button'),
-    ];
 
     // Add event listeners to only navigational links
     document.querySelectorAll('a:not(.non-nav-link)').forEach(link => {
@@ -47,5 +46,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
     leaveButton.addEventListener('click', () => {
         window.location.href = targetUrl;
+    });
+
+    // Elements that should not trigger the browser warning dialog
+    const safeElements = [
+        document.getElementById('form-next-or-submit-button'),
+        document.getElementById('form-previous-button'),
+        document.getElementById('form-save-button'),
+    ];
+
+    safeElements.forEach(element => {
+        if (element) {
+            element.addEventListener('click', () => {
+                window.removeEventListener('beforeunload', beforeUnloadListener);
+            });
+        }
     });
 });

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/unsavedChanges.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/unsavedChanges.js
@@ -19,12 +19,10 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('form-next-or-submit-button'),
         document.getElementById('form-previous-button'),
         document.getElementById('form-save-button'),
-        document.getElementById('show-source-types-dialog'),
-        document.getElementById('show-source-roles-dialog'),
     ];
 
-    // Add event listeners to all links on page to unhide modal if clicked
-    document.querySelectorAll('a').forEach(link => {
+    // Add event listeners to only navigational links
+    document.querySelectorAll('a:not(.non-nav-link)').forEach(link => {
         link.addEventListener('click', (event) => {
             event.preventDefault();
             targetUrl = event.currentTarget.href;

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/unsavedChanges.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/unsavedChanges.js
@@ -1,6 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const transferUuid = urlParams.get('transfer_uuid');
+    const transferUuid = new URLSearchParams(window.location.search).get('transfer_uuid');
     
     // Skip click-away protection if on the first step of a fresh form
     if (currentFormStep <= 1 && !transferUuid) {
@@ -11,40 +10,43 @@ document.addEventListener('DOMContentLoaded', () => {
         event.preventDefault();
         event.returnValue = '';
     };
-    window.addEventListener('beforeunload', beforeUnloadListener);
 
-    const modal = document.getElementById('unsaved-transferform-modal');
-    const modalSaveButton = document.getElementById('modal-save-button');
-    const closeButton = document.getElementById('close-modal-button');
-    const cancelButton = document.getElementById('unsaved-transferform-modal-cancel');
-    const leaveButton = document.getElementById('unsaved-transferform-modal-leave');
+    const elements = {
+        modal: document.getElementById('unsaved-transferform-modal'),
+        saveButton: document.getElementById('modal-save-button'),
+        closeButton: document.getElementById('close-modal-button'),
+        cancelButton: document.getElementById('unsaved-transferform-modal-cancel'),
+        leaveButton: document.getElementById('unsaved-transferform-modal-leave'),
+        formSaveButton: document.getElementById('form-save-button')
+    };
+
+    // The URL to navigate to when the user chooses to leave the form
     let targetUrl = '';
+
+    const hideModal = () => elements.modal.classList.remove('visible');
+    const showModal = () => elements.modal.classList.add('visible');
 
     // Add event listeners to only navigational links
     document.querySelectorAll('a:not(.non-nav-link)').forEach(link => {
         link.addEventListener('click', (event) => {
             event.preventDefault();
             targetUrl = event.currentTarget.href;
-            modal.classList.add('visible');
+            showModal();
         });
     });
 
-    modalSaveButton.addEventListener('click', (event) => {
+    elements.saveButton.addEventListener('click', (event) => {
         event.preventDefault();
         // Save and submit the form using the form's save button
-        document.getElementById('form-save-button').click();
-        modal.classList.remove('visible');
+        elements.formSaveButton.click();
+        hideModal();
     });
 
-    closeButton.addEventListener('click', () => {
-        modal.classList.remove('visible');
-    });
+    elements.closeButton.addEventListener('click', hideModal);
+    elements.cancelButton.addEventListener('click', hideModal);
 
-    cancelButton.addEventListener('click', () => {
-        modal.classList.remove('visible');
-    });
-
-    leaveButton.addEventListener('click', () => {
+    elements.leaveButton.addEventListener('click', () => {
+        window.removeEventListener('beforeunload', beforeUnloadListener);
         window.location.href = targetUrl;
     });
 
@@ -52,7 +54,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const safeElements = [
         document.getElementById('form-next-or-submit-button'),
         document.getElementById('form-previous-button'),
-        document.getElementById('form-save-button'),
+        elements.formSaveButton,
     ];
 
     safeElements.forEach(element => {
@@ -62,4 +64,6 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
     });
+
+    window.addEventListener('beforeunload', beforeUnloadListener);
 });

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/unsavedChanges.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/unsavedChanges.js
@@ -8,11 +8,20 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const modal = document.getElementById('unsaved-transferform-modal');
-    const saveButton = document.getElementById('modal-save-button');
+    const modalSaveButton = document.getElementById('modal-save-button');
     const closeButton = document.getElementById('close-modal-button');
     const cancelButton = document.getElementById('unsaved-transferform-modal-cancel');
     const leaveButton = document.getElementById('unsaved-transferform-modal-leave');
     let targetUrl = '';
+
+    // Elements that should not trigger the modal and the browser warning dialog
+    const safeElements = [
+        document.getElementById('form-next-or-submit-button'),
+        document.getElementById('form-previous-button'),
+        document.getElementById('form-save-button'),
+        document.getElementById('show-source-types-dialog'),
+        document.getElementById('show-source-roles-dialog'),
+    ];
 
     // Add event listeners to all links on page to unhide modal if clicked
     document.querySelectorAll('a').forEach(link => {
@@ -23,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    saveButton.addEventListener('click', (event) => {
+    modalSaveButton.addEventListener('click', (event) => {
         event.preventDefault();
         // Save and submit the form using the form's save button
         document.getElementById('form-save-button').click();

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/unsavedChanges.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/unsavedChanges.js
@@ -52,8 +52,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Elements that should not trigger the browser warning dialog
     const safeElements = [
-        document.getElementById('form-next-or-submit-button'),
+        document.getElementById('form-next-button'),
         document.getElementById('form-previous-button'),
+        document.getElementById('submit-form-btn'),
         elements.formSaveButton,
     ];
 

--- a/bagitobjecttransfer/recordtransfer/templates/includes/unsaved_transferform_modal.html
+++ b/bagitobjecttransfer/recordtransfer/templates/includes/unsaved_transferform_modal.html
@@ -4,7 +4,7 @@
     <div class="modal-content">
         <div class="modal-header">
             <h3>Are you sure you want to leave?</h3>
-            <button class="close-modal-button">
+            <button class="close-modal-button" id="close-modal-button">
                 <img height="20"
                      width="20"
                      alt="Close"

--- a/bagitobjecttransfer/recordtransfer/templates/includes/unsaved_transferform_modal.html
+++ b/bagitobjecttransfer/recordtransfer/templates/includes/unsaved_transferform_modal.html
@@ -1,22 +1,27 @@
 {% load i18n %}
+{% load static %}
 <dialog id="unsaved-transferform-modal" class="modal" open>
     <div class="modal-content">
         <div class="modal-header">
-            <span class="close">&times;</span>
-            <h2>Are you sure you want to leave?</h2>
+            <h3>Are you sure you want to leave?</h3>
+            <button class="close-modal-button">
+                <img height="20"
+                     width="20"
+                     alt="Close"
+                     src="{% static 'close_menu_64x64px.webp' %}"
+                     draggable="false">
+            </button>
         </div>
         <div class="modal-body">
             <p>
                 <strong>You have unsaved data!</strong>
                 If you would like to save your submission for later, click this link:
             </p>
-            <button id="modal-save-button" class="text-link margin-top-25px">
-                {% trans "Save form and resume later" %}
-            </button>
+            <button id="modal-save-button" class="text-link margin-top-10px">{% trans "Save form and resume later" %}</button>
         </div>
         <div class="modal-footer">
-            <button id="unsaved-transferform-modal-cancel" class="red-button">Cancel</button>
-            <button id="unsaved-transferform-modal-leave" class="green-button">Leave</button>
+            <button id="unsaved-transferform-modal-cancel" class="red-button large-button">Cancel</button>
+            <button id="unsaved-transferform-modal-leave" class="green-button large-button">Leave</button>
         </div>
     </div>
 </dialog>

--- a/bagitobjecttransfer/recordtransfer/templates/includes/unsaved_transferform_modal.html
+++ b/bagitobjecttransfer/recordtransfer/templates/includes/unsaved_transferform_modal.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load static %}
-<dialog id="unsaved-transferform-modal" class="modal" open>
+<dialog id="unsaved-transferform-modal" class="modal">
     <div class="modal-content">
         <div class="modal-header">
             <h3>Are you sure you want to leave?</h3>

--- a/bagitobjecttransfer/recordtransfer/templates/includes/unsaved_transferform_modal.html
+++ b/bagitobjecttransfer/recordtransfer/templates/includes/unsaved_transferform_modal.html
@@ -20,8 +20,10 @@
             <button id="modal-save-button" class="text-link margin-top-10px">{% trans "Save form and resume later" %}</button>
         </div>
         <div class="modal-footer">
-            <button id="unsaved-transferform-modal-cancel" class="red-button large-button">Cancel</button>
-            <button id="unsaved-transferform-modal-leave" class="green-button large-button">Leave</button>
+            <button id="unsaved-transferform-modal-cancel"
+                    class="red-button large-button">Cancel</button>
+            <button id="unsaved-transferform-modal-leave"
+                    class="green-button large-button">Leave</button>
         </div>
     </div>
 </dialog>

--- a/bagitobjecttransfer/recordtransfer/templates/includes/unsaved_transferform_modal.html
+++ b/bagitobjecttransfer/recordtransfer/templates/includes/unsaved_transferform_modal.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+<dialog id="unsaved-transferform-modal" class="modal" open>
+    <div class="modal-content">
+        <div class="modal-header">
+            <span class="close">&times;</span>
+            <h2>Are you sure you want to leave?</h2>
+        </div>
+        <div class="modal-body">
+            <p>
+                <strong>You have unsaved data!</strong>
+                If you would like to save your submission for later, click this link:
+            </p>
+            <button id="modal-save-button" class="text-link margin-top-25px">
+                {% trans "Save form and resume later" %}
+            </button>
+        </div>
+        <div class="modal-footer">
+            <button id="unsaved-transferform-modal-cancel" class="red-button">Cancel</button>
+            <button id="unsaved-transferform-modal-leave" class="green-button">Leave</button>
+        </div>
+    </div>
+</dialog>

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/banner.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/banner.html
@@ -3,7 +3,7 @@
         <span class="banner-text">
             The National Residential School Crisis Line&nbsp;
         </span>
-        <a class="banner-link" href="tel:1-866-925-4419">
+        <a class="banner-link non-nav-link" href="tel:1-866-925-4419">
             1-866-925-4419
         </a>
     </div>

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/base.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/base.html
@@ -1,8 +1,9 @@
 {% load static %}
 {% load i18n %}
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <!-- JS -->
         {% block javascript %}
             <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/footer.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/footer.html
@@ -29,7 +29,7 @@
                     <title>{% trans 'phone' %}</title>
                     <path d="M22 20c-2 2-2 4-4 4s-4-2-6-4-4-4-4-6 2-2 4-4-4-8-6-8-6 6-6 6c0 4 4.109 12.109 8 16s12 8 16 8c0 0 6-4 6-6s-6-8-8-6z"/>
                 </svg>
-                <a href="tel:1-855-415-4534" class="contact-link-link">
+                <a href="tel:1-855-415-4534" class="contact-link-link non-nav-link">
                     1-855-415-4534
                 </a>
             </span>
@@ -44,7 +44,7 @@
                     <path d="m297.746 278.328c-.003.002-.005.004-.007.005-11.702 7.801-26.724 11.702-41.741 11.702-15.02 0-30.036-3.9-41.739-11.703-.002-.001-.003-.002-.005-.003l-214.254-142.835v257.072c0 30.417 24.747 55.163 55.166 55.163h401.666c30.418 0 55.164-24.746 55.164-55.163v-257.072z"/>
                 </svg>
                 </svg>
-                <a href="mailto:nctr@umanitoba.ca" class="contact-link-link">
+                <a href="mailto:nctr@umanitoba.ca" class="contact-link-link non-nav-link">
                     nctr@umanitoba.ca
                 </a>
             </span>

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/header.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/header.html
@@ -63,12 +63,12 @@
             {% endif %}
             <span class="toggle-container">
                 <li class="nav-toggle-open">
-                    <a class="nav-link" href="#">
+                    <a class="non-nav-link" href="#">
                         <img height="20" src="{% static 'menu_64x64px.webp'%}">
                     </a>
                 </li>
                 <li class="nav-toggle-close">
-                    <a class="nav-link" href="#">
+                    <a class="non-nav-link" href="#">
                         <img height="20" src="{% static 'close_menu_64x64px.webp'%}">
                     </a>
                 </li>

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_base.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_base.html
@@ -39,13 +39,15 @@
                 {% if wizard.steps.prev %}
                     {# Without formnovalidate, you can't go to the previous step without valid data #}
                     {# Which kind of defeats the purpose of going back to the previous step! #}
-                    <button formnovalidate="formnovalidate"
+                    <button id="form-previous-button"
+                            formnovalidate="formnovalidate"
                             name="wizard_goto_step"
                             value="{{ wizard.steps.prev }}"
                             class="blue-button margin-right-20px">{% trans "Previous Step" %}</button>
                 {% endif %}
                 <button {% block submitbuttonattributes %}
                         {% endblock submitbuttonattributes %}
+                        id="form-next-or-submit-button"
                         type="{% block submitbuttontype %}submit{% endblock submitbuttontype %}"
                         class="blue-button">
                     {% if wizard.steps.step1 == wizard.steps.count %}
@@ -67,6 +69,5 @@
             {% endif %}
         </div>
     </form>
-
     {% include "includes/unsaved_transferform_modal.html" %}
 {% endblock content %}

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_base.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_base.html
@@ -46,8 +46,10 @@
                             class="blue-button margin-right-20px">{% trans "Previous Step" %}</button>
                 {% endif %}
                 <button {% block submitbuttonattributes %}
+                        {% comment %} Button is "next" by default, but the id for a "submit" button can be
+                        overrided using this block {% endcomment %}
+                        id="form-next-button"
                         {% endblock submitbuttonattributes %}
-                        id="form-next-or-submit-button"
                         type="{% block submitbuttontype %}submit{% endblock submitbuttontype %}"
                         class="blue-button">
                     {% if wizard.steps.step1 == wizard.steps.count %}

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_base.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_base.html
@@ -9,6 +9,7 @@
 {% block javascript %}
     {{ block.super }}
     <script src="{% static 'transferform.bundle.js' %}"></script>
+    <script>currentFormStep = {{ wizard.steps.step1 }}</script>
 {% endblock javascript %}
 {% block content %}
     <div class="form-title title-text">
@@ -67,5 +68,5 @@
         </div>
     </form>
 
-    {% include "includes/unsaved_transferform_modal.html" with wizard=wizard %}
+    {% include "includes/unsaved_transferform_modal.html" %}
 {% endblock content %}

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_base.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_base.html
@@ -1,9 +1,7 @@
 {% extends "recordtransfer/base.html" %}
-
 {% load i18n %}
 {% load static %}
 {% block title %}
-
     {% blocktrans with currentstep=wizard.steps.step1 totalsteps=wizard.steps.count %}
         Transfer Step {{ currentstep }} (of {{ totalsteps }})
     {% endblocktrans %}
@@ -60,11 +58,14 @@
         <div class="{% block savelinkclass %}flex-item{% endblock savelinkclass %}">
             <label></label>
             {% if wizard.steps.step1 > 1 and wizard.steps.step1 <= wizard.steps.count %}
-                <button class="text-link margin-top-25px"
+                <button id="form-save-button"
+                        class="text-link margin-top-25px"
                         formnovalidate="formnovalidate"
                         name="save_form_step"
                         value="{{ wizard.steps.current }}">{% trans "Click to save form and resume later" %}</button>
             {% endif %}
         </div>
     </form>
+
+    {% include "includes/unsaved_transferform_modal.html" with wizard=wizard %}
 {% endblock content %}

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_rights.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_rights.html
@@ -4,7 +4,7 @@
 {% block form_explanation %}
     <p>
         {% blocktrans %}
-        <a id="show-rights-dialog" href="#">Click here</a> for an explanation of the different types
+        <a id="show-rights-dialog" class="non-nav-link" href="#">Click here</a> for an explanation of the different types
         of rights.
         {% endblocktrans %}
     </p>

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_sourceinfo.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_sourceinfo.html
@@ -1,11 +1,11 @@
-{% extends 'recordtransfer/transferform_standard.html' %}
+{% extends "recordtransfer/transferform_standard.html" %}
 {% load static %}
 {% load i18n %}
 
 {% block javascript %}
     {{ block.super }}
     {{ js_context|json_script:"py_context_source_info" }}
-{% endblock %}
+{% endblock javascript %}
 
 {% block formfields %}
     {% for field in wizard.form %}
@@ -42,7 +42,7 @@
                 <div>
                     <i>
                         {% blocktrans %}
-                        <a id="show-source-types-dialog" href="#">Click here</a> for an explanation
+                        <a id="show-source-types-dialog" class="non-nav-link" href="#">Click here</a> for an explanation
                         of the different types of source types.
                         {% endblocktrans %}
                     </i>
@@ -55,7 +55,7 @@
                 <div>
                     <i>
                         {% blocktrans %}
-                        <a id="show-source-roles-dialog" href="#">Click here</a> for an explanation
+                        <a id="show-source-roles-dialog" class="non-nav-link" href="#">Click here</a> for an explanation
                         of the different types of source roles.
                         {% endblocktrans %}
                     </i>
@@ -64,7 +64,7 @@
             </div>
         {% endif %}
     {% endfor %}
-{% endblock %}
+{% endblock formfields %}
 
 {% block form_explanation %}
     <div id="source-types-dialog" title="Explanation of Source Types">
@@ -95,6 +95,5 @@
             </p>
         {% endfor %}
     </div>
-{% endblock %}
-
-{% block buttonarrayclass %}flex-item{% endblock %}
+{% endblock form_explanation %}
+{% block buttonarrayclass %}flex-item{% endblock buttonarrayclass %}


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/283

Change notes:
- Displays a custom warning modal when user clicks on any navigational link while on the transfer form (except when on the first step of a fresh form)
- Triggers browser's default dialog when user attempts to close tab or exit browser

Additional note:
- Submission of form in the final step is broken, but not from my changes. I'm looking into what's causing it - I think it might be related to this bug: https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/237
(EDIT: this was not the cause of the issue, it was due to errors in `dropzoneForm.js`)