### PR TITLE
Make mobile navigation menu fixed

### DIFF
--- a/app/recordtransfer/static/recordtransfer/css/base/navbar.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/navbar.css
@@ -177,9 +177,8 @@ header.homepage {
 /* Mobile-only transitions */
 @media all and (max-width: 799px) {
     .nav-items-container {
-        transition: transform 0.3s ease-out;
+        transition: opacity 0.3s ease-out;
         position: fixed;
-        top: 0;
         transform: translateY(-100%);
     }
 

--- a/app/recordtransfer/static/recordtransfer/css/base/navbar.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/navbar.css
@@ -54,8 +54,6 @@ header.homepage {
     text-align: left;
 }
 
-
-
 /* Sliding menu styles */
 .nav-items-container {
     position: absolute;
@@ -181,15 +179,10 @@ header.homepage {
     transition: background-color 0.3s ease, color 0.3s ease;
 }
 
+/* Mobile-only transitions */
 @media all and (max-width: 799px) {
     .nav-items-container {
-        transition: opacity 0.3s ease-out, transform 0.3s ease;
-        position: fixed;
-        transform: translateY(-100%);
-    }
-
-    .nav-items-container.open {
-        transform: translateY(0);
+        transition: opacity 0.3s ease-out;
     }
 
     .nav-item:hover {
@@ -198,7 +191,7 @@ header.homepage {
 
     .nav-wrapper {
         position: fixed;
-        z-index: 1001;
+        z-index: 1000;
         right: 0;
         transform: translateY(-100%);
     }

--- a/app/recordtransfer/static/recordtransfer/css/base/navbar.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/navbar.css
@@ -176,12 +176,11 @@ header.homepage {
 
 /* Mobile-only transitions */
 @media all and (max-width: 799px) {
-
     .nav-items-container {
+        transition: transform 0.3s ease-in-out;
         position: fixed;
         top: 0;
         transform: translateY(-100%);
-        transition: transform 0.3s ease-in-out;
     }
 
     .nav-item:hover {

--- a/app/recordtransfer/static/recordtransfer/css/base/navbar.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/navbar.css
@@ -176,8 +176,12 @@ header.homepage {
 
 /* Mobile-only transitions */
 @media all and (max-width: 799px) {
+
     .nav-items-container {
-        transition: opacity 0.3s ease-out;
+        position: fixed;
+        top: 0;
+        transform: translateY(-100%);
+        transition: transform 0.3s ease-in-out;
     }
 
     .nav-item:hover {

--- a/app/recordtransfer/static/recordtransfer/css/base/navbar.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/navbar.css
@@ -177,7 +177,7 @@ header.homepage {
 /* Mobile-only transitions */
 @media all and (max-width: 799px) {
     .nav-items-container {
-        transition: transform 0.3s ease-in-out;
+        transition: transform 0.3s ease-out;
         position: fixed;
         top: 0;
         transform: translateY(-100%);

--- a/app/recordtransfer/static/recordtransfer/css/base/navbar.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/navbar.css
@@ -54,6 +54,8 @@ header.homepage {
     text-align: left;
 }
 
+
+
 /* Sliding menu styles */
 .nav-items-container {
     position: absolute;
@@ -127,6 +129,11 @@ header.homepage {
 /* Burger button */
 .nav-icon-bars {
     display: inline-block;
+
+}
+
+.nav-wrapper {
+    top: 10%;
 }
 
 .nav-icon-close {
@@ -174,18 +181,33 @@ header.homepage {
     transition: background-color 0.3s ease, color 0.3s ease;
 }
 
-/* Mobile-only transitions */
 @media all and (max-width: 799px) {
     .nav-items-container {
-        transition: opacity 0.3s ease-out;
+        transition: opacity 0.3s ease-out, transform 0.3s ease;
         position: fixed;
         transform: translateY(-100%);
+    }
+
+    .nav-items-container.open {
+        transform: translateY(0);
     }
 
     .nav-item:hover {
         background-color: #f2f2f2;
     }
+
+    .nav-wrapper {
+        position: fixed;
+        z-index: 1001;
+        right: 0;
+        transform: translateY(-100%);
+    }
+
+    .nav-wrapper.open {
+        transform: translateY(0);
+    }
 }
+
 
 /* Desktop menu */
 @media all and (min-width: 800px) {

--- a/app/recordtransfer/templates/recordtransfer/header.html
+++ b/app/recordtransfer/templates/recordtransfer/header.html
@@ -1,87 +1,80 @@
 {% load static %}
 {% load i18n %}
-
 <header class="header {% if request.path == '/' %}homepage{% endif %}">
     <div class="menu-overlay"></div>
     <nav class="main-header-content">
         <div class="main-navbar">
             <div class="nav-logo">
-                <img id="app-logo" height="60" width="60" src="{% static 'recordtransfer/img/NCTR-Logo-White.svg'%}">
+                <img id="app-logo"
+                     height="60"
+                     width="60"
+                     src="{% static 'recordtransfer/img/NCTR-Logo-White.svg' %}"
+                     alt="{% trans "NCTR Logo" %}">
             </div>
             <div class="nav-title">
-                <a class="nav-link title" href="{% url 'recordtransfer:index' %}" title="Go to home page">
+                <a class="nav-link title"
+                   href="{% url 'recordtransfer:index' %}"
+                   title="Go to home page">
                     <span id="app-title" class="title-text-light">{% trans "NCTR Record Transfer" %}</span>
                 </a>
             </div>
-            <div class="nav-items-container">
-                <a class="nav-item nav-item-flex" href="{% url 'recordtransfer:index' %}">
-                    <div class="nav-link">
-                        {% trans "Home" %}
-                    </div>
-                    <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
-                </a>
-                <a class="nav-item nav-item-flex" href="{% url 'recordtransfer:about' %}">
-                    <div class="nav-link">
-                        {% trans "About" %}
-                    </div>
-                    <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
-                </a>
-
-                <a class="nav-item nav-item-flex" href="{% url 'recordtransfer:help' %}">
-                    <div class="nav-link">
-                        {% trans "Help" %}
-                    </div>
-                    <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
-                </a>
-                {% if user.is_staff %}
-                <a class="nav-item nav-item-flex" href="{% url 'admin:index' %}">
-                    <div class="nav-link">
-                        {% trans "Admin" %}
-                    </div>
-                    <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
-                </a>
-                {% endif %}
-                {% if user.is_authenticated %}
-                <a class="nav-item nav-item-flex" href="{% url 'recordtransfer:user_profile' %}">
-                    <div class="nav-link">
-                        {% trans "Profile" %}
-                    </div>
-                    <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
-                </a>
-                <a class="nav-item nav-item-flex" href="{% url 'recordtransfer:submit' %}">
-                    <div class="nav-link">
-                        {% trans "Submit" %}
-                    </div>
-                    <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
-                </a>
-                <a class="nav-item-button nav-item-flex" href="{% url 'logout' %}">
-                    <div id="logout-btn" class="nav-link nav-button">
-                        {% trans "Logout" %}
-                    </div>
-                </a>
-                {% elif not user.is_authenticated %}
-                {% if SIGN_UP_ENABLED %}
-                <a class="nav-item nav-item-flex" href="{% url 'recordtransfer:create_account' %}">
-                    <div class="nav-link">
-                        {% trans "Sign Up" %}
-                    </div>
-                    <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
-                </a>
-                {% endif %}
-                {% if 'login' not in request.path %}
-                <a class="nav-item-button nav-item-flex" href="{% url 'login' %}">
-                    <div class="nav-link nav-button">
-                        {% trans "Log In" %}
-                    </div>
-                </a>
-                {% endif %}
-                {% endif %}
-            </div>
-            <div class="nav-toggle-open">
-                <a class="nav-link non-nav-link nav-toggle-button" href="#">
-                    <i class="fa fa-bars nav-icon-bars" aria-hidden="true"></i>
-                    <i class="fas fa-times nav-icon-close" aria-hidden="true"></i>
-                </a>
+            <div class="nav-wrapper">
+                <div class="nav-toggle-open">
+                    <a class="nav-link non-nav-link nav-toggle-button" href="#">
+                        <i class="fa fa-bars nav-icon-bars" aria-hidden="true"></i>
+                        <i class="fas fa-times nav-icon-close" aria-hidden="true"></i>
+                    </a>
+                </div>
+                <div class="nav-items-container">
+                    <a class="nav-item nav-item-flex"
+                       href="{% url 'recordtransfer:index' %}">
+                        <div class="nav-link">{% trans "Home" %}</div>
+                        <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                    </a>
+                    <a class="nav-item nav-item-flex"
+                       href="{% url 'recordtransfer:about' %}">
+                        <div class="nav-link">{% trans "About" %}</div>
+                        <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                    </a>
+                    <a class="nav-item nav-item-flex" href="{% url 'recordtransfer:help' %}">
+                        <div class="nav-link">{% trans "Help" %}</div>
+                        <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                    </a>
+                    {% if user.is_staff %}
+                        <a class="nav-item nav-item-flex" href="{% url 'admin:index' %}">
+                            <div class="nav-link">{% trans "Admin" %}</div>
+                            <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                        </a>
+                    {% endif %}
+                    {% if user.is_authenticated %}
+                        <a class="nav-item nav-item-flex"
+                           href="{% url 'recordtransfer:user_profile' %}">
+                            <div class="nav-link">{% trans "Profile" %}</div>
+                            <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                        </a>
+                        <a class="nav-item nav-item-flex"
+                           href="{% url 'recordtransfer:submit' %}">
+                            <div class="nav-link">{% trans "Submit" %}</div>
+                            <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                        </a>
+                        <a class="nav-item-button nav-item-flex" href="{% url 'logout' %}">
+                            <div id="logout-btn" class="nav-link nav-button">{% trans "Logout" %}</div>
+                        </a>
+                    {% elif not user.is_authenticated %}
+                        {% if SIGN_UP_ENABLED %}
+                            <a class="nav-item nav-item-flex"
+                               href="{% url 'recordtransfer:create_account' %}">
+                                <div class="nav-link">{% trans "Sign Up" %}</div>
+                                <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                            </a>
+                        {% endif %}
+                        {% if 'login' not in request.path %}
+                            <a class="nav-item-button nav-item-flex" href="{% url 'login' %}">
+                                <div class="nav-link nav-button">{% trans "Log In" %}</div>
+                            </a>
+                        {% endif %}
+                    {% endif %}
+                </div>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
I made the nav-items-container and nav-toggle-button wrap into nav-wrapper. Did so that they both can be stay fixed and scrolled together. Sticky wasn't working very well. Fixed worked because it bypasses layout issues , it’s immune to parent styling. 