### PR TITLE
Fix invisible reCAPTCHA breaking Previous Step button on final step

### DIFF
--- a/bagitobjecttransfer/recordtransfer/forms/transfer_forms.py
+++ b/bagitobjecttransfer/recordtransfer/forms/transfer_forms.py
@@ -783,7 +783,7 @@ class UploadFilesForm(TransferForm):
         label=gettext("Other notes"),
     )
 
-    session_token = forms.CharField(required=False, widget=forms.HiddenInput(), label="hidden")
+    session_token = forms.CharField(required=True, widget=forms.HiddenInput(), label="hidden")
 
     captcha = ReCaptchaField(widget=ReCaptchaV2Invisible, label="hidden")
 

--- a/bagitobjecttransfer/recordtransfer/forms/transfer_forms.py
+++ b/bagitobjecttransfer/recordtransfer/forms/transfer_forms.py
@@ -783,7 +783,7 @@ class UploadFilesForm(TransferForm):
         label=gettext("Other notes"),
     )
 
-    session_token = forms.CharField(required=True, widget=forms.HiddenInput(), label="hidden")
+    session_token = forms.CharField(required=False, widget=forms.HiddenInput(), label="hidden")
 
     captcha = ReCaptchaField(widget=ReCaptchaV2Invisible, label="hidden")
 

