### PR TITLE
Update styling of password reset email

### DIFF
--- a/app/recordtransfer/templates/registration/password_reset_email.html
+++ b/app/recordtransfer/templates/registration/password_reset_email.html
@@ -1,46 +1,38 @@
-<!DOCTYPE html>
-<html style="
-    font-family: 'Segoe UI', Frutiger, 'Frutiger Linotype', 'Dejavu Sans', 'Helvetica Neue', Arial, sans-serif;
-    margin: 0;">
-    <body style="
-        margin: 0;">
-        <div style="
-            color: #333333;
-            font-size: 20pt;
-            width: 100%;
-            padding: 6px 20px;
-            background-color: #eeeeee;
-            margin-bottom: 15px;">
-            Reset Password
-        </div>
-        <div style="
-            padding: 0px 20px;">
-            <div>
-                Someone asked for a password reset for the <a href="{{ protocol }}://{{ domain }}">
-                NCTR Record Transfer Portal</a>. Follow the link below to reset your password:
-            </div>
-            <div style="
-                margin: 20px 20px;">
-                <a href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token%}">
-                    Reset Password
-                </a>
-            </div>
-            <div>
-                If that link doesn't work, copy and paste this link into your browser, and press
-                enter:
-            </div>
-            <div style="
-                margin: 20px 20px;">
-                {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token%}
-            </div>
-            <div style="
-                font-size: 10pt;">
-                <i>This email address is not monitored, do not reply to this message.</i>
-            </div>
-            <div style="
-                font-size: 10pt;">
-                <i>If you do not want to receive these emails anymore, click this link.</i>
-            </div>
-        </div>
-    </body>
-</html>
+{% extends "recordtransfer/email/email_base.html" %}
+{% load i18n %}
+{% load static %}
+{% block title %}
+    {% blocktrans %}Reset Your Password{% endblocktrans %}
+{% endblock title %}
+{% block content %}
+    <div>
+        {% blocktrans %}
+            Someone asked for a password reset for the NCTR Record Transfer Portal.
+            Follow the link below to reset your password:
+        {% endblocktrans %}
+    </div>
+    <div style="text-align: left; margin-top: 20px;">
+        {% url 'password_reset_confirm' uidb64=uid token=token as password_reset_url %}
+        <a href="{{ protocol }}://{{ domain }}{{ password_reset_url }}"
+           style="display: inline-block;
+                  background-color: #EE7623;
+                  color: white;
+                  padding: 10px 20px;
+                  font-weight: bold;
+                  font-family: 'Merriweather', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif">
+            {% blocktrans %}Reset Password{% endblocktrans %}
+        </a>
+        <!-- Fallback text link for plain-text clients -->
+        <p style="font-size: 10px; color:#A0A0A0; margin-top: 10px;">
+            {% trans "If the button doesn't work, copy and paste this link into your browser:" %}
+            <br>
+            <a href="{{ protocol }}://{{ domain }}{{ password_reset_url }}"
+               style="color:#606060">{{ protocol }}://{{ domain }}{{ password_reset_url }}</a>
+        </p>
+    </div>
+    <div style="margin-top: 20px; font-size: 10pt; color: #666;">
+        <p>
+            <i>{% trans "This email address is not monitored, do not reply to this message." %}</i>
+        </p>
+    </div>
+{% endblock content %}


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/696

I updated the styling of the password reset email to be consistent with the new email styling.