### PR TITLE
Fix Group Description does not populate when returning to form

### DIFF
--- a/app/recordtransfer/static/recordtransfer/js/submission_form/submissionGroup.js
+++ b/app/recordtransfer/static/recordtransfer/js/submission_form/submissionGroup.js
@@ -12,6 +12,7 @@ const noDescription = "No description available";
  * @param {object} context - The context object containing URLs and element IDs for the form.
  */
 export async function setupSubmissionGroupForm(context) {
+    console.log("Setting up submission group form with context:", context);
     const selectField = document.getElementById(context["id_submission_group_selection"]);
     const groupDescDisplay = document.getElementById(context["id_display_group_description"]);
 
@@ -36,7 +37,7 @@ export async function setupSubmissionGroupForm(context) {
 
     // Select the default group at first
     selectGroup(context["default_group_uuid"], selectField);
-
+    updateGroupDescription(selectField, groupDescDisplay);
 }
 
 /**
@@ -73,23 +74,21 @@ const updateGroupDescription = (selectField, groupDescDisplay) => {
  * @param {object} context - The context object containing the URL to fetch group descriptions.
  */
 const fetchSubmissionGroups = async (context) => {
-    fetch(context["fetch_group_descriptions_url"], {
+    const response = await fetch(context["fetch_group_descriptions_url"], {
         method: "GET"
-    })
-        .then(response => {
-            if (!response.ok) {
-                return Promise.reject(response);
-            }
+    });
 
-            return response.json();
-        })
-        .then(groups => {
-            // Apply the group description to the data-description attribute of each option
-            groups.forEach(function (group) {
-                document.querySelector(`option[value='${group.uuid}']`)
-                    .setAttribute("data-description", group.description);
-            });
-        });
+    if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const groups = await response.json();
+
+    // Populate the select option data-attributes with the fetched group descriptions
+    groups.forEach(function (group) {
+        document.querySelector(`option[value='${group.uuid}']`)
+            .setAttribute("data-description", group.description);
+    });
 };
 
 /**

--- a/app/recordtransfer/static/recordtransfer/js/submission_form/submissionGroup.js
+++ b/app/recordtransfer/static/recordtransfer/js/submission_form/submissionGroup.js
@@ -12,7 +12,6 @@ const noDescription = "No description available";
  * @param {object} context - The context object containing URLs and element IDs for the form.
  */
 export async function setupSubmissionGroupForm(context) {
-    console.log("Setting up submission group form with context:", context);
     const selectField = document.getElementById(context["id_submission_group_selection"]);
     const groupDescDisplay = document.getElementById(context["id_display_group_description"]);
 


### PR DESCRIPTION
Closes #757

Although defined as an async function, `fetchSubmissionGroups` was not actually waiting on the fetch to resolve first (no await is used within . It was returning immediately, even before groups and group descriptions have been fetched & populated. `updateGroupDescription` was being called before `fetchSubmissionGroups` could resolve, meaning the selected option had no `data-attribute` populated.

I've fixed this so that `fetchSubmissionGroups` `await`s for a response before continuing, and updating the group description display upon form initialization.