### PR TITLE
Switch to mysqlclient for MySQL Connections

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-*.sqlite3
+**/*.sqlite3
 **/__pycache__
 .dockerignore
 docker-compose*
@@ -6,5 +6,4 @@ Dockerfile
 example.dev.env
 example.prod.env
 node_modules
-development_database.sqlite3
 ./static/

--- a/.github/workflows/publish-to-ghcr.yml
+++ b/.github/workflows/publish-to-ghcr.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           context: .
           file: Containerfile
+          target: prod
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,34 +1,61 @@
-FROM nikolaik/python-nodejs:python3.10-nodejs22-slim
+FROM nikolaik/python-nodejs:python3.10-nodejs22-slim AS builder
 
 ENV PYTHONUNBUFFERED=1
+
 # Make arg passed from compose files into environment variable
 ARG WEBPACK_MODE
 ENV WEBPACK_MODE $WEBPACK_MODE
 
-# Install poetry
-RUN python -m pip install --user pipx && \
-    python -m pipx ensurepath && \
-    python -m pipx install poetry
-
 WORKDIR /app/
+
+# Install build dependencies and poetry
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        default-libmysqlclient-dev \
+        pkg-config \
+    && \
+    curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
 
 # Copy poetry-related files, and install Python dependencies
 COPY pyproject.toml poetry.lock README.md /app/
-RUN poetry config virtualenvs.create false && poetry install
+RUN poetry config virtualenvs.create true && \
+    poetry config virtualenvs.in-project true && \
+    poetry install -E prod
 
 # Copy Node-related files, and install NodeJS dependencies
 COPY package*.json webpack.config.js /app/
 RUN npm install --no-color
-
-# Copy entrypoint script to image
-COPY ./docker/entrypoint.sh /app/
-RUN chmod +x /app/entrypoint.sh
 
 # Copy application code to image
 COPY ./bagitobjecttransfer /app/bagitobjecttransfer
 
 # Run webpack to bundle and minify assets
 RUN npm run build
+
+
+FROM python:3.10-slim
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app/
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends default-mysql-client && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy built assets from builder image
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/dist /app/dist
+COPY --from=builder /app/bagitobjecttransfer /app/bagitobjecttransfer
+
+# Activate virtual environment
+ENV PATH="/app/.venv/bin:$PATH"
+ENV VIRTUAL_ENV="/app/.venv"
+
+# Copy entrypoint script to image
+COPY ./docker/entrypoint.sh /app/
+RUN chmod +x /app/entrypoint.sh
 
 WORKDIR /app/bagitobjecttransfer/
 

--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app/
 
-# Install build dependencies and poetry
+# Install poetry
 RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
 
 # Copy poetry-related files, and install Python dependencies

--- a/bagitobjecttransfer/bagitobjecttransfer/settings/docker_prod.py
+++ b/bagitobjecttransfer/bagitobjecttransfer/settings/docker_prod.py
@@ -24,9 +24,6 @@ DATABASES = {
         "USER": config("MYSQL_USER"),
         "PASSWORD": config("MYSQL_PASSWORD"),
         "NAME": config("MYSQL_DATABASE"),
-        # "OPTIONS": {
-        #    "converter_str_fallback": True,
-        # },
     }
 }
 

--- a/bagitobjecttransfer/bagitobjecttransfer/settings/docker_prod.py
+++ b/bagitobjecttransfer/bagitobjecttransfer/settings/docker_prod.py
@@ -18,15 +18,15 @@ CSRF_TRUSTED_ORIGINS = config("CSRF_TRUSTED_ORIGINS", cast=str).split(",")
 
 DATABASES = {
     "default": {
-        "ENGINE": "mysql.connector.django",
+        "ENGINE": "django.db.backends.mysql",
         "HOST": config("MYSQL_HOST"),
         "PORT": config("MYSQL_PORT", cast=int, default=3306),
         "USER": config("MYSQL_USER"),
         "PASSWORD": config("MYSQL_PASSWORD"),
         "NAME": config("MYSQL_DATABASE"),
-        "OPTIONS": {
-            "converter_str_fallback": True,
-        },
+        # "OPTIONS": {
+        #    "converter_str_fallback": True,
+        # },
     }
 }
 

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -40,6 +40,7 @@ services:
   rq:
     build:
       context: .
