### PR TITLE
Fix duplicate in-progress submissions being created

### DIFF
--- a/app/recordtransfer/templates/recordtransfer/submission_form_base.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_form_base.html
@@ -34,6 +34,7 @@
     {% endblock form_explanation %}
     <form id="submission-form"
           hx-post="{{ request.path }}"
+          {% if in_progress_uuid %}hx-vals='{"in_progress_uuid":"{{ in_progress_uuid }}"}'{% endif %}
           hx-target="#main-container"
           hx-select="#main-container"
           hx-swap="outerHTML"

--- a/app/recordtransfer/views/pre_submission.py
+++ b/app/recordtransfer/views/pre_submission.py
@@ -199,7 +199,7 @@ class SubmissionFormWizard(SessionWizardView):
 
     def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         """Dispatch the request to the appropriate handler method."""
-        self.in_progress_uuid = request.GET.get("resume")
+        self.in_progress_uuid = request.GET.get("resume") or request.POST.get("in_progress_uuid")
 
         if not self.in_progress_uuid:
             self.submission_group_uuid = request.GET.get("group")
@@ -535,6 +535,9 @@ class SubmissionFormWizard(SessionWizardView):
         context = super().get_context_data(form, **kwargs)
 
         context.update({"form_title": self._TEMPLATES[self.current_step][FORMTITLE]})
+
+        if self.in_progress_uuid:
+            context["in_progress_uuid"] = self.in_progress_uuid
 
         if INFOMESSAGE in self._TEMPLATES[self.current_step]:
             context.update({"info_message": self._TEMPLATES[self.current_step][INFOMESSAGE]})


### PR DESCRIPTION
It's possible for the `resume` GET parameter to be missing when the save_form_step button is clicked. When this happens, the view doesn't know the in-progress UUID and creates a new in-progress submission.

This pull request uses HTMX `hx-vals` to pass the in-progress UUID as a fallback to use in case resume is missing from the GET request.