### PR TITLE
Fix running tests when using manage.py

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -27,7 +27,7 @@ The debugging configuration has already been set up in the `.vscode/launch.json`
 A GitHub Actions workflow is set up to run Django tests on every pull request to the master branch. All tests must pass before a merge is allowed. The workflow configuration can be found in `.github/workflows/django-tests.yml`.
 
 
-### Re-build JS as Changes are Made
+## Re-build JS as Changes are Made
 
 After you run the dev container (`compose.dev.yml`), you can automatically re-build the JS files any time they change with this command:
 
@@ -41,7 +41,7 @@ podman-compose -f compose.dev.yml exec app npm run watch
 
 This will re-build the bundled JS files any time you save a change to a `.js` file which is useful while you're writing Javascript. This command does not exit until you press CTRL-C, so make sure to run it in a separate terminal.
 
-# Virtual Environment and Poetry Setup
+## Virtual Environment and Poetry Setup
 
 Python dependencies are managed with [Poetry](https://python-poetry.org/). To install Poetry and create a virtual environment with the minimally necessary packages, follow these instructions:
 
@@ -71,33 +71,51 @@ Finally, install the dependencies with `poetry`:
 poetry install
 ```
 
-## Testing Setup
+## Running Tests
 
 Ensure you follow the instructions in the [Virtual Environment and Poetry Setup](#virtual-environment-and-poetry-setup) section before continuing.
 
 Install the `dev` dependencies with Poetry:
 
 ```shell
-poetry install --extras "dev"
+poetry install -E dev
 ```
 
-The tests can be run with [pytest](https://docs.pytest.org/en/stable/how-to/usage.html) (using [pytest-django](https://pytest-django.readthedocs.io/en/latest/#example-using-pyproject-toml)):
-To run tests, use:
+The tests can be run in a few different ways:
+
+1. Using [pytest](https://docs.pytest.org/en/stable/how-to/usage.html) (this uses [settings in the `pyproject.toml` file](https://pytest-django.readthedocs.io/en/latest/#example-using-pyproject-toml))
+2. The [Django test runner](https://docs.djangoproject.com/en/4.2/ref/django-admin/#test)
+3. The [VS Code test runner](https://code.visualstudio.com/docs/python/testing#_run-tests)
+
+This document focuses only on the first two options. For information on [running and debugging tests with VS Code, click here](https://code.visualstudio.com/docs/python/testing#_run-tests).
+
+The `pytest` commands can be run from the root of the repository. The Django admin tests must be run from the `app` directory.
+
+To run all tests:
+
 ```shell
 pytest
+
+# Or, from the app/ directory:
+python manage.py test
 ```
 
-For unit tests only:
+To run only the unit tests:
+
 ```shell
 pytest -k "unit"
+
+# Or, from the app/ directory:
+python manage.py test --exclude-tag=e2e
 ```
 
-For E2E tests only:
+To run only the end-to-end tests:
+
 ```shell
 pytest -k "e2e"
-```
 
-The tests should also be discoverable and runnable from the VSCode test explorer.
+# There is currently no way to do this with python manage.py test (yet)
+```
 
 ## Building the Documentation
 
@@ -105,9 +123,10 @@ The documentation for this repository is built with [Sphinx](https://sphinx-doc.
 
 Ensure you follow the instructions in the [Virtual Environment and Poetry Setup](#virtual-environment-and-poetry-setup) section before continuing.
 
-Install the `docs` dependencies with Poetry:
+Install the `dev` dependencies with Poetry:
+
 ```shell
-poetry install --extras "docs"
+poetry install -E dev
 ```
 
 To build the docs, run:

--- a/app/app/settings/test.py
+++ b/app/app/settings/test.py
@@ -9,8 +9,6 @@ DEBUG = True
 
 TESTING = True
 
-TEST_RUNNER = "override_storage.LocMemStorageDiscoverRunner"
-
 SITE_ID = 1
 
 ALLOWED_HOSTS = [

--- a/app/recordtransfer/tests/e2e/test_e2e.py
+++ b/app/recordtransfer/tests/e2e/test_e2e.py
@@ -1,8 +1,8 @@
-import os
 import tempfile
 from typing import ClassVar
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.test import tag
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -20,6 +20,7 @@ def get_section_title(step: TransferStep) -> str:
     return TransferFormWizard._TEMPLATES[step][FORMTITLE]
 
 
+@tag("e2e")
 class TransferFormWizardTest(StaticLiveServerTestCase):
     """End-to-end tests for the transfer form wizard."""
 

--- a/app/recordtransfer/tests/unit/test_models.py
+++ b/app/recordtransfer/tests/unit/test_models.py
@@ -1,8 +1,6 @@
-# pylint: disable=too-many-public-methods
 import logging
 import shutil
 import tempfile
-from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
@@ -648,14 +646,10 @@ class TestUploadSession(TestCase):
         logging.disable(logging.NOTSET)
 
 
-class TestBaseUploadedFile(TestCase, ABC):
-    """Tests for the BaseUploadedFile model."""
+class TestPermUploadedFile(TestCase):
+    """Test the PermUploadedFile model."""
 
-    @property
-    @abstractmethod
-    def model_class(self) -> type:
-        """Must be implemented by child classes."""
-        pass
+    model_class = PermUploadedFile
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -752,13 +746,13 @@ class TestBaseUploadedFile(TestCase, ABC):
         logging.disable(logging.NOTSET)
 
 
-class TestTempUploadedFile(TestBaseUploadedFile):
-    """Tests for the TempUploadedFile model."""
+class TestTempUploadedFile(TestPermUploadedFile):
+    """Tests for the TempUploadedFile model.
 
-    @property
-    def model_class(self) -> type:
-        """Return the TempUploadedFile model class."""
-        return TempUploadedFile
+    These tests are basically the same as the permanent file tests.
+    """
+
+    model_class = TempUploadedFile
 
     def test_move_to_permanent_storage(self) -> None:
         """Test that the file is moved to permanent storage."""
@@ -768,12 +762,3 @@ class TestTempUploadedFile(TestBaseUploadedFile):
         self.assertFalse(self.uploaded_file.exists)
         perm_uploaded_file = PermUploadedFile.objects.get(session=self.session, name="test.pdf")
         self.assertTrue(perm_uploaded_file.exists)
-
-
-class TestPermUploadedFile(TestBaseUploadedFile):
-    """Tests for the PermUploadedFile model."""
-
-    @property
-    def model_class(self) -> type:
-        """Return the PermUploadedFile model class."""
-        return PermUploadedFile

--- a/app/recordtransfer/tests/unit/views/test_media.py
+++ b/app/recordtransfer/tests/unit/views/test_media.py
@@ -277,19 +277,6 @@ class TestUploadFilesView(TestCase):
         self.assertEqual(response_json.get("accepted"), False)
         self.assertEqual(session.file_count, 0)
 
-    @skipIf(True, "File content scanning is not implemented yet")
-    def test_content_issue_flagged(self) -> None:
-        """
-        self.patch__accept_contents.return_value = {
-            "accepted": False,
-            "error": "ISSUE",
-            "clamav": {
-                "reason": "Virus",
-                "status": "FOUND",
-            },
-        }
-        """
-
 
 class TestMediaRequestView(TestCase):
     """Test the recordtransfer:media view."""

--- a/app/recordtransfer/tests/unit/views/test_media.py
+++ b/app/recordtransfer/tests/unit/views/test_media.py
@@ -7,8 +7,6 @@ from django.forms import ValidationError
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.translation import gettext
-from override_storage import override_storage
-from override_storage.storage import LocMemStorage
 
 from recordtransfer.models import TempUploadedFile, UploadSession, User
 
@@ -69,7 +67,6 @@ class TestCreateUploadSessionView(TestCase):
 @patch("django.conf.settings.MAX_TOTAL_UPLOAD_SIZE_MB", 3)
 @patch("django.conf.settings.MAX_SINGLE_UPLOAD_SIZE_MB", 1)
 @patch("django.conf.settings.MAX_TOTAL_UPLOAD_COUNT", 4)  # Number of files
-@override_storage(storage=LocMemStorage())
 class TestUploadFilesView(TestCase):
     """Tests for recordtransfer:upload_files view."""
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -423,17 +423,6 @@ files = [
 Django = ">=3.2"
 
 [[package]]
-name = "django-override-storage"
-version = "0.3.2"
-description = "Django test helpers to manage file storage side effects."
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-files = [
-    {file = "django-override-storage-0.3.2.tar.gz", hash = "sha256:995e1a42f056c9f9bc114077c11d67520ec7d8a752a59be62729e641562b133e"},
-    {file = "django_override_storage-0.3.2-py2.py3-none-any.whl", hash = "sha256:1f1a13274d66cc481b19d63c8bd43c94066824008bcdd26ec65d125b1ce8ec39"},
-]
-
-[[package]]
 name = "django-recaptcha"
 version = "4.0.0"
 description = "Django recaptcha form field/widget app."
@@ -1523,11 +1512,11 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
-dev = ["Sphinx", "pytest-django", "selenium", "sphinx-rtd-theme"]
+dev = ["Sphinx", "pytest-django", "selenium", "sphinx-rtd-theme", "sphinxcontrib-mermaid"]
 docs = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-mermaid"]
 prod = ["gunicorn", "mysqlclient"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "18278e63acefb85b98b84ecb55a5d827ed9cc1c1658c62a698a9331f112888cd"
+content-hash = "6483eff153ff3edd248be084dde4012e811fa6824bd49c85d65d43ea4c788999"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ debugpy = "^1.8.2"
 Django = "4.2.*"
 django-countries = "^7.6.1"
 django-formtools = "^2.5.1"
-django-override-storage = "^0.3.2"
 django-recaptcha = "^4.0.0"
 django-rq = "^3.0.0"
 gunicorn = { version = "^23.0.0", optional = true }
@@ -33,7 +32,13 @@ pytest-django = { version = "^4.9.0", optional = true }
 [tool.poetry.extras]
 prod = ["gunicorn", "mysqlclient"]
 docs = ["Sphinx", "sphinxcontrib-mermaid", "sphinx-rtd-theme"]
-dev = ["pytest-django", "selenium", "Sphinx", "sphinx-rtd-theme"]
+dev = [
+    "pytest-django",
+    "selenium",
+    "Sphinx",
+    "sphinxcontrib-mermaid",
+    "sphinx-rtd-theme",
+]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Closes #349

The tests now work whether you're using `manage.py`, `pytest`, or the VS Code test explorer.

I removed a package that was only being used when run via `manage.py`. Since the tests are running fine without that package, I've decided to remove it.