### PR TITLE
Make mobile menu stick to top when scrolled down

### DIFF
--- a/app/recordtransfer/static/recordtransfer/css/base/base.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/base.css
@@ -54,9 +54,8 @@ h2 {
     font-size: 16;
 }
 
-.title-text-light {
+.text-light {
     color: white;
-    font-size: 20pt;
 }
 
 .medium-text {

--- a/app/recordtransfer/static/recordtransfer/css/base/navbar.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/navbar.css
@@ -182,6 +182,22 @@ header.homepage {
     transition: background-color 0.3s ease, color 0.3s ease;
 }
 
+@media all and (max-width: 450px) {
+    .nav-title {
+        margin-left: 10px;
+    }
+
+    #app-logo {
+        width: 35px;
+        height: 35px;
+    }
+
+    #app-title {
+        font-size: 16pt;
+    }
+}
+
+
 /* Mobile-only transitions */
 @media all and (max-width: 799px) {
     .nav-items-container {

--- a/app/recordtransfer/static/recordtransfer/css/base/navbar.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/navbar.css
@@ -52,6 +52,16 @@ header.homepage {
     align-content: start;
     justify-content: flex-start;
     text-align: left;
+    /* Add padding to account for fixed position mobile menu */
+    padding-right: 40px;
+}
+
+/* Mobile navigation container - wraps both toggle and menu */
+.nav-wrapper {
+    position: fixed;
+    top: 20px;
+    right: 0;
+    z-index: 1001;
 }
 
 /* Sliding menu styles */
@@ -75,7 +85,7 @@ header.homepage {
 }
 
 .nav-items-container.open {
-    top: 80%;
+    top: 100%;
     visibility: visible;
     transition: top 0.3s ease, opacity 0.3s ease;
 }
@@ -189,6 +199,16 @@ header.homepage {
         align-items: center;
         flex-wrap: nowrap;
         background: none;
+    }
+
+    /* Reset mobile container for desktop */
+    .nav-wrapper {
+        position: static;
+    }
+
+    .nav-title {
+        /* Unset padding used to account for mobile menu */
+        padding-right: 0;
     }
 
     .nav-items-container {

--- a/app/recordtransfer/static/recordtransfer/css/base/navbar.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/navbar.css
@@ -48,7 +48,7 @@ header.homepage {
 /* Site title */
 .nav-title {
     margin-left: 20px;
-    flex-grow: 1;
+    flex: 1;
     align-content: start;
     justify-content: flex-start;
     text-align: left;
@@ -118,20 +118,13 @@ header.homepage {
 
 .nav-toggle-open {
     order: 1;
-    flex: 1;
     text-align: right;
-    display: block;
     font-size: 20pt;
 }
 
 /* Burger button */
 .nav-icon-bars {
     display: inline-block;
-
-}
-
-.nav-wrapper {
-    top: 10%;
 }
 
 .nav-icon-close {
@@ -188,19 +181,7 @@ header.homepage {
     .nav-item:hover {
         background-color: #f2f2f2;
     }
-
-    .nav-wrapper {
-        position: fixed;
-        z-index: 1000;
-        right: 0;
-        transform: translateY(-100%);
-    }
-
-    .nav-wrapper.open {
-        transform: translateY(0);
-    }
 }
-
 
 /* Desktop menu */
 @media all and (min-width: 800px) {

--- a/app/recordtransfer/static/recordtransfer/js/base/navbar.js
+++ b/app/recordtransfer/static/recordtransfer/js/base/navbar.js
@@ -38,4 +38,33 @@ export function setupNavbar() {
             toggleButton.classList.remove("active");
         }
     });
+
+    /**
+     * Aligns the navigation wrapper (e.g. burger menu) with the title
+     * when the page is at the top. When the user scrolls, it moves the
+     * nav wrapper to a fixed position at the top-right corner.
+     */
+    function alignNavWrapper() {
+        const navWrapper = document.querySelector(".nav-wrapper");
+        const navTitle = document.querySelector(".nav-title");
+
+        if (!navWrapper || !navTitle) {
+            return;
+        }
+
+        const position = window.getComputedStyle(navWrapper).position;
+
+        // Position is fixed if mobile menu is active
+        if (position !== "fixed") {
+            return;
+        }
+
+        const titleRect = navTitle.getBoundingClientRect();
+        navWrapper.style.top = `${Math.max(20, titleRect.top)}px`;
+    }
+
+    window.addEventListener("scroll", alignNavWrapper);
+    window.addEventListener("resize", alignNavWrapper);
+
+    alignNavWrapper();
 }

--- a/app/recordtransfer/static/recordtransfer/js/base/navbar.js
+++ b/app/recordtransfer/static/recordtransfer/js/base/navbar.js
@@ -65,6 +65,5 @@ export function setupNavbar() {
 
     window.addEventListener("scroll", alignNavWrapper);
     window.addEventListener("resize", alignNavWrapper);
-
-    alignNavWrapper();
+    window.addEventListener("load", alignNavWrapper);
 }

--- a/app/recordtransfer/templates/recordtransfer/header.html
+++ b/app/recordtransfer/templates/recordtransfer/header.html
@@ -1,6 +1,6 @@
 {% load static %}
 {% load i18n %}
-<header class="header {% if request.path == '/' %}homepage{% endif %}">
+<header class="header {% if request.path == "/" %}homepage{% endif %}">
     <div class="menu-overlay"></div>
     <nav class="main-header-content">
         <div class="main-navbar">
@@ -18,63 +18,61 @@
                     <span id="app-title" class="title-text-light">{% trans "NCTR Record Transfer" %}</span>
                 </a>
             </div>
-            <div class="nav-wrapper">
-                <div class="nav-toggle-open">
-                    <a class="nav-link non-nav-link nav-toggle-button" href="#">
-                        <i class="fa fa-bars nav-icon-bars" aria-hidden="true"></i>
-                        <i class="fas fa-times nav-icon-close" aria-hidden="true"></i>
+            <div class="nav-items-container">
+                <a class="nav-item nav-item-flex"
+                   href="{% url 'recordtransfer:index' %}">
+                    <div class="nav-link">{% trans "Home" %}</div>
+                    <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                </a>
+                <a class="nav-item nav-item-flex"
+                   href="{% url 'recordtransfer:about' %}">
+                    <div class="nav-link">{% trans "About" %}</div>
+                    <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                </a>
+                <a class="nav-item nav-item-flex" href="{% url 'recordtransfer:help' %}">
+                    <div class="nav-link">{% trans "Help" %}</div>
+                    <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                </a>
+                {% if user.is_staff %}
+                    <a class="nav-item nav-item-flex" href="{% url 'admin:index' %}">
+                        <div class="nav-link">{% trans "Admin" %}</div>
+                        <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
                     </a>
-                </div>
-                <div class="nav-items-container">
+                {% endif %}
+                {% if user.is_authenticated %}
                     <a class="nav-item nav-item-flex"
-                       href="{% url 'recordtransfer:index' %}">
-                        <div class="nav-link">{% trans "Home" %}</div>
+                       href="{% url 'recordtransfer:user_profile' %}">
+                        <div class="nav-link">{% trans "Profile" %}</div>
                         <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
                     </a>
                     <a class="nav-item nav-item-flex"
-                       href="{% url 'recordtransfer:about' %}">
-                        <div class="nav-link">{% trans "About" %}</div>
+                       href="{% url 'recordtransfer:submit' %}">
+                        <div class="nav-link">{% trans "Submit" %}</div>
                         <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
                     </a>
-                    <a class="nav-item nav-item-flex" href="{% url 'recordtransfer:help' %}">
-                        <div class="nav-link">{% trans "Help" %}</div>
-                        <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                    <a class="nav-item-button nav-item-flex" href="{% url 'logout' %}">
+                        <div id="logout-btn" class="nav-link nav-button">{% trans "Logout" %}</div>
                     </a>
-                    {% if user.is_staff %}
-                        <a class="nav-item nav-item-flex" href="{% url 'admin:index' %}">
-                            <div class="nav-link">{% trans "Admin" %}</div>
+                {% elif not user.is_authenticated %}
+                    {% if SIGN_UP_ENABLED %}
+                        <a class="nav-item nav-item-flex"
+                           href="{% url 'recordtransfer:create_account' %}">
+                            <div class="nav-link">{% trans "Sign Up" %}</div>
                             <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
                         </a>
                     {% endif %}
-                    {% if user.is_authenticated %}
-                        <a class="nav-item nav-item-flex"
-                           href="{% url 'recordtransfer:user_profile' %}">
-                            <div class="nav-link">{% trans "Profile" %}</div>
-                            <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                    {% if 'login' not in request.path %}
+                        <a class="nav-item-button nav-item-flex" href="{% url 'login' %}">
+                            <div class="nav-link nav-button">{% trans "Log In" %}</div>
                         </a>
-                        <a class="nav-item nav-item-flex"
-                           href="{% url 'recordtransfer:submit' %}">
-                            <div class="nav-link">{% trans "Submit" %}</div>
-                            <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
-                        </a>
-                        <a class="nav-item-button nav-item-flex" href="{% url 'logout' %}">
-                            <div id="logout-btn" class="nav-link nav-button">{% trans "Logout" %}</div>
-                        </a>
-                    {% elif not user.is_authenticated %}
-                        {% if SIGN_UP_ENABLED %}
-                            <a class="nav-item nav-item-flex"
-                               href="{% url 'recordtransfer:create_account' %}">
-                                <div class="nav-link">{% trans "Sign Up" %}</div>
-                                <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
-                            </a>
-                        {% endif %}
-                        {% if 'login' not in request.path %}
-                            <a class="nav-item-button nav-item-flex" href="{% url 'login' %}">
-                                <div class="nav-link nav-button">{% trans "Log In" %}</div>
-                            </a>
-                        {% endif %}
                     {% endif %}
-                </div>
+                {% endif %}
+            </div>
+            <div class="nav-toggle-open">
+                <a class="nav-link non-nav-link nav-toggle-button" href="#">
+                    <i class="fa fa-bars nav-icon-bars" aria-hidden="true"></i>
+                    <i class="fas fa-times nav-icon-close" aria-hidden="true"></i>
+                </a>
             </div>
         </div>
     </nav>

--- a/app/recordtransfer/templates/recordtransfer/header.html
+++ b/app/recordtransfer/templates/recordtransfer/header.html
@@ -19,6 +19,12 @@
                 </a>
             </div>
             <div class="nav-wrapper">
+                <div class="nav-toggle-open">
+                    <a class="nav-link non-nav-link nav-toggle-button" href="#">
+                        <i class="fa fa-bars nav-icon-bars" aria-hidden="true"></i>
+                        <i class="fas fa-times nav-icon-close" aria-hidden="true"></i>
+                    </a>
+                </div>
                 <div class="nav-items-container">
                     <a class="nav-item nav-item-flex"
                        href="{% url 'recordtransfer:index' %}">
@@ -68,12 +74,6 @@
                             </a>
                         {% endif %}
                     {% endif %}
-                </div>
-                <div class="nav-toggle-open">
-                    <a class="nav-link non-nav-link nav-toggle-button" href="#">
-                        <i class="fa fa-bars nav-icon-bars" aria-hidden="true"></i>
-                        <i class="fas fa-times nav-icon-close" aria-hidden="true"></i>
-                    </a>
                 </div>
             </div>
         </div>

--- a/app/recordtransfer/templates/recordtransfer/header.html
+++ b/app/recordtransfer/templates/recordtransfer/header.html
@@ -6,8 +6,8 @@
         <div class="main-navbar">
             <div class="nav-logo">
                 <img id="app-logo"
-                     height="60"
-                     width="60"
+                     height="50"
+                     width="50"
                      src="{% static 'recordtransfer/img/NCTR-Logo-White.svg' %}"
                      alt="{% trans "NCTR Logo" %}">
             </div>
@@ -15,64 +15,66 @@
                 <a class="nav-link title"
                    href="{% url 'recordtransfer:index' %}"
                    title="Go to home page">
-                    <span id="app-title" class="title-text-light">{% trans "NCTR Record Transfer" %}</span>
+                    <span id="app-title" class="title-text text-light">{% trans "NCTR Record Transfer" %}</span>
                 </a>
             </div>
-            <div class="nav-items-container">
-                <a class="nav-item nav-item-flex"
-                   href="{% url 'recordtransfer:index' %}">
-                    <div class="nav-link">{% trans "Home" %}</div>
-                    <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
-                </a>
-                <a class="nav-item nav-item-flex"
-                   href="{% url 'recordtransfer:about' %}">
-                    <div class="nav-link">{% trans "About" %}</div>
-                    <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
-                </a>
-                <a class="nav-item nav-item-flex" href="{% url 'recordtransfer:help' %}">
-                    <div class="nav-link">{% trans "Help" %}</div>
-                    <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
-                </a>
-                {% if user.is_staff %}
-                    <a class="nav-item nav-item-flex" href="{% url 'admin:index' %}">
-                        <div class="nav-link">{% trans "Admin" %}</div>
-                        <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
-                    </a>
-                {% endif %}
-                {% if user.is_authenticated %}
+            <div class="nav-wrapper">
+                <div class="nav-items-container">
                     <a class="nav-item nav-item-flex"
-                       href="{% url 'recordtransfer:user_profile' %}">
-                        <div class="nav-link">{% trans "Profile" %}</div>
+                       href="{% url 'recordtransfer:index' %}">
+                        <div class="nav-link">{% trans "Home" %}</div>
                         <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
                     </a>
                     <a class="nav-item nav-item-flex"
-                       href="{% url 'recordtransfer:submit' %}">
-                        <div class="nav-link">{% trans "Submit" %}</div>
+                       href="{% url 'recordtransfer:about' %}">
+                        <div class="nav-link">{% trans "About" %}</div>
                         <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
                     </a>
-                    <a class="nav-item-button nav-item-flex" href="{% url 'logout' %}">
-                        <div id="logout-btn" class="nav-link nav-button">{% trans "Logout" %}</div>
+                    <a class="nav-item nav-item-flex" href="{% url 'recordtransfer:help' %}">
+                        <div class="nav-link">{% trans "Help" %}</div>
+                        <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
                     </a>
-                {% elif not user.is_authenticated %}
-                    {% if SIGN_UP_ENABLED %}
-                        <a class="nav-item nav-item-flex"
-                           href="{% url 'recordtransfer:create_account' %}">
-                            <div class="nav-link">{% trans "Sign Up" %}</div>
+                    {% if user.is_staff %}
+                        <a class="nav-item nav-item-flex" href="{% url 'admin:index' %}">
+                            <div class="nav-link">{% trans "Admin" %}</div>
                             <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
                         </a>
                     {% endif %}
-                    {% if 'login' not in request.path %}
-                        <a class="nav-item-button nav-item-flex" href="{% url 'login' %}">
-                            <div class="nav-link nav-button">{% trans "Log In" %}</div>
+                    {% if user.is_authenticated %}
+                        <a class="nav-item nav-item-flex"
+                           href="{% url 'recordtransfer:user_profile' %}">
+                            <div class="nav-link">{% trans "Profile" %}</div>
+                            <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
                         </a>
+                        <a class="nav-item nav-item-flex"
+                           href="{% url 'recordtransfer:submit' %}">
+                            <div class="nav-link">{% trans "Submit" %}</div>
+                            <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                        </a>
+                        <a class="nav-item-button nav-item-flex" href="{% url 'logout' %}">
+                            <div id="logout-btn" class="nav-link nav-button">{% trans "Logout" %}</div>
+                        </a>
+                    {% elif not user.is_authenticated %}
+                        {% if SIGN_UP_ENABLED %}
+                            <a class="nav-item nav-item-flex"
+                               href="{% url 'recordtransfer:create_account' %}">
+                                <div class="nav-link">{% trans "Sign Up" %}</div>
+                                <i class="fa fa-angle-right nav-link-icon" aria-hidden="true"></i>
+                            </a>
+                        {% endif %}
+                        {% if 'login' not in request.path %}
+                            <a class="nav-item-button nav-item-flex" href="{% url 'login' %}">
+                                <div class="nav-link nav-button">{% trans "Log In" %}</div>
+                            </a>
+                        {% endif %}
                     {% endif %}
-                {% endif %}
-            </div>
-            <div class="nav-toggle-open">
-                <a class="nav-link non-nav-link nav-toggle-button" href="#">
-                    <i class="fa fa-bars nav-icon-bars" aria-hidden="true"></i>
-                    <i class="fas fa-times nav-icon-close" aria-hidden="true"></i>
-                </a>
+                </div>
+                <div class="nav-toggle-open">
+                    <a class="nav-link non-nav-link nav-toggle-button" href="#">
+                        <i class="fa fa-bars nav-icon-bars" aria-hidden="true"></i>
+                        <i class="fas fa-times nav-icon-close" aria-hidden="true"></i>
+                    </a>
+                </div>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
Closes #522 

This change makes the mobile menu `position: fixed;` and ensures it stays at ~ 20px from the top of the screen. I've also made it so that the menu stays aligned with the title in the header so that the positioning of the menu icon looks good when scrolled all the way to the top.

This is a combo of my own changes and @Eashana0104's (see #587)