### PR TITLE
Fix issues with click here links to view help

### DIFF
--- a/app/recordtransfer/static/recordtransfer/js/base/tooltip.js
+++ b/app/recordtransfer/static/recordtransfer/js/base/tooltip.js
@@ -83,6 +83,7 @@ export function setupHelpTooltips() {
 
         icon.addEventListener("mouseleave", () => {
             tooltip.classList.remove("visible");
+            tooltip.style.display = "none";
         });
     });
 }

--- a/app/recordtransfer/templates/recordtransfer/submission_form_rights.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_form_rights.html
@@ -1,11 +1,11 @@
-{% extends 'recordtransfer/submission_form_formset.html' %}
+{% extends "recordtransfer/submission_form_formset.html" %}
 {% load i18n %}
-
 {% block form_explanation %}
     <p>
+        {% url "recordtransfer:help" as help_url %}
         {% blocktrans %}
-        <a class="non-nav-link" target="_blank" href="/about/#rights-types">Click here</a>
+        <a class="non-nav-link" target="_blank" href="{{ help_url }}#rights-types">Click here</a>
         for an explanation of the different types of rights.
         {% endblocktrans %}
     </p>
-{% endblock %}
+{% endblock form_explanation %}

--- a/app/recordtransfer/templates/recordtransfer/submission_form_sourceinfo.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_form_sourceinfo.html
@@ -35,12 +35,12 @@
             {# Render hidden field #}
             {{ field }}
         {% endif %}
+        {% url 'recordtransfer:help' as help_url %}
         {% if field.name == "other_source_type" %}
             <div class="flex-item initially-hidden hidden-item">
                 <label></label>
                 <div>
                     <i>
-                        {% url 'recordtransfer:help' as help_url %}
                         {% blocktrans %}
                         <a class="non-nav-link" target="_blank" href="{{ help_url }}#source-types">Click here</a>
                         for an explanation of the different types of source types.
@@ -54,7 +54,6 @@
                 <label></label>
                 <div>
                     <i>
-                        {% url 'recordtransfer:help' as help_url %}
                         {% blocktrans %}
                         <a class="non-nav-link" target="_blank" href="{{ help_url }}#source-roles">Click here</a>
                         for an explanation of the different types of source roles.

--- a/app/recordtransfer/templates/recordtransfer/submission_form_sourceinfo.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_form_sourceinfo.html
@@ -1,32 +1,27 @@
 {% extends "recordtransfer/submission_form_standard.html" %}
 {% load static %}
 {% load i18n %}
-
 {% block javascript %}
     {{ block.super }}
 {% endblock javascript %}
-
 {% block formfields %}
     {% for field in wizard.form %}
         {% if field.errors %}
             {% for error in field.errors %}
-            <div class="flex-error initially-hidden">
-                <label for="nothing"></label>
-                <div class="field-error">{{ error }}</div>
-            </div>
+                <div class="flex-error initially-hidden">
+                    <label for="nothing"></label>
+                    <div class="field-error">{{ error }}</div>
+                </div>
             {% endfor %}
         {% endif %}
         {% if field.label != 'hidden' %}
-            {% if field.name == "enter_manual_source_info" %}
-            <div class="flex-item">
-            {% else %}
-            <div class="flex-item initially-hidden hidden-item">
-            {% endif %}
+            <div class="flex-item {% if field.name != 'enter_manual_source_info' %}initially-hidden hidden-item{% endif %}">
                 <label for="{{ field.id_for_label }}" class="{{ field.css_classes }}">{{ field.label }}</label>
                 {{ field }}
                 {# Help tooltip #}
                 {% if field.help_text %}
-                    <div tooltip-content="{{ field.help_text }}" class="help-tooltip help-icon">
+                    <div tooltip-content="{{ field.help_text }}"
+                         class="help-tooltip help-icon">
                         <i class="fa fa-info-circle" aria-hidden="true"></i>
                     </div>
                 {% endif %}
@@ -65,5 +60,6 @@
         {% endif %}
     {% endfor %}
 {% endblock formfields %}
-
-{% block buttonarrayclass %}flex-item{% endblock buttonarrayclass %}
+{% block buttonarrayclass %}
+    flex-item
+{% endblock buttonarrayclass %}

--- a/app/recordtransfer/templates/recordtransfer/submission_form_sourceinfo.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_form_sourceinfo.html
@@ -40,8 +40,9 @@
                 <label></label>
                 <div>
                     <i>
+                        {% url 'recordtransfer:help' as help_url %}
                         {% blocktrans %}
-                        <a class="non-nav-link" target="_blank" href="/about/#source-types">Click here</a>
+                        <a class="non-nav-link" target="_blank" href="{{ help_url }}#source-types">Click here</a>
                         for an explanation of the different types of source types.
                         {% endblocktrans %}
                     </i>
@@ -53,8 +54,9 @@
                 <label></label>
                 <div>
                     <i>
+                        {% url 'recordtransfer:help' as help_url %}
                         {% blocktrans %}
-                        <a class="non-nav-link" target="_blank" href="/about/#source-roles">Click here</a>
+                        <a class="non-nav-link" target="_blank" href="{{ help_url }}#source-roles">Click here</a>
                         for an explanation of the different types of source roles.
                         {% endblocktrans %}
                     </i>


### PR DESCRIPTION
The "Click here" links that take you to the help page were incorrectly re-directing to the about page. As well, the tooltips may invisibly cover these links because their display is not being set to `none` when they are hidden.

These changes fix both of these problems.