### PR TITLE
Fix Not Being Able to Access Uploaded Files on Review Step

### DIFF
--- a/app/recordtransfer/decorators.py
+++ b/app/recordtransfer/decorators.py
@@ -29,8 +29,11 @@ def validate_upload_access(view_func: Callable) -> Callable:
                 status=403,
             )
 
-        # For POST requests, only allow during upload_files step
-        if request.method == "POST" and current_step != SubmissionStep.UPLOAD_FILES.value:
+        # For POST and DELETE requests, only allow during upload_files step
+        if (
+            request.method in ("POST", "DELETE")
+            and current_step != SubmissionStep.UPLOAD_FILES.value
+        ):
             return JsonResponse(
                 {"error": gettext("Uploads are only permitted during the file upload step")},
                 status=403,

--- a/app/recordtransfer/decorators.py
+++ b/app/recordtransfer/decorators.py
@@ -9,9 +9,9 @@ from django.utils.translation import gettext
 from recordtransfer.enums import SubmissionStep
 
 
-def require_upload_step(view_func: Callable) -> Callable:
-    """Restricts access to views based on the current wizard step. Only allows access if the
-    request originates from the UPLOAD_FILES step of SubmissionFormWizard.
+def validate_upload_access(view_func: Callable) -> Callable:
+    """Restricts access to views based on the current wizard step. Only allows POST requests
+    during the UPLOAD_FILES step. GET requests are allowed for both UPLOAD_FILES and REVIEW steps.
     """
 
     @functools.wraps(view_func)
@@ -20,8 +20,17 @@ def require_upload_step(view_func: Callable) -> Callable:
         wizard_data = request.session.get("wizard_submission_form_wizard", {})
         current_step = wizard_data.get("step")
 
-        # Allow access only if we're on the upload_files step
-        if not current_step or current_step != SubmissionStep.UPLOAD_FILES.value:
+        if not current_step or current_step not in [
+            SubmissionStep.UPLOAD_FILES.value,
+            SubmissionStep.REVIEW.value,
+        ]:
+            return JsonResponse(
+                {"error": gettext("Access denied. Please try again.")},
+                status=403,
+            )
+
+        # For POST requests, only allow during upload_files step
+        if request.method == "POST" and current_step != SubmissionStep.UPLOAD_FILES.value:
             return JsonResponse(
                 {"error": gettext("Uploads are only permitted during the file upload step")},
                 status=403,

--- a/app/recordtransfer/decorators.py
+++ b/app/recordtransfer/decorators.py
@@ -11,7 +11,7 @@ from recordtransfer.enums import SubmissionStep
 
 def validate_upload_access(view_func: Callable) -> Callable:
     """Restricts access to views based on the current wizard step. Only allows POST requests
-    during the UPLOAD_FILES step. GET requests are allowed for both UPLOAD_FILES and REVIEW steps.
+    during the UPLOAD_FILES step.
     """
 
     @functools.wraps(view_func)

--- a/app/recordtransfer/tests/unit/test_decorators.py
+++ b/app/recordtransfer/tests/unit/test_decorators.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest, JsonResponse
 from django.test import RequestFactory, TestCase
 from django.utils.translation import gettext
 
-from recordtransfer.decorators import require_upload_step
+from recordtransfer.decorators import validate_upload_access
 from recordtransfer.enums import SubmissionStep
 
 
@@ -19,7 +19,7 @@ class TestRequireUploadStepDecorator(TestCase):
     def test_request_without_wizard_data(self) -> None:
         """Requests without wizard data should be forbidden."""
 
-        @require_upload_step
+        @validate_upload_access
         def dummy_view(request: HttpRequest, *args, **kwargs):
             return JsonResponse({"success": True})
 
@@ -30,13 +30,13 @@ class TestRequireUploadStepDecorator(TestCase):
             self.assertEqual(response.status_code, 403)
             self.assertEqual(
                 json.loads(response.content),
-                {"error": gettext("Uploads are only permitted during the file upload step")},
+                {"error": gettext("Access denied. Please try again.")},
             )
 
     def test_request_with_wrong_step(self) -> None:
         """Requests with the wrong wizard step should be forbidden."""
 
-        @require_upload_step
+        @validate_upload_access
         def dummy_view(request: HttpRequest, *args, **kwargs):
             return JsonResponse({"success": True})
 
@@ -48,23 +48,95 @@ class TestRequireUploadStepDecorator(TestCase):
             self.assertEqual(response.status_code, 403)
             self.assertEqual(
                 json.loads(response.content),
-                {"error": gettext("Uploads are only permitted during the file upload step")},
+                {"error": gettext("Access denied. Please try again.")},
             )
 
-    def test_request_with_correct_step(self) -> None:
-        """Requests with the correct wizard step should pass through."""
+    def test_post_request_during_upload_step(self) -> None:
+        """POST requests during the UPLOAD_FILES step should be allowed."""
 
-        @require_upload_step
+        @validate_upload_access
         def dummy_view(request: HttpRequest, *args, **kwargs):
             return JsonResponse({"success": True})
 
-        for method in ["get", "post", "put", "delete"]:
-            request = getattr(self.factory, method)("/dummy-url/")
+        request = self.factory.post("/dummy-url/")
+        request.session = SessionStore()
+        request.session["wizard_submission_form_wizard"] = {
+            "step": SubmissionStep.UPLOAD_FILES.value
+        }
+        response = dummy_view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {"success": True})
+
+    def test_post_request_during_review_step(self) -> None:
+        """POST requests during the REVIEW step should be forbidden."""
+
+        @validate_upload_access
+        def dummy_view(request: HttpRequest, *args, **kwargs):
+            return JsonResponse({"success": True})
+
+        request = self.factory.post("/dummy-url/")
+        request.session = SessionStore()
+        request.session["wizard_submission_form_wizard"] = {
+            "step": SubmissionStep.REVIEW.value
+        }
+        response = dummy_view(request)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            json.loads(response.content),
+            {"error": gettext("Uploads are only permitted during the file upload step")},
+        )
+
+    def test_post_request_during_other_step(self) -> None:
+        """POST requests during any step other than UPLOAD_FILES should be forbidden."""
+
+        @validate_upload_access
+        def dummy_view(request: HttpRequest, *args, **kwargs):
+            return JsonResponse({"success": True})
+
+        for step in SubmissionStep:
+            if step == SubmissionStep.UPLOAD_FILES or step == SubmissionStep.REVIEW:
+                continue
+
+            request = self.factory.post("/dummy-url/")
             request.session = SessionStore()
             request.session["wizard_submission_form_wizard"] = {
-                "step": SubmissionStep.UPLOAD_FILES.value
+                "step": step.value
             }
-            request.session.save()
             response = dummy_view(request)
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(json.loads(response.content), {"success": True})
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(
+                json.loads(response.content),
+                {"error": gettext("Access denied. Please try again.")},
+            )
+
+    def test_get_request_during_upload_step(self) -> None:
+        """GET requests during the UPLOAD_FILES step should be allowed."""
+
+        @validate_upload_access
+        def dummy_view(request: HttpRequest, *args, **kwargs):
+            return JsonResponse({"success": True})
+
+        request = self.factory.get("/dummy-url/")
+        request.session = SessionStore()
+        request.session["wizard_submission_form_wizard"] = {
+            "step": SubmissionStep.UPLOAD_FILES.value
+        }
+        response = dummy_view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {"success": True})
+
+    def test_get_request_during_review_step(self) -> None:
+        """GET requests during the REVIEW step should be allowed."""
+
+        @validate_upload_access
+        def dummy_view(request: HttpRequest, *args, **kwargs):
+            return JsonResponse({"success": True})
+
+        request = self.factory.get("/dummy-url/")
+        request.session = SessionStore()
+        request.session["wizard_submission_form_wizard"] = {
+            "step": SubmissionStep.REVIEW.value
+        }
+        response = dummy_view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {"success": True})

--- a/app/recordtransfer/tests/unit/test_decorators.py
+++ b/app/recordtransfer/tests/unit/test_decorators.py
@@ -76,9 +76,7 @@ class TestRequireUploadStepDecorator(TestCase):
 
         request = self.factory.post("/dummy-url/")
         request.session = SessionStore()
-        request.session["wizard_submission_form_wizard"] = {
-            "step": SubmissionStep.REVIEW.value
-        }
+        request.session["wizard_submission_form_wizard"] = {"step": SubmissionStep.REVIEW.value}
         response = dummy_view(request)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(
@@ -99,9 +97,7 @@ class TestRequireUploadStepDecorator(TestCase):
 
             request = self.factory.post("/dummy-url/")
             request.session = SessionStore()
-            request.session["wizard_submission_form_wizard"] = {
-                "step": step.value
-            }
+            request.session["wizard_submission_form_wizard"] = {"step": step.value}
             response = dummy_view(request)
             self.assertEqual(response.status_code, 403)
             self.assertEqual(
@@ -134,9 +130,7 @@ class TestRequireUploadStepDecorator(TestCase):
 
         request = self.factory.get("/dummy-url/")
         request.session = SessionStore()
-        request.session["wizard_submission_form_wizard"] = {
-            "step": SubmissionStep.REVIEW.value
-        }
+        request.session["wizard_submission_form_wizard"] = {"step": SubmissionStep.REVIEW.value}
         response = dummy_view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.content), {"success": True})

--- a/app/recordtransfer/views/media.py
+++ b/app/recordtransfer/views/media.py
@@ -19,7 +19,7 @@ from django.http import (
 from django.utils.translation import gettext
 from django.views.decorators.http import require_http_methods
 
-from recordtransfer.decorators import require_upload_step
+from recordtransfer.decorators import validate_upload_access
 from recordtransfer.models import UploadSession, User
 from recordtransfer.utils import accept_file, accept_session
 
@@ -51,7 +51,7 @@ def media_request(request: HttpRequest, path: str) -> HttpResponse:
     return response
 
 
-@require_upload_step
+@validate_upload_access
 @require_http_methods(["POST"])
 def create_upload_session(request: HttpRequest) -> JsonResponse:
     """Create a new upload session and return the session token.
@@ -74,7 +74,7 @@ def create_upload_session(request: HttpRequest) -> JsonResponse:
         )
 
 
-@require_upload_step
+@validate_upload_access
 @require_http_methods(["GET", "POST"])
 def upload_or_list_files(request: HttpRequest, session_token: str) -> JsonResponse:
     """Upload a single file to the server list the files uploaded in a given upload session. The
@@ -187,7 +187,7 @@ def upload_or_list_files(request: HttpRequest, session_token: str) -> JsonRespon
         )
 
 
-@require_upload_step
+@validate_upload_access
 @require_http_methods(["DELETE", "GET"])
 def uploaded_file(request: HttpRequest, session_token: str, file_name: str) -> HttpResponse:
     """Get or delete a file that has been uploaded in a given upload session.


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/627

This issue was caused by the `requires_upload_step` decorator requiring both file upload and file access operations to be restricted to the upload step. I've changed it so that:
1) file uploads and deletes are restricted to just the Upload Files step
2) uploaded file access is restricted to the Upload Files and Review step