### PR TITLE
Prevent Footer Image from Flickering

### DIFF
--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/base.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/base.html
@@ -22,6 +22,7 @@
         <link rel="shortcut icon"
               type="image/png"
               href="{% static "recordtransfer/img/favicon.ico" %}" />
+        <link rel="preload" href="{% static 'footer.webp' %}" as="image">
         <title>
             {% block title %}{% endblock title %}
         </title>


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/357

- Preloads footer image in the head tag of the base template