### PR TITLE
Automate Static Asset Build for E2E Tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,21 @@
+"""Contains pytest hooks. The hooks defined here are used to modify the behavior of
+pytest during test collection and execution.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def pytest_collection_modifyitems(session, config, items) -> None:
+    """Run npm build only if e2e tests are being run. `items` is a list of test items to be
+    run.
+    """
+    e2e_tests = any("e2e" in str(Path(item.fspath)) for item in items)
+
+    if e2e_tests:
+        try:
+            subprocess.run(["npm", "run", "build"], check=True)
+        except subprocess.CalledProcessError as e:
+            pytest.exit(f"Failed to run npm build: {e}")

--- a/conftest.py
+++ b/conftest.py
@@ -12,9 +12,8 @@ def pytest_collection_modifyitems(session, config, items) -> None:
     """Run npm build only if e2e tests are being run. `items` is a list of test items to be
     run.
     """
-    e2e_tests = any("e2e" in str(Path(item.fspath)) for item in items)
-
-    if e2e_tests:
+    # Check if running unit tests via -k parameter
+    if config.getoption("-k") == "e2e":
         try:
             subprocess.run(["npm", "run", "build"], check=True)
         except subprocess.CalledProcessError as e:

--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,19 @@ def pytest_collection_modifyitems(session, config, items) -> None:
     # Check if running unit tests via -e2e parameter
     if config.getoption("-k") == "e2e":
         try:
-            subprocess.run(["npm", "run", "build"], check=True)
+            npm_cmd = "npm.cmd" if os.name == "nt" else "npm"
+            subprocess.run(
+                [npm_cmd, "run", "build"],
+                check=True,
+                env={
+                    **os.environ,
+                    "WEBPACK_MODE": "development",
+                },
+            )
         except subprocess.CalledProcessError as e:
             pytest.exit(f"Failed to run npm build: {e}")
+        except FileNotFoundError as e:
+            pytest.exit(
+                f"npm command not found (got: {e}). npm must be installed to run e2e tests."
+            )
+

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@
 pytest during test collection and execution.
 """
 
+import os
 import subprocess
 
 import pytest
@@ -11,8 +12,8 @@ def pytest_collection_modifyitems(session, config, items) -> None:
     """Run npm build only if e2e tests are being run. `items` is a list of test items to be
     run.
     """
-    # Check if running unit tests via -e2e parameter
-    if config.getoption("-k") == "e2e":
+    # Check if running unit tests via -e2e parameter or running all tests
+    if config.getoption("-k") == "e2e" or not config.getoption("-k"):
         try:
             npm_cmd = "npm.cmd" if os.name == "nt" else "npm"
             subprocess.run(
@@ -29,4 +30,3 @@ def pytest_collection_modifyitems(session, config, items) -> None:
             pytest.exit(
                 f"npm command not found (got: {e}). npm must be installed to run e2e tests."
             )
-

--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,7 @@ def pytest_collection_modifyitems(session, config, items) -> None:
     """Run npm build only if e2e tests are being run. `items` is a list of test items to be
     run.
     """
-    # Check if running unit tests via -k parameter
+    # Check if running unit tests via -e2e parameter
     if config.getoption("-k") == "e2e":
         try:
             subprocess.run(["npm", "run", "build"], check=True)

--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,6 @@ pytest during test collection and execution.
 """
 
 import subprocess
-from pathlib import Path
 
 import pytest
 

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@ pytest during test collection and execution.
 """
 
 import os
+import shutil
 import subprocess
 
 import pytest
@@ -15,7 +16,7 @@ def pytest_collection_modifyitems(session, config, items) -> None:
     # Check if running unit tests via -e2e parameter or running all tests
     if config.getoption("-k") == "e2e" or not config.getoption("-k"):
         try:
-            npm_cmd = "npm.cmd" if os.name == "nt" else "npm"
+            npm_cmd = shutil.which("npm") or "npm"
             subprocess.run(
                 [npm_cmd, "run", "build"],
                 check=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,5 +43,5 @@ pythonpath = "bagitobjecttransfer"
 python_files = "test_*.py"
 DJANGO_SETTINGS_MODULE = "bagitobjecttransfer.settings.test"
 
-[tool.poetry.plugins."pytest11"]
+[tool.poetry.plugins.pytest11]
 npm_build = "conftest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,6 @@ build-backend = "poetry.core.masonry.api"
 pythonpath = "bagitobjecttransfer"
 python_files = "test_*.py"
 DJANGO_SETTINGS_MODULE = "bagitobjecttransfer.settings.test"
+
+[tool.poetry.plugins."pytest11"]
+npm_build = "conftest"


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/343

Uses a pytest hook to call `npm run build` before any E2E test is run:
- https://docs.pytest.org/en/stable/how-to/writing_plugins.html#making-your-plugin-installable-by-others
- https://docs.pytest.org/en/stable/how-to/writing_hook_functions.html