### PR TITLE
Fix Saving Form from Unsaved Changes Modal Does Not Work on Review Step

### DIFF
--- a/app/recordtransfer/templates/recordtransfer/submission_form_base.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_form_base.html
@@ -82,13 +82,14 @@
         </div>
         <div class="{% block savelinkclass %}flex-item{% endblock savelinkclass %}">
             <label></label>
-            {% if SHOW_SAVE_BUTTON %}
-                <button id="form-save-button"
-                        class="link link-primary"
-                        formnovalidate="formnovalidate"
-                        name="save_form_step"
-                        value="{{ wizard.steps.current }}">{% trans "Click to save form and resume later" %}</button>
-            {% endif %}
+            <button id="form-save-button"
+                    class="link link-primary"
+                    formnovalidate="formnovalidate"
+                    name="save_form_step"
+                    value="{{ wizard.steps.current }}"
+                    {% if not SHOW_SAVE_BUTTON %}hidden{% endif %}>
+                {% trans "Click to save form and resume later" %}
+            </button>
         </div>
     </form>
     {% include "includes/unsaved_changes_modal.html" %}

--- a/app/recordtransfer/tests/e2e/test_submission_form_e2e.py
+++ b/app/recordtransfer/tests/e2e/test_submission_form_e2e.py
@@ -7,10 +7,10 @@ from caais.models import RightsType, SourceRole, SourceType
 from django.conf import settings
 from django.test import override_settings, tag
 from django.urls import reverse
+from selenium.common.exceptions import StaleElementReferenceException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select, WebDriverWait
-from selenium.common.exceptions import StaleElementReferenceException
 
 from recordtransfer.enums import SubmissionStep
 from recordtransfer.models import User
@@ -465,7 +465,7 @@ class SubmissionFormWizardTest(SeleniumLiveServerTestCase):
         driver = self.driver
 
         # Navigate to the submission form wizard
-        driver.get(f"{self.live_server_url}/submission/")
+        driver.get(urljoin(self.live_server_url, reverse("recordtransfer:submit")))
 
         self.complete_legal_agreement_step()
         self.complete_contact_information_step()
@@ -592,7 +592,7 @@ class SubmissionFormWizardTest(SeleniumLiveServerTestCase):
         driver = self.driver
 
         # Navigate to the submission form wizard
-        driver.get(f"{self.live_server_url}/submission/")
+        driver.get(urljoin(self.live_server_url, reverse("recordtransfer:submit")))
 
         # Fill out the Legal Agreement step
         self.complete_legal_agreement_step()
@@ -900,7 +900,7 @@ class SubmissionFormWizardTest(SeleniumLiveServerTestCase):
         driver = self.driver
 
         # Navigate to the submission form wizard
-        driver.get(f"{self.live_server_url}/submission/")
+        driver.get(urljoin(self.live_server_url, reverse("recordtransfer:submit")))
 
         # Complete required steps before Rights step
         self.complete_legal_agreement_step()
@@ -1057,3 +1057,42 @@ class SubmissionFormWizardTest(SeleniumLiveServerTestCase):
             postal_or_zip_code_input.get_attribute("value"), data["postal_or_zip_code"]
         )
         self.assertEqual(country_input.get_attribute("value"), data["country"])
+
+    def test_form_save_from_unsaved_changes_modal_on_review_step(self) -> None:
+        """Test that the user can save the form from the unsaved changes modal on the Review
+        step.
+        """
+        driver = self.driver
+
+        # Complete the form till the Review step
+        self.complete_form_till_review_step()
+
+        # Wait for the Review step to load
+        WebDriverWait(driver, 5).until(
+            EC.presence_of_element_located((By.CLASS_NAME, "review-summary"))
+        )
+
+        # Attempt to navigate to Home page without saving
+        home_link = driver.find_element(By.ID, "nav-home")
+        driver.execute_script("arguments[0].click();", home_link)
+
+        # Check for unsaved changes modal
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located((By.ID, "unsaved_changes_modal"))
+        )
+
+        # Verify the modal is visible
+        modal = driver.find_element(By.ID, "unsaved_changes_modal")
+        self.assertTrue(modal.is_displayed())
+
+        # Wait for the buttons in the modal to be clickable
+        WebDriverWait(driver, 10).until(EC.element_to_be_clickable((By.ID, "modal-save-link")))
+
+        # Click on save button in the modal
+        save_button = driver.find_element(By.ID, "modal-save-link")
+        save_button.click()
+
+        # Check that user is redirected to the profile page
+        WebDriverWait(driver, 10).until(
+            EC.url_to_be(urljoin(self.live_server_url, reverse("recordtransfer:user_profile")))
+        )


### PR DESCRIPTION
Closes #776 

This issue is that the "Click to save form and resume later" button does not exist on the Review Step. The reason for this is that the user would not be interested in saving the form at the final Review Step.

However, the "Save form and resume later" button on the unsaved changes modal relies on the former button to perform the save. To address this, I've made it so that the "Click to save form and resume later" button is included as a hidden button in every step, and is displayed conditionally, so that it can still be used by the modal even when it's not visible.