### PR TITLE
Fix large flag in CAAIS Metadata admin change form on small screen size

### DIFF
--- a/app/caais/forms.py
+++ b/app/caais/forms.py
@@ -3,7 +3,6 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext
 
 from django_countries.fields import CountryField
-from django_countries.widgets import CountrySelectWidget
 
 from caais.models import (
     AbstractTerm,
@@ -23,6 +22,7 @@ from caais.models import (
     SourceOfMaterial,
     StorageLocation,
 )
+from caais.widgets import CustomCountrySelectWidget
 
 
 SelectTermWidget = forms.widgets.Select(attrs={
@@ -263,7 +263,7 @@ class InlineSourceOfMaterialForm(CaaisModelForm):
 
     country = CountryField(blank_label=gettext('Select a Country')).formfield(
         required=False,
-        widget=CountrySelectWidget(
+        widget=CustomCountrySelectWidget(
             attrs={
                 'class': 'vTextField',
             }

--- a/app/caais/static/caais/css/base/metadataChangeForm.css
+++ b/app/caais/static/caais/css/base/metadataChangeForm.css
@@ -31,8 +31,3 @@ td.delete {
     font-size: 14px;
     padding: 6px 0 0 0;
 }
-
-/* For the country select flag */
-.country-select-flag {
-    object-fit: contain;
-}

--- a/app/caais/widgets.py
+++ b/app/caais/widgets.py
@@ -1,0 +1,13 @@
+from django.utils.safestring import SafeText
+from django_countries.widgets import CountrySelectWidget
+
+
+class CustomCountrySelectWidget(CountrySelectWidget):
+    """Custom Country Select Widget that wraps the rendered field in a container div, so that both
+    the select field and the flag show side by side.
+    """
+
+    def render(self, name, value, attrs=None, renderer=None) -> SafeText:
+        """Render the widget with a container div around it."""
+        rendered = super().render(name, value, attrs, renderer)
+        return SafeText(f'<div class="country-select-container">{rendered}</div>')


### PR DESCRIPTION
Closes #456 

Wraps the original rendered HTML for the `CountrySelectField` in a div, so that they are displayed side-by-side. The issue before was that the flag was a direct child of a flexbox containing the select field and the flag image, which meant that on a small screen, the flag image gets wrapped onto a separate row, causing it to fill up the available width of the entire flexbox.