### PR TITLE
Add script to update version, update version

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -261,4 +261,4 @@ To make it easy to update these files, a script can be run to update these files
 python scripts/update_version.py "2025.07.07"
 ```
 
-This project uses [Calendar versioning](https://calver.org/), and version strings should match the format `YYYY.MM.DD`.
+This project uses [Calendar versioning](https://calver.org/), and version strings should match the format YYYY.MM.DD. The update script accepts zero-padded months and days (e.g., 2025.07.07), but it will strip leading zeros, so the actual version used will have non-padded month and day numbers (e.g., 2025.7.7).

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -245,3 +245,20 @@ podman-compose -f compose.dev.yml exec app python manage.py reset --seed
 
 An admin user will be created with the username `admin` and password `123`, , along with test
 submissions and a test submission group.
+
+## Updating the Application Version
+
+For each new release of this application, the version string in these files needs to be updated:
+
+- `package.json`
+- `package-lock.json`
+- `pyproject.toml`
+- `uv.lock`
+
+To make it easy to update these files, a script can be run to update these files with the same version. From the root of the repository, you can update the version of the application like this:
+
+```shell
+python scripts/update_version.py "2025.07.07"
+```
+
+This project uses [Calendar versioning](https://calver.org/), and version strings should match the format `YYYY.MM.DD`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "secure-record-transfer",
-    "version": "2025.07.07",
+    "version": "2025.7.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "secure-record-transfer",
-            "version": "2025.07.07",
+            "version": "2025.7.7",
             "license": "ISC",
             "dependencies": {
                 "@floating-ui/dom": "^1.6.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "secure-record-transfer",
-    "version": "2025.05.30",
+    "version": "2025.07.07",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "secure-record-transfer",
-            "version": "2025.05.30",
+            "version": "2025.07.07",
             "license": "ISC",
             "dependencies": {
                 "@floating-ui/dom": "^1.6.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "secure-record-transfer",
-    "version": "2025.05.30",
+    "version": "2025.07.07",
     "description": "Transfer files and metadata to an archive based on accession standards",
     "scripts": {
         "build": "webpack --config webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "secure-record-transfer",
-    "version": "2025.07.07",
+    "version": "2025.7.7",
     "description": "Transfer files and metadata to an archive based on accession standards",
     "scripts": {
         "build": "webpack --config webpack.config.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "secure-record-transfer"
-version = "2025.07.07"
+version = "2025.7.7"
 description = "Transfer files and metadata to an archive based on accession standards"
 authors = [
     { name = "Daniel Lovegrove", email = "Daniel.Lovegrove@umanitoba.ca" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "secure-record-transfer"
-version = "2025.05.30"
+version = "2025.07.07"
 description = "Transfer files and metadata to an archive based on accession standards"
 authors = [
     { name = "Daniel Lovegrove", email = "Daniel.Lovegrove@umanitoba.ca" },

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -44,9 +44,14 @@ def get_arg_parser() -> argparse.ArgumentParser:
 def update_node_version_files(version: str) -> bool:
     """Update version in package.json and package-lock.json files."""
     changed = False
+    package_name = ""
+
     for file_path in [PACKAGE_JSON, PACKAGE_LOCK_JSON]:
         with open(file_path, "r") as f:
             data = json.load(f)
+
+        if file_path == PACKAGE_JSON:
+            package_name = data.get("name", "")
 
         if version == data["version"]:
             logging.info("Version in %s is already %s", file_path.name, version)
@@ -55,6 +60,12 @@ def update_node_version_files(version: str) -> bool:
         logging.info("Updating version in %s to %s", file_path.name, version)
 
         data["version"] = version
+
+        # Update the version of this package in package-lock.json
+        if file_path == PACKAGE_LOCK_JSON and "" in data.get("packages", {}):
+            this_package = data["packages"][""]
+            if this_package["name"] == package_name:
+                this_package["version"] = version
 
         with open(file_path, "w") as f:
             json.dump(data, f, indent=4)

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -81,18 +81,19 @@ def update_python_version_files(version: str) -> bool:
     """Update version in pyproject.toml file."""
     content = PYPROJECT_TOML.read_text()
 
-    # Find the version line in [project] section
-    version_pattern = r'(version\s*=\s*")[^"\s]*(")'
+    version_pattern = r'version\s*=\s*"(?P<version>[^"\s]+)"'
+
     match = re.search(version_pattern, content)
 
     if match:
-        old_version = content[match.start(1) + len('version = "') : match.end(2) - 1]
+        old_version = match.group("version")
+
         if version == old_version:
             logging.info("Version in %s is already %s", PYPROJECT_TOML.name, version)
             return False
 
         logging.info("Updating version in %s to %s", PYPROJECT_TOML.name, version)
-        new_content = re.sub(version_pattern, rf"\g<1>{version}\g<2>", content)
+        new_content = re.sub(version_pattern, f'version = "{version}"', content)
         PYPROJECT_TOML.write_text(new_content)
 
         subprocess.run(["uv", "lock"])

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -1,0 +1,113 @@
+"""Update all the version files in this repository.
+
+Call it like:
+
+  python scripts/update_version.py 2025.07.07
+
+"""
+
+import argparse
+import json
+import logging
+import re
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+
+BASE_DIR = Path(__file__).parent.parent
+
+PACKAGE_JSON = BASE_DIR / "package.json"
+PACKAGE_LOCK_JSON = BASE_DIR / "package-lock.json"
+PYPROJECT_TOML = BASE_DIR / "pyproject.toml"
+
+
+def calver(version_string: str) -> str:
+    """Validate that version string matches YYYY-MM-DD format."""
+    pattern = r"\d{4}\.\d{2}\.\d{2}"
+    if not re.match(pattern, version_string):
+        raise argparse.ArgumentTypeError(
+            f"Version must match format YYYY-MM-DD, got: {version_string}"
+        )
+    return version_string
+
+
+def get_arg_parser() -> argparse.ArgumentParser:
+    """Create an argument parser for this script."""
+    parser = argparse.ArgumentParser(
+        description="Update version in package.json, package-lock.json, and pyproject.toml"
+    )
+    parser.add_argument("version", type=calver, help="Version string to set (e.g., '2025-07-07')")
+    return parser
+
+
+def update_node_version_files(version: str) -> bool:
+    """Update version in package.json and package-lock.json files."""
+    changed = False
+    for file_path in [PACKAGE_JSON, PACKAGE_LOCK_JSON]:
+        with open(file_path, "r") as f:
+            data = json.load(f)
+
+        if version == data["version"]:
+            logging.info("Version in %s is already %s", file_path.name, version)
+            continue
+
+        logging.info("Updating version in %s to %s", file_path.name, version)
+
+        data["version"] = version
+
+        with open(file_path, "w") as f:
+            json.dump(data, f, indent=4)
+            f.write("\n")
+
+        changed = True
+
+    return changed
+
+
+def update_python_version_files(version: str) -> bool:
+    """Update version in pyproject.toml file."""
+    content = PYPROJECT_TOML.read_text()
+
+    # Find the version line in [project] section
+    version_pattern = r'(version\s*=\s*")[^"\s]*(")'
+    match = re.search(version_pattern, content)
+
+    if match:
+        old_version = content[match.start(1) + len('version = "') : match.end(2) - 1]
+        if version == old_version:
+            logging.info("Version in %s is already %s", PYPROJECT_TOML.name, version)
+            return False
+
+        logging.info("Updating version in %s to %s", PYPROJECT_TOML.name, version)
+        new_content = re.sub(version_pattern, rf"\g<1>{version}\g<2>", content)
+        PYPROJECT_TOML.write_text(new_content)
+        return True
+
+    else:
+        logging.error("Could not find version field in %s", PYPROJECT_TOML.name)
+        return False
+
+
+def main() -> None:
+    """Change the version in all the required files."""
+    arg_parser = get_arg_parser()
+
+    parsed = arg_parser.parse_args()
+
+    changed = update_node_version_files(parsed.version)
+    changed = update_python_version_files(parsed.version) or changed
+
+    if changed:
+        logging.info("Version(s) updated, you can commit the updated files now")
+
+
+if __name__ == "__main__":
+    err = False
+    for file in (PACKAGE_JSON, PACKAGE_LOCK_JSON, PYPROJECT_TOML):
+        if not file.exists():
+            logging.error("Could not find %s", file)
+            err = True
+
+    if not err:
+        main()

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -37,7 +37,7 @@ def get_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Update version in package.json, package-lock.json, and pyproject.toml"
     )
-    parser.add_argument("version", type=calver, help="Version string to set (e.g., '2025-07-07')")
+    parser.add_argument("version", type=calver, help="Version string to set (e.g., '2025.07.07')")
     return parser
 
 

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -10,6 +10,7 @@ import argparse
 import json
 import logging
 import re
+import subprocess
 from pathlib import Path
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -93,6 +94,9 @@ def update_python_version_files(version: str) -> bool:
         logging.info("Updating version in %s to %s", PYPROJECT_TOML.name, version)
         new_content = re.sub(version_pattern, rf"\g<1>{version}\g<2>", content)
         PYPROJECT_TOML.write_text(new_content)
+
+        subprocess.run(["uv", "lock"])
+
         return True
 
     else:

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -17,7 +17,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 
 def calver(version_string: str) -> str:
     """Validate that version string matches YYYY.MM.DD format."""
-    pattern = r"\d{4}\.\d{2}\.\d{2}"
+    pattern = r"^\d{4}\.\d{2}\.\d{2}$"
     if not re.match(pattern, version_string):
         raise argparse.ArgumentTypeError(
             f"Version must match format YYYY.MM.DD, got: {version_string}"
@@ -28,7 +28,7 @@ def calver(version_string: str) -> str:
 def get_arg_parser() -> argparse.ArgumentParser:
     """Create an argument parser for this script."""
     parser = argparse.ArgumentParser(
-        description="Update version in package.json, package-lock.json, and pyproject.toml"
+        description="Update version in package.json, package-lock.json, pyproject.toml, and uv.lock"
     )
     parser.add_argument("version", type=calver, help="Version string to set (e.g., '2025.07.07')")
     return parser
@@ -56,11 +56,32 @@ def update_python_version_files(version: str) -> None:
     """Update version in pyproject.toml file."""
     uv = shutil.which("uv") or "uv"
 
+    # Update the version
     subprocess.run(
         args=[uv, "version", version],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+
+    # And optionally, run uv lock (for older versions of uv)
+    result = subprocess.run(args=["uv", "--version"], stdout=subprocess.PIPE)
+
+    match_obj = re.search(r"uv (?P<uv_version>\d+.\d+.\d+)", result.stdout.decode())
+
+    if not match_obj:
+        uv_version = (0, 0, 0)
+    else:
+        uv_version_str = match_obj.group("uv_version")
+        uv_version = tuple(map(int, uv_version_str.split(".")))
+
+    # In versions before 0.7.7, uv lock needs to be run separately.
+    # See release notes for 0.7.7 here: https://github.com/astral-sh/uv/releases/tag/0.7.7
+    if uv_version < (0, 7, 7):
+        subprocess.run(
+            args=[uv, "lock"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
 
     logging.info("Updated version in pyproject.toml and uv.lock to %s", version)
 

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -24,11 +24,11 @@ PYPROJECT_TOML = BASE_DIR / "pyproject.toml"
 
 
 def calver(version_string: str) -> str:
-    """Validate that version string matches YYYY-MM-DD format."""
+    """Validate that version string matches YYYY.MM.DD format."""
     pattern = r"\d{4}\.\d{2}\.\d{2}"
     if not re.match(pattern, version_string):
         raise argparse.ArgumentTypeError(
-            f"Version must match format YYYY-MM-DD, got: {version_string}"
+            f"Version must match format YYYY.MM.DD, got: {version_string}"
         )
     return version_string
 

--- a/uv.lock
+++ b/uv.lock
@@ -785,7 +785,7 @@ wheels = [
 
 [[package]]
 name = "secure-record-transfer"
-version = "2025.5.30"
+version = "2025.7.7"
 source = { virtual = "." }
 dependencies = [
     { name = "bagit" },


### PR DESCRIPTION
Adds a script that can be used to update the version without having to manually update the `package.json`, `package-lock.json`, and `pyproject.toml` files.

Additionally, updates the version to `2025.07.07` for today's release.