### PR TITLE
Use cache mount for uv, fix prod permissions

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,7 @@
 FROM nikolaik/python-nodejs:python3.10-nodejs22-slim AS base
 
 ENV PYTHONUNBUFFERED=1
+ENV UV_LINK_MODE=copy
 ENV PROJ_DIR="/opt/secure-record-transfer/"
 ENV APP_DIR="/opt/secure-record-transfer/app/"
 
@@ -12,8 +13,10 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy uv-related files, and install Python dependencies
+# Uses a persistent cache mount for uv (see https://docs.astral.sh/uv/guides/integration/docker/#caching)
 COPY pyproject.toml uv.lock ${PROJ_DIR}
-RUN uv sync
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync
 
 # Install Node.js dependencies
 COPY package*.json ${PROJ_DIR}
@@ -60,6 +63,8 @@ ENTRYPOINT ["/opt/secure-record-transfer/entrypoint.sh"]
 
 FROM base AS builder
 
+ENV UV_LINK_MODE=copy
+
 # Install build tools for production dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -68,7 +73,9 @@ RUN apt-get update && \
     pkg-config
 
 # Install production dependencies (e.g., mysqlclient)
-RUN uv sync --extra prod
+# Compile byte code to improve startup time (see https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --extra prod --compile-bytecode
 
 
 FROM python:3.10-slim AS prod

--- a/Containerfile
+++ b/Containerfile
@@ -89,26 +89,18 @@ RUN useradd --create-home --uid 1000 myuser && \
     mkdir -p ${APP_DIR} && \
     chown -R myuser:myuser ${PROJ_DIR}
 
-
 # Install required dependencies for mysqlclient and curl for health checks
+# Allow myuser to fix permissions on static and media volumes with sudo
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends default-mysql-client curl && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends default-mysql-client curl sudo && \
+    rm -rf /var/lib/apt/lists/* && \
+    echo "myuser ALL=(ALL) NOPASSWD: /usr/bin/chown -R myuser\\:myuser /opt/secure-record-transfer/app/static/" >> /etc/sudoers && \
+    echo "myuser ALL=(ALL) NOPASSWD: /usr/bin/chown -R myuser\\:myuser /opt/secure-record-transfer/app/media/" >> /etc/sudoers
 
-COPY --from=builder ${PROJ_DIR}/entrypoint.sh ${PROJ_DIR}/entrypoint.sh
-COPY --from=builder ${PROJ_DIR}/.venv ${PROJ_DIR}/.venv
-COPY --from=builder ${PROJ_DIR}/dist ${PROJ_DIR}/dist
-COPY --from=builder ${APP_DIR} ${APP_DIR}
-
-# Set ownership and secure permissions AFTER copying files
-RUN chown -R myuser:myuser ${PROJ_DIR} && \
-    find ${PROJ_DIR} -type d -exec chmod 755 {} + && \
-    find ${PROJ_DIR} -type f -exec chmod 644 {} + && \
-    chmod +x ${PROJ_DIR}/entrypoint.sh && \
-    chmod +x ${PROJ_DIR}/.venv/bin/* && \
-    mkdir -p ${APP_DIR}/static ${APP_DIR}/media && \
-    chown myuser:myuser ${APP_DIR}/static ${APP_DIR}/media && \
-    chmod 775 ${APP_DIR}/static ${APP_DIR}/media
+COPY --from=builder --chown=myuser:myuser ${PROJ_DIR}/entrypoint.sh ${PROJ_DIR}/entrypoint.sh
+COPY --from=builder --chown=myuser:myuser ${PROJ_DIR}/.venv ${PROJ_DIR}/.venv
+COPY --from=builder --chown=myuser:myuser ${PROJ_DIR}/dist ${PROJ_DIR}/dist
+COPY --from=builder --chown=myuser:myuser ${APP_DIR} ${APP_DIR}
 
 # Activate virtual environment
 ENV PATH="${PROJ_DIR}/.venv/bin:$PATH"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -21,6 +21,11 @@ elif [ "$SERVICE_NAME" = 'rq-scheduler' ]; then
 
 elif [ "$SERVICE_NAME" = 'app' ]; then
   if [ "$ENV" != 'dev' ]; then
+    echo ">> Fixing volume permissions."
+    sudo chown -R myuser:myuser /opt/secure-record-transfer/app/static/
+    sudo chown -R myuser:myuser /opt/secure-record-transfer/app/media/
+    echo "OK"
+
     echo ">> Collecting static files."
     python manage.py collectstatic --no-input --clear \
       --ignore "recordtransfer/**/*.js" \


### PR DESCRIPTION
Closes #797

A persistent cache mount is now used for `uv` which notably speeds it up.

Additionally, I was struggling with the file permissions in the production container again due to the named volume being given the permissions `root:root` by default. This change fixes that by allowing the permissions to be changed after the `app` container starts.