### PR TITLE
Fix undefined WEBPACK_MODE in Containerfile

### DIFF
--- a/.github/workflows/publish-to-ghcr.yml
+++ b/.github/workflows/publish-to-ghcr.yml
@@ -49,6 +49,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            WEBPACK_MODE=production
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,8 @@
 FROM nikolaik/python-nodejs:python3.10-nodejs22-slim
 
 ENV PYTHONUNBUFFERED=1
+ARG WEBPACK_MODE
+ENV WEBPACK_MODE $WEBPACK_MODE
 
 # Install poetry
 RUN python -m pip install --user pipx && \

--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,7 @@
 FROM nikolaik/python-nodejs:python3.10-nodejs22-slim
 
 ENV PYTHONUNBUFFERED=1
+# Make arg passed from compose files into environment variable
 ARG WEBPACK_MODE
 ENV WEBPACK_MODE $WEBPACK_MODE
 

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -41,6 +41,8 @@ services:
     build:
       context: .
       dockerfile: Containerfile
+      args:
+          WEBPACK_MODE: development
     container_name: recordtransfer_rq_workers
     command: python manage.py rqworker default
     volumes:
@@ -67,6 +69,8 @@ services:
     build:
       context: .
       dockerfile: Containerfile
+      args:
+          WEBPACK_MODE: development
     container_name: recordtransfer_django_app
     command: python manage.py runserver 0.0.0.0:8000
     volumes:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -44,6 +44,8 @@ services:
     build:
       context: .
       dockerfile: Containerfile
+      args:
+          WEBPACK_MODE: production
     command: python manage.py rqworker default
     restart: unless-stopped
     env_file:
@@ -64,6 +66,8 @@ services:
     build:
       context: .
       dockerfile: Containerfile
+      args:
+        WEBPACK_MODE: production
     command: gunicorn bagitobjecttransfer.wsgi:application --bind 0.0.0.0:8000 --enable-stdio-inheritance
     restart: unless-stopped
     expose:


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/310

Passes `WEBPACK_MODE` as an `arg` from the compose files to the Containerfile, and sets it as an environment variable  there, which `npm run build` has access to.