+      target: dev
       dockerfile: Containerfile
       args:
           WEBPACK_MODE: development
@@ -68,6 +69,7 @@ services:
   app:
     build:
       context: .
+      target: dev
       dockerfile: Containerfile
       args:
           WEBPACK_MODE: development

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -43,6 +43,7 @@ services:
   rq:
     build:
       context: .
+      target: prod
       dockerfile: Containerfile
       args:
           WEBPACK_MODE: production
@@ -65,6 +66,7 @@ services:
   app:
     build:
       context: .
+      target: prod
       dockerfile: Containerfile
       args:
         WEBPACK_MODE: production

--- a/poetry.lock
+++ b/poetry.lock
@@ -495,7 +495,7 @@ test = ["pytest (>=6)"]
 name = "gunicorn"
 version = "23.0.0"
 description = "WSGI HTTP Server for UNIX"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d"},
@@ -704,7 +704,7 @@ attrs = ">=19.2.0"
 name = "packaging"
 version = "24.2"
 description = "Core utilities for Python packages"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
@@ -1525,9 +1525,9 @@ type = ["pytest-mypy"]
 [extras]
 dev = ["Sphinx", "pytest-django", "selenium", "sphinx-rtd-theme"]
 docs = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-mermaid"]
-prod = ["mysqlclient"]
+prod = ["gunicorn", "mysqlclient"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "b20d6fd889e54e7d0405b134a4c35bc720bf0133c41b8f0ac7a4047c7cedd58e"
+content-hash = "18278e63acefb85b98b84ecb55a5d827ed9cc1c1658c62a698a9331f112888cd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -670,45 +670,21 @@ files = [
 ]
 
 [[package]]
