### PR TITLE
Move other to bottom when selecting provinces

### DIFF
--- a/.github/workflows/django-tests.yml
+++ b/.github/workflows/django-tests.yml
@@ -2,7 +2,7 @@ name: Run Django Unit Tests
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, 639-submission-form-feedback]
   push:
     branches: [master]
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -2,7 +2,7 @@ name: Run E2E Tests
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, 639-submission-form-feedback]
   push:
     branches: [master]
   workflow_dispatch:

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -2,7 +2,7 @@ name: PR JS Lint Check
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, 639-submission-form-feedback]
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/lint-py.yml
+++ b/.github/workflows/lint-py.yml
@@ -2,7 +2,7 @@ name: PR Python Lint Check
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, 639-submission-form-feedback]
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/smoke-test-prod.yml
+++ b/.github/workflows/smoke-test-prod.yml
@@ -2,7 +2,7 @@ name: Production Smoke Test (via compose.prod.yml)
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, 639-submission-form-feedback]
   push:
     branches: [master]
   workflow_dispatch:

--- a/app/recordtransfer/forms/submission_forms.py
+++ b/app/recordtransfer/forms/submission_forms.py
@@ -174,7 +174,6 @@ class ContactInfoForm(SubmissionForm):
         choices=[
             ("", gettext("Select your province")),
             # Canada
-            ("Other", gettext(OtherValues.PROVINCE_OR_STATE)),
             ("AB", "Alberta"),
             ("BC", "British Columbia"),
             ("MB", "Manitoba"),
@@ -239,6 +238,7 @@ class ContactInfoForm(SubmissionForm):
             ("WV", "West Virginia"),
             ("WI", "Wisconsin"),
             ("WY", "Wyoming"),
+            ("Other", gettext(OtherValues.PROVINCE_OR_STATE)),
         ],
         initial="",
         label="Province or state",


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/639?issue=NationalCentreTruthReconciliation%7CSecure-Record-Transfer%7C615. I looked for select fields with other as an option and only could find one field where Other was at top instead of bottom, moved it to bottom.