### PR TITLE
Test Compose Files in Podman & Docker

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -47,6 +47,7 @@ services:
       dockerfile: Containerfile
       args:
           WEBPACK_MODE: production
+    image: secure-record-transfer-prod
     command: python manage.py rqworker default
     restart: unless-stopped
     env_file:
@@ -54,7 +55,6 @@ services:
     environment:
       - ENV=prod
       - IS_RQ=yes
-      - WEBPACK_MODE=production
       - DJANGO_SETTINGS_MODULE=app.settings.docker_prod
     depends_on:
       - db
@@ -64,34 +64,20 @@ services:
       - media-volume:/opt/secure-record-transfer/app/media/
 
   rq-scheduler:
-    build:
-      context: .
-      target: prod
-      dockerfile: Containerfile
-      args:
-          WEBPACK_MODE: production
+    image: secure-record-transfer-prod
     command: python manage.py schedule_jobs
     restart: unless-stopped
     env_file:
       - .prod.env
     environment:
       - ENV=prod
-      - IS_RQ=yes
-      - WEBPACK_MODE=production
+      - IS_RQ=no
       - DJANGO_SETTINGS_MODULE=app.settings.docker_prod
     depends_on:
-      - db
-      - redis
-    volumes:
-      - ./app/:/opt/secure-record-transfer/app/:z
+      - rq
 
   app:
-    build:
-      context: .
-      target: prod
-      dockerfile: Containerfile
-      args:
-        WEBPACK_MODE: production
+    image: secure-record-transfer-prod
     command: gunicorn app.wsgi:application --bind 0.0.0.0:8000 --enable-stdio-inheritance
     restart: unless-stopped
     expose:
@@ -101,11 +87,10 @@ services:
     environment:
       - ENV=prod
       - IS_RQ=no
-      - WEBPACK_MODE=production
       - DJANGO_SETTINGS_MODULE=app.settings.docker_prod
     depends_on:
-      - db
       - rq
+      - rq-scheduler
       - clamav
     volumes:
       - static-volume:/opt/secure-record-transfer/app/static/


### PR DESCRIPTION
Closes #406 

I have verified that both the dev and prod containers are now working in both Docker and Podman. I made a few simplifications to the prod compose file to bring it in line with the dev container.

Here is the dev container running in Podman:

![dev-container](https://github.com/user-attachments/assets/7454e7fd-9c61-4a19-8eee-a54d687a4217)

And here is the prod container running in Podman with the latest changes on this branch (you can see the image is tagged `secure-record-transfer-prod`):

![prod-container](https://github.com/user-attachments/assets/ddd813c4-057a-4934-8325-2884020c3c82)

The reason I removed `WEBPACK_MODE` from the container's `env:` is that it's only needed when the container is built in production. The reason it's included as an `env:` variable in the dev containers is so that running Webpack uses the proper configuration (whereas Webpack can't be run in the prod containers).