-name = "mysql-connector-python"
-version = "9.2.0"
-description = "A self-contained Python driver for communicating with MySQL servers, using an API that is compliant with the Python Database API Specification v2.0 (PEP 249)."
-optional = false
-python-versions = ">=3.9"
+name = "mysqlclient"
+version = "2.2.7"
+description = "Python interface to MySQL"
+optional = true
+python-versions = ">=3.8"
 files = [
-    {file = "mysql_connector_python-9.2.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:65808b0a9998150416ee0b5781fdff456faea247e24d505f606aea2acaf21374"},
-    {file = "mysql_connector_python-9.2.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:877552ff04800be4a53604bfee95b4078d10fcc072d54b9ea8dcd159c692742c"},
-    {file = "mysql_connector_python-9.2.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:8a6cfb611bdfea41c67c5305e8fc0e30fdacd258c489dc619f566213cce8bba9"},
-    {file = "mysql_connector_python-9.2.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:7c25dc2cb4fca82242d71a0bda2087bdfa3638e0c8175a747a6e765242763b4a"},
-    {file = "mysql_connector_python-9.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:5c72ecad9007bc52d4f213e47d3c4cf17b3a3cabfeb2d36317fd4493adf5ed7d"},
-    {file = "mysql_connector_python-9.2.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:bddecd023c0e92182eb3159abee7385a1d38b395a58ff4d94d3d6f1abeca6334"},
-    {file = "mysql_connector_python-9.2.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:cc09ca64db620f7c898e1fb7c61a3d6f8f21694fcd276ab2635650ce216f8556"},
-    {file = "mysql_connector_python-9.2.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:4142a0a4e997210558136ad2b623188c102996eda2d951a3933d6338b210f15e"},
-    {file = "mysql_connector_python-9.2.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:e1afa12519671e024d80fbbf74606cc4fb96786b005d79ed959acf3584ba6af4"},
-    {file = "mysql_connector_python-9.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:cf2684641084abc47be2dbba7bd42ce22c682bad4228a10bb12c343e1ecfc484"},
-    {file = "mysql_connector_python-9.2.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:03fe54ca19c2dffa8f04ca0601a1217b126ff8306c76a9b2b4e555f8fbbd2178"},
-    {file = "mysql_connector_python-9.2.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:b13b136c188363e18f9b3f6237a0e6eba8601df259ab0f8687cd689f433a391b"},
-    {file = "mysql_connector_python-9.2.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e8338a9babe6c67287080ec9f6a0fc245de24841bc532ef97dfd1f93caf4668b"},
-    {file = "mysql_connector_python-9.2.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:92ef9e5a37b25978a261b5a14fcfa0cf51cd96168dec4a52657bbfc1e1cb7d9a"},
-    {file = "mysql_connector_python-9.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b7d149bcc455cf606a4aa604d45267fba16c8abf36056b804f8d16e8f5e753c1"},
-    {file = "mysql_connector_python-9.2.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:417c538dfd64e6d415280067f4d7ce3f901ce85c548e609247a794d205769276"},
-    {file = "mysql_connector_python-9.2.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4d97485eb3f63ab26f6438570c4a392bb1f53c3ad9dca1bfd8b61b5ec1bba690"},
-    {file = "mysql_connector_python-9.2.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c2e973bcc6eab68e41e01438b706788e3f47b0b4d6a17fcb74583f7e0b990c5f"},
-    {file = "mysql_connector_python-9.2.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:2238ba121a30dd3a23d33ce3437642e38a1d4b86afaf7a487cdb0d7727db2010"},
-    {file = "mysql_connector_python-9.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:6557942f6c6be3b41d2965456b53a244a7ce3e6fb81cb195c243549be72a6a24"},
-    {file = "mysql_connector_python-9.2.0-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:0aee4e3a053672ded2134eda6fff3bc64796df88c9a9e5cab130b576830e14a8"},
-    {file = "mysql_connector_python-9.2.0-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:86c3217849857113912e8fc628e13182f00955ed1257cb7bfdc3d5ac3c5ff371"},
-    {file = "mysql_connector_python-9.2.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:2a96bed643e901e91c05f421a37844939f5e2f65cc54a406ec5d95e704bda068"},
-    {file = "mysql_connector_python-9.2.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:292974916c6908e62bb0eb864c1c5679aa5c827209a200b5658aa4b4468c19a0"},
-    {file = "mysql_connector_python-9.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:2c358b5732666043683445e88405d58232d5bb0977d24ec55e02a315b33fecbc"},
-    {file = "mysql_connector_python-9.2.0-py2.py3-none-any.whl", hash = "sha256:d007c05a48fc076e5ac7ad3d76e332fa5b0e885853c2da80071ade2d6e01aba5"},
+    {file = "mysqlclient-2.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:2e3c11f7625029d7276ca506f8960a7fd3c5a0a0122c9e7404e6a8fe961b3d22"},
+    {file = "mysqlclient-2.2.7-cp311-cp311-win_amd64.whl", hash = "sha256:a22d99d26baf4af68ebef430e3131bb5a9b722b79a9fcfac6d9bbf8a88800687"},
+    {file = "mysqlclient-2.2.7-cp312-cp312-win_amd64.whl", hash = "sha256:4b4c0200890837fc64014cc938ef2273252ab544c1b12a6c1d674c23943f3f2e"},
+    {file = "mysqlclient-2.2.7-cp313-cp313-win_amd64.whl", hash = "sha256:201a6faa301011dd07bca6b651fe5aaa546d7c9a5426835a06c3172e1056a3c5"},
+    {file = "mysqlclient-2.2.7-cp39-cp39-win_amd64.whl", hash = "sha256:199dab53a224357dd0cb4d78ca0e54018f9cee9bf9ec68d72db50e0a23569076"},
+    {file = "mysqlclient-2.2.7-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:92af368ed9c9144737af569c86d3b6c74a012a6f6b792eb868384787b52bb585"},
+    {file = "mysqlclient-2.2.7-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:977e35244fe6ef44124e9a1c2d1554728a7b76695598e4b92b37dc2130503069"},
+    {file = "mysqlclient-2.2.7.tar.gz", hash = "sha256:24ae22b59416d5fcce7e99c9d37548350b4565baac82f95e149cac6ce4163845"},
 ]
