### PR TITLE
Add Link to Profile on Submission Group Page

### DIFF
--- a/app/recordtransfer/static/recordtransfer/css/base/base.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/base.css
@@ -334,6 +334,37 @@ h2 {
     cursor: not-allowed;
 }
 
+.step-link,
+.back-to-btn {
+    background: none;
+    border: none;
+    color: #007bff;
+    font-size: 0.9rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    transition: color 0.2s;
+}
+
+.step-link:hover,
+.back-to-btn:hover {
+    color: #0056b3;
+}
+
+.step-link i,
+.back-to-btn i {
+    font-size: 0.8rem;
+}
+
+.step-link {
+    padding: 0.5rem 1rem;
+}
+
+.back-to-btn {
+    margin-bottom: 1rem;
+}
+
 @media (max-width: 1199px) {
 
     .main-header-content,

--- a/app/recordtransfer/static/recordtransfer/css/base/base.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/base.css
@@ -362,7 +362,8 @@ h2 {
 }
 
 .back-to-btn {
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
+    text-decoration: none;
 }
 
 @media (max-width: 1199px) {

--- a/app/recordtransfer/static/recordtransfer/css/submission_form/review_step.css
+++ b/app/recordtransfer/static/recordtransfer/css/submission_form/review_step.css
@@ -82,27 +82,6 @@ dd {
     margin-bottom: 1rem;
 }
 
-.step-link {
-    background: none;
-    border: none;
-    color: #007bff;
-    font-size: 0.9rem;
-    cursor: pointer;
-    padding: 0.5rem 1rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    transition: color 0.2s;
-}
-
-.step-link:hover {
-    color: #0056b3;
-}
-
-.step-link i {
-    font-size: 0.8rem;
-}
-
 .align-center {
     align-self: center;
 }

--- a/app/recordtransfer/templates/includes/submission_table.html
+++ b/app/recordtransfer/templates/includes/submission_table.html
@@ -16,7 +16,7 @@
                 <td>{{ submission.metadata.accession_title }}</td>
                 <td>{{ submission.extent_statements }}</td>
                 <td>
-                    <a href="{% url "recordtransfer:submission_detail" uuid=submission.uuid %}">{% trans "Click to view report" %}</a>
+                    <a href="{% url "recordtransfer:submission_detail" uuid=submission.uuid %}" target="_blank">{% trans "Click to view report" %}</a>
                 </td>
                 <td>
                     <a href="{% url "recordtransfer:submission_csv" uuid=submission.uuid %}">{% trans "Click to download" %}</a>

--- a/app/recordtransfer/templates/recordtransfer/submission_group_show_create.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_group_show_create.html
@@ -17,9 +17,9 @@
 {% endblock title %}
 {% block content %}
     {% if user.is_authenticated %}
-        <button class="back-to-btn">
+        <a href="{% url 'recordtransfer:user_profile' %}" class="back-to-btn">
             <i class="fas fa-arrow-left"></i> {% trans "Back to Profile" %}
-        </button>
+        </a>
         <div class="title-text">
             {% if IS_NEW %}
                 {% trans "Create New Submission Group" %}

--- a/app/recordtransfer/templates/recordtransfer/submission_group_show_create.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_group_show_create.html
@@ -17,6 +17,9 @@
 {% endblock title %}
 {% block content %}
     {% if user.is_authenticated %}
+        <button class="back-to-btn">
+            <i class="fas fa-arrow-left"></i> {% trans "Back to Profile" %}
+        </button>
         <div class="title-text">
             {% if IS_NEW %}
                 {% trans "Create New Submission Group" %}


### PR DESCRIPTION
Closes #481 

In addition, clicking on the "Click to view report" on the Past Submissions table of the Profile page causes the report to open up on a new tab, rather than on the same tab.