### PR TITLE
Fix Submission Broken in Production

### DIFF
--- a/app/recordtransfer/static/recordtransfer/js/submission_form/index.js
+++ b/app/recordtransfer/static/recordtransfer/js/submission_form/index.js
@@ -55,8 +55,9 @@ export const initializeSubmissionForm = () => {
 
     const submitButton = document.getElementById("submit-form-btn");
     if (submitButton) {
-        submitButton.addEventListener("click", () => {
-            singleCaptchaFn();
+        submitButton.addEventListener("click", (event) => {
+            event.preventDefault(); // Prevent form submission
+            singleCaptchaFn(); // Let reCAPTCHA handle the submission after validation
         });
     }
 };

--- a/app/recordtransfer/templates/recordtransfer/submission_form_base.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_form_base.html
@@ -57,7 +57,7 @@
                     <button {% block submitbuttonattributes %}
                             id="form-next-button"
                             {% endblock submitbuttonattributes %}
-                            type="{% block submitbuttontype %}submit{% endblock submitbuttontype %}"
+                            type="submit"
                             class="btn btn-primary margin-right-30px">
                         {% if wizard.steps.step1 == wizard.steps.count %}
                             {% trans "Submit" %}

--- a/app/recordtransfer/templates/recordtransfer/submission_form_review.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_form_review.html
@@ -4,9 +4,6 @@
 {% block submitbuttonattributes %}
     id="submit-form-btn"
 {% endblock submitbuttonattributes %}
-{% block submitbuttontype %}
-    button
-{% endblock submitbuttontype %}
 {% block savelinkclass %}
     flex-med-width-item
 {% endblock savelinkclass %}


### PR DESCRIPTION
Closes #794 

The submit button was carrying out its default behaviour (submitting the form) when clicked on, without waiting for reCAPTCHA verification to be run first. This meant the reCAPTCHA (`g-recaptcha-response` ) field did not get a chance to be populated before submission, hence the validation error preventing submission.

I've fixed that by preventing the default behaviour of the button when clicked on.

One thing I'm not sure of is why the form managed to submit without issue in development.