### PR TITLE
Fix Help Icons Showing In Front of Hover Elements

### DIFF
--- a/app/recordtransfer/static/recordtransfer/css/base/tooltip.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/tooltip.css
@@ -21,7 +21,6 @@
 }
 
 .help-tooltip.help-icon {
-    z-index: 1000;
     margin-left: 10px;
 }
 


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/668

Removed `z-index` property from `help-icon` class. I believe the `z-index` that we were setting is greater than or equal to to the `z-index` of hover elements like the date-picker and tooltips, causing the help icons to be displayed in front.