### PR TITLE
Fix Exporting of Submissions from SubmissionAdmin

### DIFF
--- a/app/recordtransfer/admin.py
+++ b/app/recordtransfer/admin.py
@@ -589,40 +589,35 @@ class SubmissionAdmin(admin.ModelAdmin):
     @admin.action(description=gettext("Export CAAIS 1.0 CSV for Submissions in Selected"))
     def export_caais_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponseRedirect:
         """Export CAAIS 1.0 CSV for submissions in the selected queryset."""
-        related_submissions = Submission.objects.filter(part_of_group__in=queryset)
-        return related_submissions.export_csv(version=ExportVersion.CAAIS_1_0)
+        return queryset.export_csv(version=ExportVersion.CAAIS_1_0)
 
     @admin.action(description=gettext("Export AtoM 2.6 Accession CSV for Submissions in Selected"))
     def export_atom_2_6_csv(
         self, request: HttpRequest, queryset: QuerySet
     ) -> HttpResponseRedirect:
         """Export AtoM 2.6 Accession CSV for submissions in the selected queryset."""
-        related_submissions = Submission.objects.filter(part_of_group__in=queryset)
-        return related_submissions.export_csv(version=ExportVersion.ATOM_2_6)
+        return queryset.export_csv(version=ExportVersion.ATOM_2_6)
 
     @admin.action(description=gettext("Export AtoM 2.3 Accession CSV for Submissions in Selected"))
     def export_atom_2_3_csv(
         self, request: HttpRequest, queryset: QuerySet
     ) -> HttpResponseRedirect:
         """Export AtoM 2.3 Accession CSV for submissions in the selected queryset."""
-        related_submissions = Submission.objects.filter(part_of_group__in=queryset)
-        return related_submissions.export_csv(version=ExportVersion.ATOM_2_3)
+        return queryset.export_csv(version=ExportVersion.ATOM_2_3)
 
     @admin.action(description=gettext("Export AtoM 2.2 Accession CSV for Submissions in Selected"))
     def export_atom_2_2_csv(
         self, request: HttpRequest, queryset: QuerySet
     ) -> HttpResponseRedirect:
         """Export AtoM 2.2 Accession CSV for submissions in the selected queryset."""
-        related_submissions = Submission.objects.filter(part_of_group__in=queryset)
-        return related_submissions.export_csv(version=ExportVersion.ATOM_2_2)
+        return queryset.export_csv(version=ExportVersion.ATOM_2_2)
 
     @admin.action(description=gettext("Export AtoM 2.1 Accession CSV for Submissions in Selected"))
     def export_atom_2_1_csv(
         self, request: HttpRequest, queryset: QuerySet
     ) -> HttpResponseRedirect:
         """Export AtoM 2.1 Accession CSV for submissions in the selected queryset."""
-        related_submissions = Submission.objects.filter(part_of_group__in=queryset)
-        return related_submissions.export_csv(version=ExportVersion.ATOM_2_1)
+        return queryset.export_csv(version=ExportVersion.ATOM_2_1)
 
 
 @admin.register(Job)


### PR DESCRIPTION
Closes #809 

The `Submission` queryset received in an action should be used directly by calling `export_csv()` on it. The prior filtering only makes sense for a queryset of `SubmissionGroup`s.