### PR TITLE
Fix tooltips in submission form

### DIFF
--- a/app/recordtransfer/static/recordtransfer/js/base/index.js
+++ b/app/recordtransfer/static/recordtransfer/js/base/index.js
@@ -8,5 +8,8 @@ window.htmx = htmx;
 document.addEventListener("DOMContentLoaded", () => {
     setupNavbar();
     setupMessages();
+});
+
+window.addEventListener("load", () => {
     setupHelpTooltips();
 });

--- a/app/recordtransfer/static/recordtransfer/js/submission_form/index.js
+++ b/app/recordtransfer/static/recordtransfer/js/submission_form/index.js
@@ -3,6 +3,7 @@ import "../../css/submission_form/review_step.css";
 import "../../css/submission_form/uppy.css";
 import "../../css/submission_form/modal.css";
 
+import { setupHelpTooltips } from "../base/tooltip";
 import { setupContactInfoForm } from "./contactInfo";
 import { setupOtherIdentifiersForm } from "./otherIdentifiers";
 import { setupRightsForm } from "./rights";
@@ -51,6 +52,7 @@ const setup = () => {
     setupDatePickers();
     setupInputMasks();
     setupUnsavedChangesProtection();
+    setupHelpTooltips();
 
     _setupWithContext();
 


### PR DESCRIPTION
Because of recent HTMX changes, we need to call `setupHelpTooltips` whenever the page loads *and* when the form is swapped. The tooltips were not being set up when the form was swapped so I added that back in.

I've also moved the tooltip setup until after the page has been styled because I had issues in the past with the tooltips appearing in weird places because their position was calculated incorrectly.