### PR TITLE
Use Modal to Create New Submission Groups on Profile Page

### DIFF
--- a/app/recordtransfer/static/recordtransfer/js/profile/delete_ip_submission.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/delete_ip_submission.js
@@ -53,7 +53,7 @@ function addQueryParam(url, paramName, paramValue) {
  */
 export const handleDeleteAfterRequest = (e, context) => {
     // Close the modal
-    const modal = document.getElementById("delete_in_progress_submission_modal");
+    const modal = document.getElementById("base_modal");
     if (modal) {
         modal.close();
     }

--- a/app/recordtransfer/static/recordtransfer/js/profile/forms.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/forms.js
@@ -55,3 +55,20 @@ export const setupProfileForm = (context) => {
 
     checkForChanges();
 };
+
+/**
+ * Disable the "Create group" button if the group name is empty
+ * @param {object} context - The context object containing form element IDs
+ * @param {string} context.id_submission_group_name - The ID of the group name input element
+ */
+export const setupSubmissionGroupForm = (context) => {
+    const groupName = document.getElementById(context["ID_SUBMISSION_GROUP_NAME"]);
+    const saveButton = document.getElementById("id_create_group_button");
+
+    const checkForChanges = () => {
+        saveButton.disabled = !groupName.value;
+    };
+
+    groupName.addEventListener("input", checkForChanges);
+    checkForChanges();
+};

--- a/app/recordtransfer/static/recordtransfer/js/profile/htmx.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/htmx.js
@@ -38,20 +38,20 @@ export const handleDeleteIpSubmissionAfterRequest = (e, context) => {
     }
 };
 
+
 /**
- * Sets up event listeners for submission group actions.
+ * Handles the modal swap event before content is replaced.
+ * Closes the modal if the server response is empty, which occurs when the submission group is
+ * successfully created.
+ * @param {CustomEvent} e - The event object containing the server response.
  */
-export function setupSubmissionGroupListeners() {
-    // Close the modal if the server sends back nothing to fill the modal, which happens when the
+export function handleModalBeforeSwap(e) {
+
     // submission group is successfully created
-    window.htmx.on("htmx:beforeSwap", (e) => {
-        if (e.detail.target.id === "modal-content-container") {
-            if (!e.detail.serverResponse) {
-                e.preventDefault();
-                closeModal();
-            }
-        }
-    });
+    if (!e.detail.serverResponse) {
+        e.preventDefault();
+        closeModal();
+    }
 }
 
 

--- a/app/recordtransfer/static/recordtransfer/js/profile/htmx.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/htmx.js
@@ -1,40 +1,4 @@
-/**
- * Gets the current page number of the table from the active tab
- * @returns {string|null} - The current page number or null if not found
- */
-function getCurrentTablePage() {
-    // Find the active tab
-    const activeTabInput = document.querySelector(
-        ".tabs input[name=\"profile_tabs\"]:checked"
-    );
-    const activeTabContent = activeTabInput
-        ? activeTabInput.closest(".tab").nextElementSibling
-        : null;
-
-    // Find the page-info-btn within the active tab content
-    if (activeTabContent) {
-        const pageInfoBtn = activeTabContent.querySelector(".page-info-btn");
-        if (pageInfoBtn) {
-            return pageInfoBtn.getAttribute("data-current-page");
-        }
-    }
-    return null;
-}
-
-/**
- * Adds a query parameter to a URL.
- * @param {string} url - The base URL.
- * @param {string} paramName - The query parameter name.
- * @param {string|null} paramValue - The query parameter value.
- * @returns {string} - The URL with the query parameter appended if applicable.
- */
-function addQueryParam(url, paramName, paramValue) {
-    if (paramName && paramValue) {
-        const separator = url.includes("?") ? "&" : "?";
-        return `${url}${separator}${paramName}=${encodeURIComponent(paramValue)}`;
-    }
-    return url;
-}
+import { addQueryParam, getCurrentTablePage } from "./utils.js";
 
 /**
  * Handles the UI and table refresh after a delete request for an in-progress submission.
@@ -51,7 +15,7 @@ function addQueryParam(url, paramName, paramValue) {
  * @param {string} context.ID_IN_PROGRESS_SUBMISSION_TABLE - The DOM element ID of the in-progress
  * submissions table to update.
  */
-export const handleDeleteAfterRequest = (e, context) => {
+export const handleDeleteIpSubmissionAfterRequest = (e, context) => {
     // Close the modal
     const modal = document.getElementById("base_modal");
     if (modal) {

--- a/app/recordtransfer/static/recordtransfer/js/profile/htmx.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/htmx.js
@@ -1,4 +1,4 @@
-import { addQueryParam, getCurrentTablePage } from "./utils.js";
+import { addQueryParam, closeModal, getCurrentTablePage } from "./utils.js";
 
 /**
  * Handles the UI and table refresh after a delete request for an in-progress submission.
@@ -16,11 +16,7 @@ import { addQueryParam, getCurrentTablePage } from "./utils.js";
  * submissions table to update.
  */
 export const handleDeleteIpSubmissionAfterRequest = (e, context) => {
-    // Close the modal
-    const modal = document.getElementById("base_modal");
-    if (modal) {
-        modal.close();
-    }
+    closeModal();
 
     // If the request was successful, refresh the table
     if (e.detail.successful) {
@@ -41,3 +37,21 @@ export const handleDeleteIpSubmissionAfterRequest = (e, context) => {
             });
     }
 };
+
+/**
+ * Sets up event listeners for submission group actions.
+ */
+export function setupSubmissionGroupListeners() {
+    // Close the modal if the server sends back nothing to fill the modal, which happens when the
+    // submission group is successfully created
+    window.htmx.on("htmx:beforeSwap", (e) => {
+        if (e.detail.target.id === "modal-content-container") {
+            if (!e.detail.serverResponse) {
+                e.preventDefault();
+                closeModal();
+            }
+        }
+    });
+}
+
+

--- a/app/recordtransfer/static/recordtransfer/js/profile/htmx.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/htmx.js
@@ -44,11 +44,32 @@ export const handleDeleteIpSubmissionAfterRequest = (e, context) => {
  * Closes the modal if the server response is empty, which occurs when the submission group is
  * successfully created.
  * @param {CustomEvent} e - The event object containing the server response.
+ * @param {object} context - Context object with URLs and element IDs for table refresh.
+ * @param {string} context.SUBMISSION_GROUP_TABLE_URL - The URL to refresh the submission group
+ * table.
+ * @param {string} context.PAGINATE_QUERY_NAME - The query parameter name for pagination
+ * (e.g., "p").
+ * @param {string} context.ID_SUBMISSION_GROUP_TABLE - The DOM element ID of the submission group
+ * table to update.
  */
-export function handleModalBeforeSwap(e) {
+export function handleModalBeforeSwap(e, context) {
     if (!e.detail.serverResponse && e.detail.requestConfig.elt.id === "submission-group-form") {
-        e.stopPropagation(); // Stop the event from bubbling up
+        e.preventDefault(); // Stop the event from bubbling up
         closeModal();
+
+        // Refresh the table
+        const refreshUrl = context["SUBMISSION_GROUP_TABLE_URL"];
+        const paginateQueryName = context["PAGINATE_QUERY_NAME"];
+        const currentPage = getCurrentTablePage();
+
+        const finalUrl = addQueryParam(refreshUrl, paginateQueryName, currentPage);
+
+        window.htmx.ajax("GET",
+            finalUrl,
+            {
+                target: "#" + context["ID_SUBMISSION_GROUP_TABLE"],
+                swap: "innerHTML"
+            });
     }
 }
 

--- a/app/recordtransfer/static/recordtransfer/js/profile/htmx.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/htmx.js
@@ -46,10 +46,8 @@ export const handleDeleteIpSubmissionAfterRequest = (e, context) => {
  * @param {CustomEvent} e - The event object containing the server response.
  */
 export function handleModalBeforeSwap(e) {
-
-    // submission group is successfully created
-    if (!e.detail.serverResponse) {
-        e.preventDefault();
+    if (!e.detail.serverResponse && e.detail.requestConfig.elt.id === "submission-group-form") {
+        e.stopPropagation(); // Stop the event from bubbling up
         closeModal();
     }
 }

--- a/app/recordtransfer/static/recordtransfer/js/profile/index.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/index.js
@@ -1,5 +1,5 @@
 import {
-    handleDeleteIpSubmissionAfterRequest, setupSubmissionGroupListeners
+    handleDeleteIpSubmissionAfterRequest, handleModalBeforeSwap
 } from "./htmx.js";
 import { setupProfileForm } from "./profileForm.js";
 import { initTabListeners, restoreTab } from "./tab.js";
@@ -31,7 +31,7 @@ function initialize() {
         return handleDeleteIpSubmissionAfterRequest(e, context);
     };
 
-    setupSubmissionGroupListeners();
+    window.handleModalBeforeSwap = handleModalBeforeSwap;
 }
 
 document.addEventListener("DOMContentLoaded", initialize);

--- a/app/recordtransfer/static/recordtransfer/js/profile/index.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/index.js
@@ -33,11 +33,14 @@ function initialize() {
     window.handleModalBeforeSwap = (e) => {
         return handleModalBeforeSwap(e, context);
     };
-    
+
     window.handleModalAfterSwap = (e) => {
+        // Sets up the submission group form if the modal content swap was triggered by the
+        // new submission group button
         if (e.detail.requestConfig.elt.id === "id_new_submission_group_button") {
             setupSubmissionGroupForm(context);
         }
+        // Always show the modal after a swap on the modal content container
         showModal();
     };
 }

--- a/app/recordtransfer/static/recordtransfer/js/profile/index.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/index.js
@@ -1,7 +1,9 @@
+import {
+    handleDeleteIpSubmissionAfterRequest, setupSubmissionGroupListeners
+} from "./htmx.js";
 import { setupProfileForm } from "./profileForm.js";
 import { initTabListeners, restoreTab } from "./tab.js";
 import { setupToastNotifications } from "./toast.js";
-import { handleDeleteIpSubmissionAfterRequest } from "./utils.js";
 
 
 /**
@@ -28,6 +30,8 @@ function initialize() {
         }
         return handleDeleteIpSubmissionAfterRequest(e, context);
     };
+
+    setupSubmissionGroupListeners();
 }
 
 document.addEventListener("DOMContentLoaded", initialize);

--- a/app/recordtransfer/static/recordtransfer/js/profile/index.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/index.js
@@ -1,7 +1,7 @@
-import { handleDeleteAfterRequest } from "./delete_ip_submission.js";
 import { setupProfileForm } from "./profileForm.js";
 import { initTabListeners, restoreTab } from "./tab.js";
 import { setupToastNotifications } from "./toast.js";
+import { handleDeleteIpSubmissionAfterRequest } from "./utils.js";
 
 
 /**
@@ -20,13 +20,13 @@ function initialize() {
     restoreTab();
     setupToastNotifications();
 
-    // Wrapper function that provides context to handleDeleteAfterRequest
-    window.handleDeleteAfterRequest = (e) => {
+    // Wrapper function that provides context to handleDeleteIpSubmissionAfterRequest
+    window.handleDeleteIpSubmissionAfterRequest = (e) => {
         if (!context) {
-            console.error("Context not available for handleDeleteAfterRequest");
+            console.error("Context not available for handleDeleteIpSubmissionAfterRequest");
             return;
         }
-        return handleDeleteAfterRequest(e, context);
+        return handleDeleteIpSubmissionAfterRequest(e, context);
     };
 }
 

--- a/app/recordtransfer/static/recordtransfer/js/profile/index.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/index.js
@@ -1,10 +1,10 @@
+import { setupProfileForm, setupSubmissionGroupForm } from "./forms.js";
 import {
     handleDeleteIpSubmissionAfterRequest, handleModalBeforeSwap
 } from "./htmx.js";
-import { setupProfileForm } from "./profileForm.js";
 import { initTabListeners, restoreTab } from "./tab.js";
 import { setupToastNotifications } from "./toast.js";
-
+import { showModal } from "./utils.js";
 
 /**
  * Main initialization function to set up all profile-related functionality
@@ -32,6 +32,13 @@ function initialize() {
     // Wrapper function that provides context to handleModalBeforeSwap
     window.handleModalBeforeSwap = (e) => {
         return handleModalBeforeSwap(e, context);
+    };
+    
+    window.handleModalAfterSwap = (e) => {
+        if (e.detail.requestConfig.elt.id === "id_new_submission_group_button") {
+            setupSubmissionGroupForm(context);
+        }
+        showModal();
     };
 }
 

--- a/app/recordtransfer/static/recordtransfer/js/profile/index.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/index.js
@@ -13,25 +13,26 @@ function initialize() {
     let context = null;
     const contextElement = document.getElementById("py_context_user_profile");
 
-    if (contextElement) {
-        context = JSON.parse(contextElement.textContent);
-        setupProfileForm(context);
+    context = JSON.parse(contextElement.textContent);
+    if (!context) {
+        console.error("Context not available to set up profile page.");
+        return;
     }
 
+    setupProfileForm(context);
     initTabListeners();
     restoreTab();
     setupToastNotifications();
 
     // Wrapper function that provides context to handleDeleteIpSubmissionAfterRequest
     window.handleDeleteIpSubmissionAfterRequest = (e) => {
-        if (!context) {
-            console.error("Context not available for handleDeleteIpSubmissionAfterRequest");
-            return;
-        }
         return handleDeleteIpSubmissionAfterRequest(e, context);
     };
 
-    window.handleModalBeforeSwap = handleModalBeforeSwap;
+    // Wrapper function that provides context to handleModalBeforeSwap
+    window.handleModalBeforeSwap = (e) => {
+        return handleModalBeforeSwap(e, context);
+    };
 }
 
 document.addEventListener("DOMContentLoaded", initialize);

--- a/app/recordtransfer/static/recordtransfer/js/profile/utils.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/utils.js
@@ -36,3 +36,12 @@ export function addQueryParam(url, paramName, paramValue) {
     return url;
 }
 
+/**
+ * Closes the modal dialog.
+ */
+export function closeModal() {
+    const modal = document.getElementById("base_modal");
+    if (modal) {
+        modal.close();
+    }
+}

--- a/app/recordtransfer/static/recordtransfer/js/profile/utils.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/utils.js
@@ -45,3 +45,13 @@ export function closeModal() {
         modal.close();
     }
 }
+
+/**
+ * Opens the modal dialog.
+ */
+export function showModal() {
+    const modal = document.getElementById("base_modal");
+    if (modal) {
+        modal.showModal();
+    }
+}

--- a/app/recordtransfer/static/recordtransfer/js/profile/utils.js
+++ b/app/recordtransfer/static/recordtransfer/js/profile/utils.js
@@ -1,0 +1,38 @@
+/**
+ * Gets the current page number of the table from the active tab
+ * @returns {string|null} - The current page number or null if not found
+ */
+export function getCurrentTablePage() {
+    // Find the active tab
+    const activeTabInput = document.querySelector(
+        ".tabs input[name=\"profile_tabs\"]:checked"
+    );
+    const activeTabContent = activeTabInput
+        ? activeTabInput.closest(".tab").nextElementSibling
+        : null;
+
+    // Find the page-info-btn within the active tab content
+    if (activeTabContent) {
+        const pageInfoBtn = activeTabContent.querySelector(".page-info-btn");
+        if (pageInfoBtn) {
+            return pageInfoBtn.getAttribute("data-current-page");
+        }
+    }
+    return null;
+}
+
+/**
+ * Adds a query parameter to a URL.
+ * @param {string} url - The base URL.
+ * @param {string} paramName - The query parameter name.
+ * @param {string|null} paramValue - The query parameter value.
+ * @returns {string} - The URL with the query parameter appended if applicable.
+ */
+export function addQueryParam(url, paramName, paramValue) {
+    if (paramName && paramValue) {
+        const separator = url.includes("?") ? "&" : "?";
+        return `${url}${separator}${paramName}=${encodeURIComponent(paramValue)}`;
+    }
+    return url;
+}
+

--- a/app/recordtransfer/templates/includes/base_modal.html
+++ b/app/recordtransfer/templates/includes/base_modal.html
@@ -1,15 +1,15 @@
 {% load i18n %}
 {% load static %}
-<dialog id={% block modal_id %}{% endblock modal_id %} class="modal">
+<dialog id="base_modal" class="modal">
     <div class="modal-box">
         <form method="dialog">
             <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
         </form>
-        <h3 class="text-lg font-bold mb-5">
-            {% block modal_title %}
-            {% endblock modal_title %}
-        </h3>
-        {% block modal_content %}
-        {% endblock modal_content %}
+        <div id="modal-content-container" hx-on::after-swap="base_modal.showModal()">
+            <div id="modal-content">
+                {% block modal_content %}
+                {% endblock modal_content %}
+            </div>
+        </div>
     </div>
 </dialog>

--- a/app/recordtransfer/templates/includes/base_modal.html
+++ b/app/recordtransfer/templates/includes/base_modal.html
@@ -6,7 +6,8 @@
             <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
         </form>
         <div id="modal-content-container"
-             hx-on::after-swap="base_modal.showModal()">
+             hx-on::after-swap="base_modal.showModal()"
+             hx-on::before-swap="handleModalBeforeSwap(event)">
             {# after-swap listener is on the parent to persist after swaps #}
             <div id="modal-content">
                 {% block modal_content %}

--- a/app/recordtransfer/templates/includes/base_modal.html
+++ b/app/recordtransfer/templates/includes/base_modal.html
@@ -6,7 +6,7 @@
             <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
         </form>
         <div id="modal-content-container"
-             hx-on::after-swap="base_modal.showModal()"
+             hx-on::after-swap="handleModalAfterSwap(event)"
              hx-on::before-swap="handleModalBeforeSwap(event)">
             {# after-swap listener is on the parent to persist after swaps #}
             <div id="modal-content">

--- a/app/recordtransfer/templates/includes/base_modal.html
+++ b/app/recordtransfer/templates/includes/base_modal.html
@@ -5,7 +5,9 @@
         <form method="dialog">
             <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
         </form>
-        <div id="modal-content-container" hx-on::after-swap="base_modal.showModal()">
+        <div id="modal-content-container"
+             hx-on::after-swap="base_modal.showModal()">
+            {# after-swap listener is on the parent to persist after swaps #}
             <div id="modal-content">
                 {% block modal_content %}
                 {% endblock modal_content %}

--- a/app/recordtransfer/templates/includes/delete_in_progress_submission_modal.html
+++ b/app/recordtransfer/templates/includes/delete_in_progress_submission_modal.html
@@ -1,12 +1,7 @@
 {% extends "includes/base_modal.html" %}
 {% load i18n %}
-{% block modal_id %}
-    delete_in_progress_submission_modal
-{% endblock modal_id %}
-{% block modal_title %}
-    {% trans "Are you sure you want to delete this in-progress submission?" %}
-{% endblock modal_title %}
 {% block modal_content %}
+    <h3 class="text-lg font-bold mb-5">{% trans "Are you sure you want to delete this in-progress submission?" %}</h3>
     <p>
         {% if in_progress.title %}
             {% blocktrans with title=in_progress.title|escape date=in_progress.last_updated|date:"F j, Y g:ia"|escape %}

--- a/app/recordtransfer/templates/includes/delete_in_progress_submission_modal.html
+++ b/app/recordtransfer/templates/includes/delete_in_progress_submission_modal.html
@@ -18,7 +18,7 @@
             <button class="btn">{% trans "Cancel" %}</button>
             <button id="confirm_delete_ip_btn"
                     hx-delete="{{ in_progress.get_delete_url }}"
-                    hx-on::after-request="handleDeleteAfterRequest(event)"
+                    hx-on::after-request="handleDeleteIpSubmissionAfterRequest(event)"
                     class="btn btn-primary">{% trans "Yes" %}</button>
         </div>
     </form>

--- a/app/recordtransfer/templates/includes/in_progress_submission_table.html
+++ b/app/recordtransfer/templates/includes/in_progress_submission_table.html
@@ -42,8 +42,9 @@
                         </a>
                     {% endif %}
                     <a hx-get="{% url "recordtransfer:in_progress_submission" uuid=in_progress.uuid %}"
-                       hx-target="#modal-container"
+                       hx-target="#modal-content-container"
                        hx-swap="innerHTML"
+                       hx-select="#modal-content"
                        hx-trigger="click"
                        class="link link-error tooltip"
                        data-tip="{% trans "Delete" %}">

--- a/app/recordtransfer/templates/includes/new_submission_group_modal.html
+++ b/app/recordtransfer/templates/includes/new_submission_group_modal.html
@@ -1,9 +1,7 @@
 {% extends "includes/base_modal.html" %}
 {% load i18n %}
 {% block modal_content %}
-    <h3 class="text-lg font-bold mb-5">
-        {% trans "Create a new submission group" %}
-    </h3>
+    <h3 class="text-lg font-bold mb-5">{% trans "Create a new submission group" %}</h3>
     <form id="submission-group-form"
           hx-post="{% url 'recordtransfer:submission_group_new' %}"
           hx-target="#modal-content-container"

--- a/app/recordtransfer/templates/includes/new_submission_group_modal.html
+++ b/app/recordtransfer/templates/includes/new_submission_group_modal.html
@@ -3,7 +3,7 @@
 {% block modal_content %}
     <h3 class="text-lg font-bold mb-5">{% trans "Create a new submission group" %}</h3>
     <form id="submission-group-form"
-          hx-post="{% url 'recordtransfer:submission_group_new' %}"
+          hx-post="{% url 'recordtransfer:submission_group_modal' %}"
           hx-target="#modal-content-container"
           hx-swap="innerHTML"
           hx-select="#modal-content">

--- a/app/recordtransfer/templates/includes/new_submission_group_modal.html
+++ b/app/recordtransfer/templates/includes/new_submission_group_modal.html
@@ -15,6 +15,7 @@
             <input type="text"
                    class="input input-bordered input-sm md:input-md validator w-full"
                    name="{{ form.name.name }}"
+                   value="{{ form.name.value|default_if_none:'' }}"
                    id="{{ form.name.id_for_label }}"
                    required>
             {% if form.name.errors %}
@@ -26,6 +27,7 @@
             <input type="text"
                    class="input input-bordered input-sm md:input-md validator w-full"
                    name="{{ form.description.name }}"
+                   value="{{ form.description.value|default_if_none:'' }}"
                    id="{{ form.description.id_for_label }}"
                    required>
             {% if form.description.errors %}

--- a/app/recordtransfer/templates/includes/new_submission_group_modal.html
+++ b/app/recordtransfer/templates/includes/new_submission_group_modal.html
@@ -1,0 +1,41 @@
+{% extends "includes/base_modal.html" %}
+{% load i18n %}
+{% block modal_id %}
+    new_submission_group_modal
+{% endblock modal_id %}
+{% block modal_title %}
+    {% trans "Create a new submission group" %}
+{% endblock modal_title %}
+{% block modal_content %}
+    <form method="post"
+          action="{% url 'recordtransfer:submission_group_new' %}"
+          id="submission-group-form">
+        {% csrf_token %}
+        <fieldset class="fieldset">
+            <legend class="fieldset-legend text-sm md:text-md">{% trans form.name.label %}</legend>
+            <input type="text"
+                   class="input input-bordered input-sm md:input-md validator w-full"
+                   name="{{ form.name.name }}"
+                   id="{{ form.name.id_for_label }}"
+                   required>
+            {% if form.name.errors %}
+                <p class="text-error text-xs md:text-sm">{% trans form.name.errors.0 %}</p>
+            {% endif %}
+        </fieldset>
+        <fieldset class="fieldset">
+            <legend class="fieldset-legend text-sm md:text-md">{% trans form.description.label %}</legend>
+            <input type="text"
+                   class="input input-bordered input-sm md:input-md validator w-full"
+                   name="{{ form.description.name }}"
+                   id="{{ form.description.id_for_label }}"
+                   required>
+            {% if form.description.errors %}
+                <p class="text-error text-xs md:text-sm">{% trans form.description.errors.0 %}</p>
+            {% endif %}
+        </fieldset>
+        <div class="modal-action">
+            <button class="btn">{% trans "Cancel" %}</button>
+            <button type="submit" class="btn btn-primary" id="id_create_group_button">{% trans "Create" %}</button>
+        </div>
+    </form>
+{% endblock modal_content %}

--- a/app/recordtransfer/templates/includes/new_submission_group_modal.html
+++ b/app/recordtransfer/templates/includes/new_submission_group_modal.html
@@ -32,7 +32,7 @@
             {% endif %}
         </fieldset>
         <div class="modal-action">
-            <button class="btn">{% trans "Cancel" %}</button>
+            <button hx-on:click="base_modal.close()" type="button" class="btn">{% trans "Cancel" %}</button>
             <button type="submit" class="btn btn-primary" id="id_create_group_button">{% trans "Create" %}</button>
         </div>
     </form>

--- a/app/recordtransfer/templates/includes/new_submission_group_modal.html
+++ b/app/recordtransfer/templates/includes/new_submission_group_modal.html
@@ -7,9 +7,10 @@
     {% trans "Create a new submission group" %}
 {% endblock modal_title %}
 {% block modal_content %}
-    <form method="post"
-          action="{% url 'recordtransfer:submission_group_new' %}"
-          id="submission-group-form">
+    <form id="submission-group-form"
+          hx-post="{% url 'recordtransfer:submission_group_new' %}"
+          hx-target="#new_submission_group_modal"
+          hx-swap="outerHTML">
         {% csrf_token %}
         <fieldset class="fieldset">
             <legend class="fieldset-legend text-sm md:text-md">{% trans form.name.label %}</legend>

--- a/app/recordtransfer/templates/includes/new_submission_group_modal.html
+++ b/app/recordtransfer/templates/includes/new_submission_group_modal.html
@@ -1,16 +1,14 @@
 {% extends "includes/base_modal.html" %}
 {% load i18n %}
-{% block modal_id %}
-    new_submission_group_modal
-{% endblock modal_id %}
-{% block modal_title %}
-    {% trans "Create a new submission group" %}
-{% endblock modal_title %}
 {% block modal_content %}
+    <h3 class="text-lg font-bold mb-5">
+        {% trans "Create a new submission group" %}
+    </h3>
     <form id="submission-group-form"
           hx-post="{% url 'recordtransfer:submission_group_new' %}"
-          hx-target="#new_submission_group_modal"
-          hx-swap="outerHTML">
+          hx-target="#modal-content-container"
+          hx-swap="innerHTML"
+          hx-select="#modal-content">
         {% csrf_token %}
         <fieldset class="fieldset">
             <legend class="fieldset-legend text-sm md:text-md">{% trans form.name.label %}</legend>

--- a/app/recordtransfer/templates/includes/new_submission_group_modal.html
+++ b/app/recordtransfer/templates/includes/new_submission_group_modal.html
@@ -26,8 +26,7 @@
                    class="input input-bordered input-sm md:input-md validator w-full"
                    name="{{ form.description.name }}"
                    value="{{ form.description.value|default_if_none:'' }}"
-                   id="{{ form.description.id_for_label }}"
-                   required>
+                   id="{{ form.description.id_for_label }}">
             {% if form.description.errors %}
                 <p class="text-error text-xs md:text-sm">{% trans form.description.errors.0 %}</p>
             {% endif %}

--- a/app/recordtransfer/templates/recordtransfer/profile.html
+++ b/app/recordtransfer/templates/recordtransfer/profile.html
@@ -73,7 +73,7 @@
                     </div>
                 </div>
                 <div class="flex justify-end">
-                    <a hx-get="{% url 'recordtransfer:submission_group_new' %}"
+                    <a hx-get="{% url 'recordtransfer:submission_group_modal' %}"
                        hx-target="#modal-content-container"
                        hx-swap="innerHTML"
                        hx-select="#modal-content"

--- a/app/recordtransfer/templates/recordtransfer/profile.html
+++ b/app/recordtransfer/templates/recordtransfer/profile.html
@@ -74,8 +74,9 @@
                 </div>
                 <div class="flex justify-end">
                     <a hx-get="{% url 'recordtransfer:submission_group_new' %}"
-                       hx-target="#modal-container"
+                       hx-target="#modal-content-container"
                        hx-swap="innerHTML"
+                       hx-select="#modal-content"
                        class="btn btn-sm">
                         <span class="hidden md:inline">{% trans "New submission group" %}</span>
                         <i class="fa fa-plus" aria-hidden="true"></i>
@@ -84,6 +85,5 @@
             </div>
         </div>
     </div>
-    <div hx-on::after-swap="document.querySelector('.modal').showModal()"
-         id="modal-container"></div>
+    {% include "includes/base_modal.html" %}
 {% endblock content %}

--- a/app/recordtransfer/templates/recordtransfer/profile.html
+++ b/app/recordtransfer/templates/recordtransfer/profile.html
@@ -73,7 +73,9 @@
                     </div>
                 </div>
                 <div class="flex justify-end">
-                    <a href="{% url 'recordtransfer:submission_group_new' %}"
+                    <a hx-get="{% url 'recordtransfer:submission_group_new' %}"
+                       hx-target="#modal-container"
+                       hx-swap="innerHTML"
                        class="btn btn-sm">
                         <span class="hidden md:inline">{% trans "New submission group" %}</span>
                         <i class="fa fa-plus" aria-hidden="true"></i>
@@ -84,5 +86,4 @@
     </div>
     <div hx-on::after-swap="document.querySelector('.modal').showModal()"
          id="modal-container"></div>
-    {% include "includes/new_submission_group_modal.html" with form=submission_group_form %}
 {% endblock content %}

--- a/app/recordtransfer/templates/recordtransfer/profile.html
+++ b/app/recordtransfer/templates/recordtransfer/profile.html
@@ -77,6 +77,7 @@
                        hx-target="#modal-content-container"
                        hx-swap="innerHTML"
                        hx-select="#modal-content"
+                       id="id_new_submission_group_button"
                        class="btn btn-sm">
                         <span class="hidden md:inline">{% trans "New submission group" %}</span>
                         <i class="fa fa-plus" aria-hidden="true"></i>

--- a/app/recordtransfer/templates/recordtransfer/profile.html
+++ b/app/recordtransfer/templates/recordtransfer/profile.html
@@ -84,4 +84,5 @@
     </div>
     <div hx-on::after-swap="document.querySelector('.modal').showModal()"
          id="modal-container"></div>
+    {% include "includes/new_submission_group_modal.html" with form=submission_group_form %}
 {% endblock content %}

--- a/app/recordtransfer/tests/unit/views/test_post_submission.py
+++ b/app/recordtransfer/tests/unit/views/test_post_submission.py
@@ -11,14 +11,15 @@ from recordtransfer.models import Submission, SubmissionGroup, User
 class TestSubmissionGroupCreateView(TestCase):
     """Tests for SubmissionGroupCreateView."""
 
+    @classmethod
+    def setUpTestData(cls) -> None:
+        """Set up test data."""
+        cls.user = User.objects.create_user(username="testuser", password="password")
+        cls.url = reverse("recordtransfer:submission_group_new")
+
     def setUp(self) -> None:
         """Set up test environment."""
-        self.user = User.objects.create_user(username="testuser", password="password")
         self.client.login(username="testuser", password="password")
-        self.url = reverse("recordtransfer:submission_group_new")
-        self.headers = {
-            "HX-Request": "true",
-        }
 
     def test_access_authenticated_user(self) -> None:
         """Test that an authenticated user can access the view."""
@@ -32,34 +33,28 @@ class TestSubmissionGroupCreateView(TestCase):
         response = self.client.get(self.url)
         self.assertRedirects(response, f"{reverse('login')}?next={self.url}")
 
-    def test_valid_form_submission_with_htmx(self) -> None:
+    def test_valid_form_submission(self) -> None:
         """Test that a valid form submission creates a new SubmissionGroup."""
         form_data = {
             "name": "Test Group",
             "description": "Test Description",
         }
-        response = self.client.post(self.url, data=form_data, headers=self.headers)
+        response = self.client.post(self.url, data=form_data)
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(str(messages[0]), gettext("Group created"))
         self.assertTrue(SubmissionGroup.objects.filter(name="Test Group").exists())
 
-        # Check that HTMX showSuccess event is included in the response
-        self.assertIn("HX-Trigger", response.headers)
-        self.assertIn("showSuccess", response.headers["HX-Trigger"])
-
-    def test_invalid_form_submission_with_htmx(self) -> None:
+    def test_invalid_form_submission(self) -> None:
         """Test that an invalid form submission does not create a new SubmissionGroup."""
         form_data = {
             "name": "",
             "description": "Test Description",
         }
-        response = self.client.post(self.url, data=form_data, headers=self.headers)
+        response = self.client.post(self.url, data=form_data)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "recordtransfer/submission_group_detail.html")
-        # Check that response contains the form with errors
-        form = response.context["form"]
-        self.assertTrue(form.errors)
-
-        # Check that new submission group is not created
-        self.assertFalse(SubmissionGroup.objects.all().exists())
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(str(messages[0]), gettext("There was an error creating the group"))
 
     def test_form_valid_json_response(self) -> None:
         """Test that a JsonResponse is returned when the form is valid and submitted from the
@@ -69,9 +64,7 @@ class TestSubmissionGroupCreateView(TestCase):
             "name": "Test Group",
             "description": "Test Description",
         }
-        response = self.client.post(
-            self.url, data=form_data, HTTP_REFERER=reverse("recordtransfer:submit")
-        )
+        response = self.client.post(self.url, data=form_data, HTTP_REFERER="submission/")
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertEqual(response_json["message"], gettext("Group created"))
@@ -85,9 +78,7 @@ class TestSubmissionGroupCreateView(TestCase):
             "name": "",
             "description": "Test Description",
         }
-        response = self.client.post(
-            self.url, data=form_data, HTTP_REFERER=reverse("recordtransfer:submit")
-        )
+        response = self.client.post(self.url, data=form_data, HTTP_REFERER="submission/")
         self.assertEqual(response.status_code, 400)
         response_json = response.json()
         self.assertEqual(response_json["message"], "This field is required.")

--- a/app/recordtransfer/tests/unit/views/test_profile.py
+++ b/app/recordtransfer/tests/unit/views/test_profile.py
@@ -676,7 +676,7 @@ class TestSubmissionGroupModalCreateView(TestCase):
         self.user = User.objects.create_user(username="testuser", password="password")
         self.client.login(username="testuser", password="password")
 
-        self.url = reverse("recordtransfer:submission_group_modal")
+        self.submission_group_modal_url = reverse("recordtransfer:submission_group_modal")
         self.headers = {
             "HX-Request": "true",
         }
@@ -689,7 +689,7 @@ class TestSubmissionGroupModalCreateView(TestCase):
             "name": "Test Group",
             "description": "Test Description",
         }
-        response = self.client.post(self.url, data=form_data, headers=self.headers)
+        response = self.client.post(self.submission_group_modal_url, data=form_data, headers=self.headers)
         self.assertTrue(SubmissionGroup.objects.filter(name="Test Group").exists())
 
         self.assertIn("HX-Trigger", response.headers)
@@ -701,7 +701,7 @@ class TestSubmissionGroupModalCreateView(TestCase):
             "name": "",
             "description": "Test Description",
         }
-        response = self.client.post(self.url, data=form_data, headers=self.headers)
+        response = self.client.post(self.submission_group_modal_url, data=form_data, headers=self.headers)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "includes/new_submission_group_modal.html")
 
@@ -718,6 +718,6 @@ class TestSubmissionGroupModalCreateView(TestCase):
             "name": "Test Group",
             "description": "Test Description",
         }
-        response = self.client.post(self.url, data=form_data)
+        response = self.client.post(self.submission_group_modal_url, data=form_data)
         self.assertEqual(response.status_code, 404)
         self.assertFalse(SubmissionGroup.objects.filter(name="Test Group").exists())

--- a/app/recordtransfer/tests/unit/views/test_profile.py
+++ b/app/recordtransfer/tests/unit/views/test_profile.py
@@ -689,7 +689,9 @@ class TestSubmissionGroupModalCreateView(TestCase):
             "name": "Test Group",
             "description": "Test Description",
         }
-        response = self.client.post(self.submission_group_modal_url, data=form_data, headers=self.headers)
+        response = self.client.post(
+            self.submission_group_modal_url, data=form_data, headers=self.headers
+        )
         self.assertTrue(SubmissionGroup.objects.filter(name="Test Group").exists())
 
         self.assertIn("HX-Trigger", response.headers)
@@ -701,7 +703,9 @@ class TestSubmissionGroupModalCreateView(TestCase):
             "name": "",
             "description": "Test Description",
         }
-        response = self.client.post(self.submission_group_modal_url, data=form_data, headers=self.headers)
+        response = self.client.post(
+            self.submission_group_modal_url, data=form_data, headers=self.headers
+        )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "includes/new_submission_group_modal.html")
 

--- a/app/recordtransfer/urls.py
+++ b/app/recordtransfer/urls.py
@@ -76,6 +76,11 @@ urlpatterns = [
         login_required(views.profile.submission_table),
         name="submission_table",
     ),
+    path(
+        "submission-group-modal",
+        login_required(views.profile.SubmissionGroupModalCreateView.as_view()),
+        name="submission_group_modal",
+    ),
 ]
 
 if settings.DEBUG:

--- a/app/recordtransfer/views/post_submission.py
+++ b/app/recordtransfer/views/post_submission.py
@@ -21,7 +21,6 @@ from django.utils import timezone
 from django.utils.text import slugify
 from django.utils.translation import gettext
 from django.views.generic import CreateView, DetailView, UpdateView, View
-from django_htmx.http import trigger_client_event
 
 from recordtransfer.constants import ID_SUBMISSION_GROUP_DESCRIPTION, ID_SUBMISSION_GROUP_NAME
 from recordtransfer.forms.submission_group_form import SubmissionGroupForm

--- a/app/recordtransfer/views/post_submission.py
+++ b/app/recordtransfer/views/post_submission.py
@@ -21,6 +21,7 @@ from django.utils import timezone
 from django.utils.text import slugify
 from django.utils.translation import gettext
 from django.views.generic import CreateView, DetailView, UpdateView, View
+from django_htmx.http import trigger_client_event
 
 from recordtransfer.constants import ID_SUBMISSION_GROUP_DESCRIPTION, ID_SUBMISSION_GROUP_NAME
 from recordtransfer.forms.submission_group_form import SubmissionGroupForm
@@ -205,7 +206,7 @@ class SubmissionGroupCreateView(CreateView):
 
     def form_valid(self, form: BaseModelForm) -> HttpResponse:
         """Handle valid form submission."""
-        response = super().form_valid(form)
+        super().form_valid(form)
         referer = self.request.headers.get("referer", "")
         if reverse("recordtransfer:submit") in referer:
             return JsonResponse(
@@ -220,7 +221,10 @@ class SubmissionGroupCreateView(CreateView):
                 },
                 status=200,
             )
-        return response
+        response = HttpResponse(status=201)
+        return trigger_client_event(
+            response, "showSuccess", {"value": "Submission group created."}
+        )
 
     def form_invalid(self, form: BaseModelForm) -> HttpResponse:
         """Handle invalid form submission."""

--- a/app/recordtransfer/views/profile.py
+++ b/app/recordtransfer/views/profile.py
@@ -30,7 +30,6 @@ from recordtransfer.constants import (
 )
 from recordtransfer.emails import send_user_account_updated
 from recordtransfer.forms import UserProfileForm
-from recordtransfer.forms.submission_group_form import SubmissionGroupForm
 from recordtransfer.models import InProgressSubmission, Submission, SubmissionGroup, User
 
 
@@ -71,7 +70,6 @@ class UserProfile(UpdateView):
                         "recordtransfer:in_progress_submission_table"
                     ),
                 },
-                "submission_group_form": SubmissionGroupForm(),
                 # Table container IDs
                 "ID_SUBMISSION_TABLE": ID_SUBMISSION_TABLE,
                 "ID_SUBMISSION_GROUP_TABLE": ID_SUBMISSION_GROUP_TABLE,

--- a/app/recordtransfer/views/profile.py
+++ b/app/recordtransfer/views/profile.py
@@ -30,6 +30,7 @@ from recordtransfer.constants import (
 )
 from recordtransfer.emails import send_user_account_updated
 from recordtransfer.forms import UserProfileForm
+from recordtransfer.forms.submission_group_form import SubmissionGroupForm
 from recordtransfer.models import InProgressSubmission, Submission, SubmissionGroup, User
 
 
@@ -70,6 +71,7 @@ class UserProfile(UpdateView):
                         "recordtransfer:in_progress_submission_table"
                     ),
                 },
+                "submission_group_form": SubmissionGroupForm(),
                 # Table container IDs
                 "ID_SUBMISSION_TABLE": ID_SUBMISSION_TABLE,
                 "ID_SUBMISSION_GROUP_TABLE": ID_SUBMISSION_GROUP_TABLE,

--- a/app/recordtransfer/views/profile.py
+++ b/app/recordtransfer/views/profile.py
@@ -69,6 +69,10 @@ class UserProfile(UpdateView):
                     "IN_PROGRESS_SUBMISSION_TABLE_URL": reverse(
                         "recordtransfer:in_progress_submission_table"
                     ),
+                    "ID_SUBMISSION_GROUP_TABLE": ID_SUBMISSION_GROUP_TABLE,
+                    "SUBMISSION_GROUP_TABLE_URL": reverse(
+                        "recordtransfer:submission_group_table"
+                    ),
                 },
                 # Table container IDs
                 "ID_SUBMISSION_TABLE": ID_SUBMISSION_TABLE,

--- a/app/recordtransfer/views/profile.py
+++ b/app/recordtransfer/views/profile.py
@@ -24,6 +24,7 @@ from recordtransfer.constants import (
     ID_IN_PROGRESS_SUBMISSION_TABLE,
     ID_LAST_NAME,
     ID_NEW_PASSWORD,
+    ID_SUBMISSION_GROUP_NAME,
     ID_SUBMISSION_GROUP_TABLE,
     ID_SUBMISSION_TABLE,
     PAGINATE_QUERY_NAME,
@@ -63,6 +64,8 @@ class UserProfile(UpdateView):
                     "ID_CURRENT_PASSWORD": ID_CURRENT_PASSWORD,
                     "ID_NEW_PASSWORD": ID_NEW_PASSWORD,
                     "ID_CONFIRM_NEW_PASSWORD": ID_CONFIRM_NEW_PASSWORD,
+                    # Submission group form
+                    "ID_SUBMISSION_GROUP_NAME": ID_SUBMISSION_GROUP_NAME,
                     # Tables
                     "PAGINATE_QUERY_NAME": PAGINATE_QUERY_NAME,
                     "ID_IN_PROGRESS_SUBMISSION_TABLE": ID_IN_PROGRESS_SUBMISSION_TABLE,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,9 +76,7 @@ module.exports = {
         ],
         submission_form: "./app/recordtransfer/static/recordtransfer/js/submission_form/index.js", // eslint-disable-line
         profile: [
-            ...glob.sync(
-                "./app/recordtransfer/static/recordtransfer/js/profile/*.js")
-                .map(file => "./" + path.relative(__dirname, file)),
+            "./app/recordtransfer/static/recordtransfer/js/profile/index.js",
             ...glob.sync(
                 "./app/recordtransfer/static/recordtransfer/css/profile/*.css")
                 .map(file => "./" + path.relative(__dirname, file)),


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/570

Change notes:
- Adds ability to create a new submission group using a modal directly from the Profile page, instead of loading a separate page
- Changes the way modals are rendered: modal's contents are being replaced now instead of the entire modal itself. This is to prevent the modal from flickering.