### PR TITLE
Simplify Permission Handling for Post Submission Views

### DIFF
--- a/app/recordtransfer/tests/unit/views/test_post_submission.py
+++ b/app/recordtransfer/tests/unit/views/test_post_submission.py
@@ -282,7 +282,7 @@ class TestSubmissionCsvView(TestCase):
         User.objects.create_user(username="otheruser", password="password")
         self.client.login(username="otheruser", password="password")
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
 
     @patch("recordtransfer.managers.SubmissionQuerySet.export_csv")
     def test_access_staff_user(self, mock_export: MagicMock) -> None:

--- a/app/recordtransfer/urls.py
+++ b/app/recordtransfer/urls.py
@@ -10,12 +10,12 @@ urlpatterns = [
     path("", views.home.Index.as_view(), name="index"),
     path(
         "submission/<uuid:uuid>/csv/",
-        login_required(views.post_submission.SubmissionCsv.as_view()),
+        login_required(views.post_submission.SubmissionCsvView.as_view()),
         name="submission_csv",
     ),
     path(
         "submission/<uuid:uuid>/",
-        login_required(views.post_submission.SubmissionDetail.as_view()),
+        login_required(views.post_submission.SubmissionDetailView.as_view()),
         name="submission_detail",
     ),
     path(

--- a/app/recordtransfer/views/post_submission.py
+++ b/app/recordtransfer/views/post_submission.py
@@ -17,7 +17,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.text import slugify
 from django.utils.translation import gettext
-from django.views.generic import CreateView, DetailView, UpdateView, View
+from django.views.generic import CreateView, DetailView, UpdateView
 
 from recordtransfer.constants import ID_SUBMISSION_GROUP_DESCRIPTION, ID_SUBMISSION_GROUP_NAME
 from recordtransfer.forms.submission_group_form import SubmissionGroupForm

--- a/app/recordtransfer/views/post_submission.py
+++ b/app/recordtransfer/views/post_submission.py
@@ -29,7 +29,7 @@ from recordtransfer.models import Submission, SubmissionGroup
 LOGGER = logging.getLogger(__name__)
 
 
-class SubmissionDetail(UserPassesTestMixin, DetailView):
+class SubmissionDetailView(UserPassesTestMixin, DetailView):
     """Generates a report for a given submission."""
 
     model = Submission
@@ -58,7 +58,7 @@ class SubmissionDetail(UserPassesTestMixin, DetailView):
         return context
 
 
-class SubmissionCsv(UserPassesTestMixin, View):
+class SubmissionCsvView(UserPassesTestMixin, View):
     """Generates a CSV containing the submission and downloads that CSV."""
 
     def get_object(self) -> Submission:


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/580

The two instances where `get_object_or_404` were being used without filtering for the user did not actually pose any security risks, as the view utilized `test_func()` as part of `UserPassesTestMixin` to test that the object requested belonged to `request.user`. However, this is not ideal, since we want to prevent any objects that don't belong to `request.user` from making it to the view in the first place.

I've made use of user filtering directly in `get_queryset()`, so that it returns a queryset appropriate to the user or staff member.

I've also added missing tests for `SubmissionDetailView` and `SubmissionCsvView`.