### PR TITLE
Add missing management module to Python lint check action

### DIFF
--- a/.github/workflows/lint-py.yml
+++ b/.github/workflows/lint-py.yml
@@ -9,8 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  lint-recordtransfer-views:
-    name: Lint RecordTransfer Views
+  lint-recordtransfer:
+    name: Lint RecordTransfer Module
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,5 +19,6 @@ jobs:
           src: >-
             ./app/recordtransfer/views
             ./app/recordtransfer/forms
+            ./app/recordtransfer/management
           version-file: "./pyproject.toml"
           args: "--config ./ruff.toml check"


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/646

Adds `./app/recordtransfer/management` to list of modules to run Python lint check action on.