### PR TITLE
Fix Sphinx documentation build warnings

### DIFF
--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -1,6 +1,0 @@
-Private Archivist Application
-=============================
-
-Along with the main public facing application is a private application intended to be used by
-archivists to view and manage the transfers made by users. This private application uses the
-Django admin app with a number of useful custom archival administration functions built in.

--- a/docs/code/caais.rst
+++ b/docs/code/caais.rst
@@ -3,4 +3,3 @@ recordtransfer.caais - Convert to CAAIS Metadata
 
 .. automodule:: recordtransfer.caais
    :members:
-   :undoc-members:

--- a/docs/code/configuration.rst
+++ b/docs/code/configuration.rst
@@ -3,4 +3,3 @@ configuration - Custom Config Parsers
 
 .. automodule:: configuration
    :members:
-   :undoc-members:

--- a/docs/code/decorators.rst
+++ b/docs/code/decorators.rst
@@ -2,4 +2,3 @@ recordtransfer.decorators - Decorators
 ======================================
 .. automodule:: recordtransfer.decorators
    :members:
-   :undoc-members:

--- a/docs/code/emails.rst
+++ b/docs/code/emails.rst
@@ -6,4 +6,3 @@ meant to run asynchronously with a Redis server.
 
 .. automodule:: recordtransfer.emails
    :members:
-   :undoc-members:

--- a/docs/code/forms.rst
+++ b/docs/code/forms.rst
@@ -3,4 +3,3 @@ recordtransfer.forms - Transfer Forms
 
 .. automodule:: recordtransfer.forms
    :members:
-   :undoc-members:

--- a/docs/code/jobs.rst
+++ b/docs/code/jobs.rst
@@ -6,4 +6,3 @@ meant to run asynchronously with a Redis server.
 
 .. automodule:: recordtransfer.jobs
    :members:
-   :undoc-members:

--- a/docs/code/models.rst
+++ b/docs/code/models.rst
@@ -3,4 +3,3 @@ recordtransfer.models - Data Models
 
 .. automodule:: recordtransfer.models
    :members:
-   :undoc-members:

--- a/docs/code/utils.rst
+++ b/docs/code/utils.rst
@@ -3,4 +3,3 @@ recordtransfer.utils - Utility Functions
 
 .. automodule:: recordtransfer.utils
    :members:
-   :undoc-members:

--- a/docs/code/views.rst
+++ b/docs/code/views.rst
@@ -6,34 +6,28 @@ Home
 ----
 .. automodule:: recordtransfer.views.home
    :members:
-   :undoc-members:
 
 Account
 -------
 .. automodule:: recordtransfer.views.account
    :members:
-   :undoc-members:
 
 Profile
 -------
 .. automodule:: recordtransfer.views.profile
    :members:
-   :undoc-members:
 
 Media
 -----
 .. automodule:: recordtransfer.views.media
    :members:
-   :undoc-members:
 
 Transfer
 --------
 .. automodule:: recordtransfer.views.transfer
    :members:
-   :undoc-members:
 
 Submission
 ----------
 .. automodule:: recordtransfer.views.submission
    :members:
-   :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,6 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 master_doc = 'index'

--- a/docs/howtouse/transferform.rst
+++ b/docs/howtouse/transferform.rst
@@ -114,7 +114,7 @@ dropping files into it. If they add a file that isn't accepted by your accepted 
 transfer will not be allowed to submit until they remove the offending files.
 
 To see more about how to change what files are accepted, go to the section on
-:ref:`Accepted File Types`.
+:ref:`ACCEPTED_FILE_FORMATS`.
 
 .. image:: images/transfer_step_8.png
     :alt: Step 8 of the transfer form

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,6 @@ with `AtoM <https://accesstomemory.org/en/>`_.
    howtouse/index
    customization/index
    settings/index
-   admin/index
    code/index
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ with `AtoM <https://accesstomemory.org/en/>`_.
    howtouse/index
    customization/index
    settings/index
+   admin/index
    code/index
 
 

--- a/docs/running/index.rst
+++ b/docs/running/index.rst
@@ -7,7 +7,7 @@ if you are using Docker, substitute the relevant Docker commands.
 
 Before running the application, make sure you have these tools installed:
 
-- `Podman <https://podman.io>`_
+- `Podman <https://podman.io/>`_
 - `Podman Desktop <https://podman-desktop.io/>`_ (Optional, but recommended)
 - `Python 3 <https://python.org>`_
 - `Podman Compose <https://github.com/containers/podman-compose>`_

--- a/docs/settings/index.rst
+++ b/docs/settings/index.rst
@@ -547,7 +547,7 @@ UPLOAD_STORAGE_FOLDER
         ======================================================  ======================================================  ======
         Default in Dev                                          Default in Prod                                         Type
         ======================================================  ======================================================  ======
-        /opt/secure-record-transfer/app/media/uploaded_files/  /opt/secure-record-transfer/app/media/uploaded_files/  string
+        /opt/secure-record-transfer/app/media/uploaded_files/   /opt/secure-record-transfer/app/media/uploaded_files/   string
         ======================================================  ======================================================  ======
 
     The files users upload will be copied here after being uploaded with either of the Django


### PR DESCRIPTION
Closes #461 

- Change doc settings for modules so that members without an explicit docstring will not be included within the docs. This means that any class attributes that you want to document should be included as part of the class's docstring.
- Removed "_static" from `html_static_path` in `docs.conf.py`, as this directory does not exist and the docs currently do not use custom static assets.