-
-[package.extras]
-dns-srv = ["dnspython (==2.6.1)"]
-fido2 = ["fido2 (==1.1.2)"]
-gssapi = ["gssapi (==1.8.3)"]
-telemetry = ["opentelemetry-api (==1.18.0)", "opentelemetry-exporter-otlp-proto-http (==1.18.0)", "opentelemetry-sdk (==1.18.0)"]
 
 [[package]]
 name = "outcome"
@@ -1549,8 +1525,9 @@ type = ["pytest-mypy"]
 [extras]
 dev = ["Sphinx", "pytest-django", "selenium", "sphinx-rtd-theme"]
 docs = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-mermaid"]
+prod = ["mysqlclient"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "2fc7cac098e9e2f0be1add868256c732201e5c64307d7fa0ff35ce04802def03"
+content-hash = "b20d6fd889e54e7d0405b134a4c35bc720bf0133c41b8f0ac7a4047c7cedd58e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ django-override-storage = "^0.3.2"
 django-recaptcha = "^4.0.0"
 django-rq = "^3.0.0"
 gunicorn = "^23.0.0"
-mysql-connector-python = "^9.0.0"
+mysqlclient = { version = "^2.2.7", optional = true }
 python-decouple = "^3.8"
 selenium = { version = "^4.27.1", optional = true }
 setuptools = "^75.1.0"
@@ -31,6 +31,7 @@ sphinx-rtd-theme = { version = "^2.0.0", optional = true }
 pytest-django = { version = "^4.9.0", optional = true }
 
 [tool.poetry.extras]
+prod = ["mysqlclient"]
 docs = ["Sphinx", "sphinxcontrib-mermaid", "sphinx-rtd-theme"]
 dev = ["pytest-django", "selenium", "Sphinx", "sphinx-rtd-theme"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ django-formtools = "^2.5.1"
 django-override-storage = "^0.3.2"
 django-recaptcha = "^4.0.0"
 django-rq = "^3.0.0"
-gunicorn = "^23.0.0"
+gunicorn = { version = "^23.0.0", optional = true }
 mysqlclient = { version = "^2.2.7", optional = true }
 python-decouple = "^3.8"
 selenium = { version = "^4.27.1", optional = true }
@@ -31,7 +31,7 @@ sphinx-rtd-theme = { version = "^2.0.0", optional = true }
 pytest-django = { version = "^4.9.0", optional = true }
 
 [tool.poetry.extras]
-prod = ["mysqlclient"]
+prod = ["gunicorn", "mysqlclient"]
 docs = ["Sphinx", "sphinxcontrib-mermaid", "sphinx-rtd-theme"]
 dev = ["pytest-django", "selenium", "Sphinx", "sphinx-rtd-theme"]
 


### PR DESCRIPTION
This pull request switches out the `mysql-connector-python` dependency for Django's recommended `mysqlclient`.

Since `mysqlclient` has some C dependencies that need to be built, I've modified how the container is built.

The Containerfile now uses a multi-stage build. The `base` stage is shared between the new `dev` and `prod` targets. A way to visualize the Containerfile is this:

```mermaid
---
title: Target Flowchart for new Containerfile
---

flowchart TD
    base("`base
    (based on *nikolaik/python-nodejs:python3.10-nodejs22-slim*)
    `")

    dev("`**dev**
    (based on *nikolaik/python-nodejs:python3.10-nodejs22-slim*)
    `")

    builder("`builder
    (based on *nikolaik/python-nodejs:python3.10-nodejs22-slim*)
    `")

    prod("`**prod**
    (based on *python:3.10-slim*)
    `")

    base --> dev
    base --> builder
    builder --> prod
```

I've switched the `prod` image to use `python:3.10-slim` which has better support than `nodejs:python3.10-nodejs22-slim`. This means that `node` and `npm` are no longer available in the production image. This is fine because the assets are built in the `base` image and do not need to rebuilt after that for prod.

Another notable change is that I'm now using a virtual environment in the container. Since I needed to be able to copy Python dependencies between different containers, using a virtual environment was the obvious solution.