### PR TITLE
Fix stretched country icon when editing CAAIS metadata in admin

### DIFF
--- a/app/caais/static/caais/css/base/metadataChangeForm.css
+++ b/app/caais/static/caais/css/base/metadataChangeForm.css
@@ -3,10 +3,12 @@
 .inline-textarea {
     width: 97%;
 }
+
 .enable-vertical-resize {
     resize: vertical;
     min-height: 1.25em;
 }
+
 .disable-resize {
     resize: none;
 }
@@ -15,6 +17,7 @@
 th.required {
     width: 92%;
 }
+
 td.delete {
     text-align: center;
     display: flex;
@@ -32,4 +35,4 @@ td.delete {
 /* For the country select flag */
 .country-select-flag {
     object-fit: contain;
-  }
+}

--- a/app/caais/static/caais/css/base/metadataChangeForm.css
+++ b/app/caais/static/caais/css/base/metadataChangeForm.css
@@ -29,6 +29,7 @@ td.delete {
     padding: 6px 0 0 0;
 }
 
+/* For the country select flag */
 .country-select-flag {
     object-fit: contain;
   }

--- a/app/caais/static/caais/css/base/metadataChangeForm.css
+++ b/app/caais/static/caais/css/base/metadataChangeForm.css
@@ -28,3 +28,7 @@ td.delete {
     font-size: 14px;
     padding: 6px 0 0 0;
 }
+
+.country-select-flag {
+    object-fit: contain;
+  }


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/383

It should look like this now:
![image](https://github.com/user-attachments/assets/45de2d43-9c36-4119-9bda-3b02758521db)
