### PR TITLE
Add permissions to workflows for unit tests and Ruff sync

### DIFF
--- a/.github/workflows/django-tests.yml
+++ b/.github/workflows/django-tests.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-ruff-config.yml
+++ b/.github/workflows/sync-ruff-config.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 0 * * 0" # Runs every week
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   sync-file:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #753

Sets explicit permissions for the unit test and Ruff config sync workflows