--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/dropzoneForm.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/transferform/dropzoneForm.js
@@ -32,8 +32,8 @@ function getCookie(name) {
  * @param {String} errorMessage The error message to show
  */
 function addDropzoneError(errorMessage) {
-    errorZone = document.getElementById('dropzone-errors')
-    newError = document.createElement('div')
+    const errorZone = document.getElementById('dropzone-errors')
+    const newError = document.createElement('div')
     newError.className = 'field-error'
     newError.innerHTML = errorMessage
     errorZone.appendChild(newError)
@@ -43,7 +43,7 @@ function addDropzoneError(errorMessage) {
  * Removes all errors shown in the dropzone-errors element.
  */
 function clearDropzoneErrors() {
-    errorZone = document.getElementById('dropzone-errors')
+    const errorZone = document.getElementById('dropzone-errors')
     while (errorZone.lastElementChild) {
         errorZone.removeChild(errorZone.lastElementChild);
     }
@@ -110,15 +110,6 @@ $(() => {
                     remainingSizeElement.classList.remove('field-error')
                 }
             }
-        }
-    }
-
-    // Function to update the visibility of the drop message
-    function updateDropMessageVisibility() {
-        if (this.files.length === 0) {
-            dropMessage.style.display = 'block'; // Show message when no files are present
-        } else {
-            dropMessage.style.display = 'none'; // Hide message when there are files
         }
     }
 
@@ -194,16 +185,25 @@ $(() => {
 
             var dropzoneClosure = this
             var submitButton = document.getElementById("submit-form-btn")
-            
+
+            // Function to update the visibility of the drop message
+            function updateDropMessageVisibility() {
+                if (dropzoneClosure.files.length === 0) {
+                    dropMessage.style.display = 'block'; // Show message when no files are present
+                } else {
+                    dropMessage.style.display = 'none'; // Hide message when there are files
+                }
+            }
+
             // Call on initialization to set the correct state
             updateDropMessageVisibility();
 
             // Update drop message visibility when files are added or removed
-            this.on("addedfile", function() {
+            this.on("addedfile", function () {
                 updateDropMessageVisibility();
             });
 
-            this.on("removedfile", function() {
+            this.on("removedfile", function () {
                 updateDropMessageVisibility();
             });
 

--- a/bagitobjecttransfer/recordtransfer/templates/django_recaptcha/includes/js_v2_invisible.html
+++ b/bagitobjecttransfer/recordtransfer/templates/django_recaptcha/includes/js_v2_invisible.html
@@ -2,18 +2,25 @@
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js{% if api_params %}?{{ api_params }}{% endif %}"></script>
 <script type="text/javascript">
     // Submit function to be called, after reCAPTCHA was successful.
+    // OVERRIDEEEEEEN
     var onSubmit_{{ widget_uuid }} = function(token) {
         console.log("reCAPTCHA validated for 'data-widget-uuid=\"{{ widget_uuid }}\"'. Submitting form...")
         document.querySelector('.g-recaptcha[data-widget-uuid="{{ widget_uuid }}"]').closest('form').submit();
     };
 
     // Helper function to prevent form submission and execute verification.
-    var verifyCaptcha_{{ widget_uuid}} = function() {
+    var verifyCaptcha_{{ widget_uuid}} = function(e) {
+        // Check if the form submission was triggered by the "Previous Step" button
+        if (e.submitter && e.submitter.id === 'form-previous-button') {
+            return; // Skip CAPTCHA verification
+        }
+        e.preventDefault();
         grecaptcha.execute();
     };
 
-    // Call the captcha verify method explicitly which we do from the dropzone queuecomplete event.
-    var singleCaptchaFn = function () {
-        verifyCaptcha_{{ widget_uuid }}();
-    };
+    // Bind the helper function to the form submit action.
+    document.addEventListener( 'DOMContentLoaded', function () {
+        var element = document.querySelector('.g-recaptcha[data-widget-uuid="{{ widget_uuid }}"]');
+        element.closest('form').addEventListener('submit', verifyCaptcha_{{ widget_uuid}});
+    });
 </script>

--- a/bagitobjecttransfer/recordtransfer/templates/django_recaptcha/includes/js_v2_invisible.html
+++ b/bagitobjecttransfer/recordtransfer/templates/django_recaptcha/includes/js_v2_invisible.html
@@ -2,25 +2,18 @@
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js{% if api_params %}?{{ api_params }}{% endif %}"></script>
 <script type="text/javascript">
     // Submit function to be called, after reCAPTCHA was successful.
-    // OVERRIDEEEEEEN
     var onSubmit_{{ widget_uuid }} = function(token) {
         console.log("reCAPTCHA validated for 'data-widget-uuid=\"{{ widget_uuid }}\"'. Submitting form...")
         document.querySelector('.g-recaptcha[data-widget-uuid="{{ widget_uuid }}"]').closest('form').submit();
     };
 
     // Helper function to prevent form submission and execute verification.
-    var verifyCaptcha_{{ widget_uuid}} = function(e) {
-        // Check if the form submission was triggered by the "Previous Step" button
-        if (e.submitter && e.submitter.id === 'form-previous-button') {
-            return; // Skip CAPTCHA verification
-        }
-        e.preventDefault();
+    var verifyCaptcha_{{ widget_uuid}} = function() {
         grecaptcha.execute();
     };
 
-    // Bind the helper function to the form submit action.
-    document.addEventListener( 'DOMContentLoaded', function () {
-        var element = document.querySelector('.g-recaptcha[data-widget-uuid="{{ widget_uuid }}"]');
-        element.closest('form').addEventListener('submit', verifyCaptcha_{{ widget_uuid}});
-    });
+    // Call the captcha verify method explicitly which we do from the dropzone queuecomplete event.
+    var singleCaptchaFn = function () {
+        verifyCaptcha_{{ widget_uuid }}();
+    };
 </script>

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/base.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/base.html
@@ -8,9 +8,6 @@
             <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js"></script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
-            {% if FILE_UPLOAD_ENABLED %}
-                {% include "captcha/js_v2_invisible.html" %}
-            {% endif %}
             <script src="{% static 'base.bundle.js' %}"></script>
         {% endblock javascript %}
         <!-- CSS -->

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_base.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/transferform_base.html
@@ -40,7 +40,8 @@
                 {% if wizard.steps.prev %}
                     {# Without formnovalidate, you can't go to the previous step without valid data #}
                     {# Which kind of defeats the purpose of going back to the previous step! #}
-                    <button formnovalidate="formnovalidate"
+                    <button id="form-previous-button"
+                            formnovalidate="formnovalidate"
                             name="wizard_goto_step"
                             value="{{ wizard.steps.prev }}"
                             class="blue-button margin-right-20px">{% trans "Previous Step" %}</button>


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/237

It turns out that the `captcha/js_v2_invisible.html` template was not actually being used to properly override `django_recaptcha/includes/js_v2_invisible.html`. The original template was still being used despite this in `base.html`:

```html
{% if FILE_UPLOAD_ENABLED %}
    {% include "captcha/js_v2_invisible.html" %}
{% endif %}
```

I've renamed that file (`captcha/js_v2_invisible.html`) to match the same folder structure as the actual `include` used in the source code so that Django renders our custom template instead.

It looks like there was difficulty in overriding this exact same template in a past issue https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/92.