### PR TITLE
Replace `clamd` with `clamav-client`, make scan limits configurable

### DIFF
--- a/app/clamav/connection.py
+++ b/app/clamav/connection.py
@@ -1,32 +1,16 @@
 from typing import Optional
 
-import clamd
+from clamav_client import clamd
 
 from . import settings
 
 
 def get_clamd_socket() -> Optional[clamd.ClamdNetworkSocket]:
-    ''' Return a socket that can be used to communicate with clamd over the network.
+    """Return a socket that can be used to communicate with clamd over the network.
 
     Returns:
-        (Optional[clamd.ClamdNetworkSocket]):
-            None if CLAMAV_ENABLED is False, otherwise, the connection object
-    '''
+        None if :ref:`CLAMAV_ENABLED` is False, otherwise, the connection object
+    """
     if not settings.CLAMAV_ENABLED:
         return None
     return clamd.ClamdNetworkSocket(settings.CLAMAV_HOST, settings.CLAMAV_PORT)
-
-
-def test_connection() -> bool:
-    ''' Test whether Clamd can be connected to over the network.
-
-    Returns:
-        (bool): True if connection is OK, False if connection could not be made
-    '''
-    if not settings.CLAMAV_ENABLED:
-        return True
-    try:
-        get_clamd_socket().ping()
-        return True
-    except clamd.ClamdError:
-        return False

--- a/app/clamav/scan.py
+++ b/app/clamav/scan.py
@@ -13,7 +13,7 @@ LOGGER = logging.getLogger(__name__)
 def check_for_malware(file: UploadedFile) -> None:
     """Scan the file for malware.
 
-    If CLAMAV_ENABLED is False, return early.
+    If :ref:`CLAMAV_ENABLED` is False, return early.
 
     Raises:
         ValidationError: If the file contains malware.

--- a/app/clamav/scan.py
+++ b/app/clamav/scan.py
@@ -1,41 +1,47 @@
 import logging
+from typing import BinaryIO, cast
 
-import clamd
-
+from clamav_client import clamd
 from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import UploadedFile
 
-from . import settings
-from . import connection
+from . import connection, settings
+
+LOGGER = logging.getLogger("clamav")
 
 
-LOGGER = logging.getLogger('clamav')
-
-
-def check_for_malware(file):
-    ''' Scan the file for malware. If malware is found, a ValidationError is raised.
+def check_for_malware(file: UploadedFile) -> None:
+    """Scan the file for malware. If malware is found, a ValidationError is raised.
 
     If CLAMAV_ENABLED is False, return early.
-    '''
+    """
     if not settings.CLAMAV_ENABLED:
         return
 
     socket = connection.get_clamd_socket()
 
+    if not socket:
+        raise ConnectionError("Connection to ClamAV could not be established.")
+
     file.seek(0)
 
     try:
-        output = socket.instream(file)
-        status, reason = output['stream']
+        output = socket.instream(cast(BinaryIO, file))
+        status, reason = output["stream"]
 
-        if status != 'OK':
-            LOGGER.warning('The given file contains Malware! Status: %s, Reason: %s', status, reason)
-            raise ValidationError(f'File contained malware. Reason: {reason}')
+        if status != "OK":
+            LOGGER.warning(
+                "The given file contains Malware! Status: %s, Reason: %s", status, reason
+            )
+            raise ValidationError(f"File contained malware. Reason: {reason}")
 
     except clamd.BufferTooLongError as exc:
-        LOGGER.error('File is too large to be read by ClamAV! %d bytes were read', file.tell(), exc_info=exc)
+        LOGGER.error(
+            "File is too large to be read by ClamAV! %d bytes were read", file.tell(), exc_info=exc
+        )
 
-    except clamd.ConnectionError as exc:
-        LOGGER.error('ConnectionError occurred connecting to ClamAV!', exc_info=exc)
+    except clamd.CommunicationError as exc:
+        LOGGER.error("CommunicationError occurred connecting to ClamAV!", exc_info=exc)
 
     # Return file pointer to beginning
     file.seek(0)

--- a/app/clamav/scan.py
+++ b/app/clamav/scan.py
@@ -13,7 +13,7 @@ LOGGER = logging.getLogger(__name__)
 def check_for_malware(file: UploadedFile) -> None:
     """Scan the file for malware. If malware is found, a ValidationError is raised.
 
-    If CLAMAV_ENABLED is False, return early.
+    If :ref:`CLAMAV_ENABLED` is False, return early.
     """
     if not settings.CLAMAV_ENABLED:
         return

--- a/app/clamav/scan.py
+++ b/app/clamav/scan.py
@@ -39,9 +39,13 @@ def check_for_malware(file: UploadedFile) -> None:
         LOGGER.error(
             "File is too large to be read by ClamAV! %d bytes were read", file.tell(), exc_info=exc
         )
+        raise ValueError("File is too large to scan for malware") from exc
 
     except clamd.CommunicationError as exc:
         LOGGER.error("CommunicationError occurred connecting to ClamAV!", exc_info=exc)
+        raise ConnectionError(
+            "Unable to scan file for malware due to scanner communication error"
+        ) from exc
 
     # Return file pointer to beginning
     file.seek(0)

--- a/app/clamav/scan.py
+++ b/app/clamav/scan.py
@@ -11,9 +11,15 @@ LOGGER = logging.getLogger(__name__)
 
 
 def check_for_malware(file: UploadedFile) -> None:
-    """Scan the file for malware. If malware is found, a ValidationError is raised.
+    """Scan the file for malware.
 
-    If :ref:`CLAMAV_ENABLED` is False, return early.
+    If CLAMAV_ENABLED is False, return early.
+
+    Raises:
+        ValidationError: If the file contains malware.
+        ConnectionError: If the connection to ClamAV cannot be established or if there is a
+        communication error.
+        ValueError: If the file is too large to be scanned.
     """
     if not settings.CLAMAV_ENABLED:
         return

--- a/app/clamav/scan.py
+++ b/app/clamav/scan.py
@@ -7,7 +7,7 @@ from django.core.files.uploadedfile import UploadedFile
 
 from . import connection, settings
 
-LOGGER = logging.getLogger("clamav")
+LOGGER = logging.getLogger(__name__)
 
 
 def check_for_malware(file: UploadedFile) -> None:

--- a/app/recordtransfer/views/media.py
+++ b/app/recordtransfer/views/media.py
@@ -98,8 +98,8 @@ def upload_or_list_files(request: HttpRequest, session_token: str) -> JsonRespon
     file is added to the upload session using the session token passed as a parameter in the
     request. If a session token is invalid, an error message is returned.
 
-    The file type is checked against this application's ACCEPTED_FILE_FORMATS setting, if the
-    file is not an accepted type, an error message is returned.
+    The file type is checked against this application's :ref:`ACCEPTED_FILE_FORMATS` setting, if
+    the file is not an accepted type, an error message is returned.
 
     Args:
         request: The HTTP GET or POST request

--- a/app/recordtransfer/views/media.py
+++ b/app/recordtransfer/views/media.py
@@ -123,92 +123,9 @@ def upload_or_list_files(request: HttpRequest, session_token: str) -> JsonRespon
             )
 
         if request.method == "GET":
-            file_metadata = [
-                {"name": f.name, "size": f.file_upload.size, "url": f.get_file_access_url()}
-                for f in session.get_uploads()
-            ]
-
-            return JsonResponse({"files": file_metadata}, status=200)
+            return _handle_list_files(session)
         else:
-            _file = request.FILES.get("file")
-            if not _file:
-                return JsonResponse(
-                    {
-                        "uploadSessionToken": session.token,
-                        "error": gettext("No file was uploaded"),
-                    },
-                    status=400,
-                )
-
-            file_check = accept_file(_file.name, _file.size)
-            if not file_check["accepted"]:
-                return JsonResponse(
-                    {"file": _file.name, "uploadSessionToken": session.token, **file_check},
-                    status=400,
-                )
-
-            session_check = accept_session(_file.name, _file.size, session)
-            if not session_check["accepted"]:
-                return JsonResponse(
-                    {"file": _file.name, "uploadSessionToken": session.token, **session_check},
-                    status=400,
-                )
-
-            try:
-                check_for_malware(_file)
-            except ValidationError as exc:
-                LOGGER.error("Malware was found in the file %s", _file.name, exc_info=exc)
-                return JsonResponse(
-                    {
-                        "file": _file.name,
-                        "accepted": False,
-                        "uploadSessionToken": session.token,
-                        "error": gettext(f'Malware was detected in the file "{_file.name}"'),
-                    },
-                    status=400,
-                )
-            except ValueError as exc:
-                LOGGER.error("File too large for malware scanning: %s", _file.name, exc_info=exc)
-                return JsonResponse({
-                    "file": _file.name,
-                    "accepted": False,
-                    "uploadSessionToken": session.token,
-                    "error": gettext(f'File "{_file.name}" is too large to scan for malware'),
-                }, status=400)
-            except ConnectionError as exc:
-                LOGGER.error("ClamAV connection error for file %s", _file.name, exc_info=exc)
-                return JsonResponse({
-                    "file": _file.name,
-                    "accepted": False,
-                    "uploadSessionToken": session.token,
-                    "error": gettext("Unable to scan file for malware due to scanner error"),
-                }, status=500)
-
-            try:
-                uploaded_file = session.add_temp_file(_file)
-            except ValueError as exc:
-                LOGGER.error("Error adding file to session: %s", str(exc), exc_info=exc)
-                return JsonResponse(
-                    {
-                        "file": _file.name,
-                        "accepted": False,
-                        "uploadSessionToken": session.token,
-                        "error": gettext("There was an error uploading the file"),
-                    },
-                    status=500,
-                )
-
-            file_url = uploaded_file.get_file_access_url()
-
-            return JsonResponse(
-                {
-                    "file": _file.name,
-                    "accepted": True,
-                    "uploadSessionToken": session.token,
-                    "url": file_url,
-                },
-                status=200,
-            )
+            return _handle_upload_file(request, session)
 
     except Exception as exc:
         LOGGER.error("Uncaught exception in upload_file view: %s", str(exc), exc_info=exc)
@@ -218,6 +135,94 @@ def upload_or_list_files(request: HttpRequest, session_token: str) -> JsonRespon
             },
             status=500,
         )
+
+def _handle_list_files(session: UploadSession) -> JsonResponse:
+    file_metadata = [
+        {"name": f.name, "size": f.file_upload.size, "url": f.get_file_access_url()}
+        for f in session.get_uploads()
+    ]
+    return JsonResponse({"files": file_metadata}, status=200)
+
+def _handle_upload_file(request: HttpRequest, session: UploadSession) -> JsonResponse:
+    _file = request.FILES.get("file")
+    if not _file:
+        return JsonResponse(
+            {
+                "uploadSessionToken": session.token,
+                "error": gettext("No file was uploaded"),
+            },
+            status=400,
+        )
+
+    file_check = accept_file(_file.name, _file.size)
+    if not file_check["accepted"]:
+        return JsonResponse(
+            {"file": _file.name, "uploadSessionToken": session.token, **file_check},
+            status=400,
+        )
+
+    session_check = accept_session(_file.name, _file.size, session)
+    if not session_check["accepted"]:
+        return JsonResponse(
+            {"file": _file.name, "uploadSessionToken": session.token, **session_check},
+            status=400,
+        )
+
+    try:
+        check_for_malware(_file)
+    except ValidationError as exc:
+        LOGGER.error("Malware was found in the file %s", _file.name, exc_info=exc)
+        return JsonResponse(
+            {
+                "file": _file.name,
+                "accepted": False,
+                "uploadSessionToken": session.token,
+                "error": gettext(f'Malware was detected in the file "{_file.name}"'),
+            },
+            status=400,
+        )
+    except ValueError as exc:
+        LOGGER.error("File too large for malware scanning: %s", _file.name, exc_info=exc)
+        return JsonResponse({
+            "file": _file.name,
+            "accepted": False,
+            "uploadSessionToken": session.token,
+            "error": gettext(f'File "{_file.name}" is too large to scan for malware'),
+        }, status=400)
+    except ConnectionError as exc:
+        LOGGER.error("ClamAV connection error for file %s", _file.name, exc_info=exc)
+        return JsonResponse({
+            "file": _file.name,
+            "accepted": False,
+            "uploadSessionToken": session.token,
+            "error": gettext("Unable to scan file for malware due to scanner error"),
+        }, status=500)
+
+    try:
+        uploaded_file = session.add_temp_file(_file)
+    except ValueError as exc:
+        LOGGER.error("Error adding file to session: %s", str(exc), exc_info=exc)
+        return JsonResponse(
+            {
+                "file": _file.name,
+                "accepted": False,
+                "uploadSessionToken": session.token,
+                "error": gettext("There was an error uploading the file"),
+            },
+            status=500,
+        )
+
+    file_url = uploaded_file.get_file_access_url()
+
+    return JsonResponse(
+        {
+            "file": _file.name,
+            "accepted": True,
+            "uploadSessionToken": session.token,
+            "url": file_url,
+        },
+        status=200,
+    )
 
 
 @require_http_methods(["DELETE", "GET"])

--- a/app/recordtransfer/views/media.py
+++ b/app/recordtransfer/views/media.py
@@ -167,6 +167,22 @@ def upload_or_list_files(request: HttpRequest, session_token: str) -> JsonRespon
                     },
                     status=400,
                 )
+            except ValueError as exc:
+                LOGGER.error("File too large for malware scanning: %s", _file.name, exc_info=exc)
+                return JsonResponse({
+                    "file": _file.name,
+                    "accepted": False,
+                    "uploadSessionToken": session.token,
+                    "error": gettext(f'File "{_file.name}" is too large to scan for malware'),
+                }, status=400)
+            except ConnectionError as exc:
+                LOGGER.error("ClamAV connection error for file %s", _file.name, exc_info=exc)
+                return JsonResponse({
+                    "file": _file.name,
+                    "accepted": False,
+                    "uploadSessionToken": session.token,
+                    "error": gettext("Unable to scan file for malware due to scanner error"),
+                }, status=500)
 
             try:
                 uploaded_file = session.add_temp_file(_file)

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -7,8 +7,6 @@ services:
     ports:
       - 3310:3310
     entrypoint: ["/etc/clamav/entrypoint.sh"]
-    env_file:
-      - .prod.env
     volumes:
       - ./docker/clamav/entrypoint.sh:/etc/clamav/entrypoint.sh:z
       - ./docker/clamav/clamd.conf.template:/etc/clamav/clamd.conf.template:z

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,11 +1,17 @@
 services:
   clamav:
-    image: docker.io/clamav/clamav-debian
+    build:
+      context: ./docker/clamav
+    image: custom-clamav
     container_name: recordtransfer_clamav
     ports:
       - 3310:3310
+    entrypoint: ["/etc/clamav/entrypoint.sh"]
+    env_file:
+      - .prod.env
     volumes:
-      - ./docker/clamav/clamd.conf:/etc/clamav/clamd.conf:z
+      - ./docker/clamav/entrypoint.sh:/etc/clamav/entrypoint.sh:z
+      - ./docker/clamav/clamd.conf.template:/etc/clamav/clamd.conf.template:z
       - ./docker/clamav/freshclam.conf:/etc/clamav/freshclam.conf:z
       - clamav-virusdb:/var/lib/clamav
       - temp-directory:/tmp

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,8 +1,6 @@
 services:
   clamav:
-    build:
-      context: ./docker/clamav
-    image: custom-clamav
+    image: docker.io/clamav/clamav-debian
     container_name: recordtransfer_clamav
     ports:
       - 3310:3310

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,8 +1,6 @@
 services:
   clamav:
-    build:
-      context: ./docker/clamav
-    image: custom-clamav
+    image: docker.io/clamav/clamav-debian
     restart: unless-stopped
     entrypoint: ["/etc/clamav/entrypoint.sh"]
     env_file:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -9,10 +9,10 @@ services:
       - .prod.env
     volumes:
       - ./docker/clamav/entrypoint.sh:/etc/clamav/entrypoint.sh:z
-      - clamav-virusdb:/var/lib/clamav
-      - temp-directory:/tmp
       - ./docker/clamav/clamd.conf.template:/etc/clamav/clamd.conf.template:z
       - ./docker/clamav/freshclam.conf:/etc/clamav/freshclam.conf:z
+      - clamav-virusdb:/var/lib/clamav
+      - temp-directory:/tmp
 
   redis:
     image: docker.io/redis:8-alpine

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,11 +1,17 @@
 services:
   clamav:
-    image: docker.io/clamav/clamav-debian
+    build:
+      context: ./docker/clamav
+    image: custom-clamav
     restart: unless-stopped
+    entrypoint: ["/etc/clamav/entrypoint.sh"]
+    env_file:
+      - .prod.env
     volumes:
+      - ./docker/clamav/entrypoint.sh:/etc/clamav/entrypoint.sh:z
       - clamav-virusdb:/var/lib/clamav
       - temp-directory:/tmp
-      - ./docker/clamav/clamd.conf:/etc/clamav/clamd.conf:z
+      - ./docker/clamav/clamd.conf.template:/etc/clamav/clamd.conf.template:z
       - ./docker/clamav/freshclam.conf:/etc/clamav/freshclam.conf:z
 
   redis:

--- a/docker/clamav/Dockerfile
+++ b/docker/clamav/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.io/clamav/clamav-debian
+
+# Install gettext for envsubst
+RUN apt-get update && apt-get install -y gettext && rm -rf /var/lib/apt/lists/*

--- a/docker/clamav/Dockerfile
+++ b/docker/clamav/Dockerfile
@@ -1,3 +1,6 @@
+# This is a custom image for Debian-based ClamAV, but with gettext installed
+# to allow for environment variable substitution in configuration files.
+
 FROM docker.io/clamav/clamav-debian
 
 # Install gettext for envsubst

--- a/docker/clamav/Dockerfile
+++ b/docker/clamav/Dockerfile
@@ -1,7 +1,0 @@
-# This is a custom image for Debian-based ClamAV, but with gettext installed
-# to allow for environment variable substitution in configuration files.
-
-FROM docker.io/clamav/clamav-debian
-
-# Install gettext for envsubst
-RUN apt-get update && apt-get install -y gettext && rm -rf /var/lib/apt/lists/*

--- a/docker/clamav/clamd.conf.template
+++ b/docker/clamav/clamd.conf.template
@@ -47,8 +47,8 @@ ScanArchive yes
 # Scan
 ###############
 
-MaxScanSize 300M
-MaxFileSize 100M
+MaxFileSize ${MAX_SINGLE_UPLOAD_SIZE_MB}M
+MaxScanSize ${MAX_SINGLE_UPLOAD_SIZE_MB}M
 MaxRecursion 30
 MaxFiles 50000
 MaxEmbeddedPE 40M

--- a/docker/clamav/entrypoint.sh
+++ b/docker/clamav/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 export MAX_SINGLE_UPLOAD_SIZE_MB="${MAX_SINGLE_UPLOAD_SIZE_MB:-64}"
 
 echo "Generating ClamAV configuration from template..."
-envsubst < /etc/clamav/clamd.conf.template > /etc/clamav/clamd.conf
+sed "s/\${MAX_SINGLE_UPLOAD_SIZE_MB}/$MAX_SINGLE_UPLOAD_SIZE_MB/g" /etc/clamav/clamd.conf.template > /etc/clamav/clamd.conf
 
 # Execute the original entrypoint command
 exec /init

--- a/docker/clamav/entrypoint.sh
+++ b/docker/clamav/entrypoint.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 set -e
 
-# Generate the actual config from template using environment variables
+# Set default if not provided
+export MAX_SINGLE_UPLOAD_SIZE_MB="${MAX_SINGLE_UPLOAD_SIZE_MB:-64}"
+
 echo "Generating ClamAV configuration from template..."
 envsubst < /etc/clamav/clamd.conf.template > /etc/clamav/clamd.conf
 
-if [ $# -eq 0 ]; then
-  exec /init
-else
-  exec "$@"
-fi
+# Execute the original entrypoint command
+exec /init

--- a/docker/clamav/entrypoint.sh
+++ b/docker/clamav/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Generate the actual config from template using environment variables
+echo "Generating ClamAV configuration from template..."
+envsubst < /etc/clamav/clamd.conf.template > /etc/clamav/clamd.conf
+
+if [ $# -eq 0 ]; then
+  exec /init
+else
+  exec "$@"
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "GPL-3.0-or-later"
 license-files = ["LICENSE"]
 dependencies = [
     "bagit>=1.8.1,<2",
-    "clamd>=1.0.2,<2",
+    "clamav-client>=0.7.1,<1",
     "dateparser>=1.2.0,<2",
     "debugpy>=1.8.2,<2",
     "Django==4.2.*",

--- a/uv.lock
+++ b/uv.lock
@@ -119,12 +119,12 @@ wheels = [
 ]
 
 [[package]]
-name = "clamd"
-version = "1.0.2"
+name = "clamav-client"
+version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/14/8b/55332f1f79f28a5ccc50f66364087e64fae8e4ed62e52007ca82b3072221/clamd-1.0.2.tar.gz", hash = "sha256:d82a2fd814684a35a1b31feadafb2e69c8ebde9403613f6bdaa5d877c0f29560", size = 8218, upload-time = "2014-08-21T14:58:18.562Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/2c/7b138ece9c42002e437f64056a5fb1ad9a2bb84049f338f856334a378d85/clamav_client-0.7.1.tar.gz", hash = "sha256:4a60e1499edc15859045a7a04e15628d670664fde01ed96740bfcbb241ebb5a5", size = 35196, upload-time = "2025-05-15T18:06:28.629Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/d0/84614de2a53ad52370adc9f9260bea420e53e0c228a248ec0eacfa65ccbb/clamd-1.0.2-py2.py3-none-any.whl", hash = "sha256:5c32546b7d1eb00fd6be00a889d79e00fbf980ed082826ccfa369bce3dcff5e7", size = 6684, upload-time = "2014-08-21T14:58:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e6/063622e1e2ec9968a3e711aa9961d32a50e9b74a90eead61f698cf92a11f/clamav_client-0.7.1-py3-none-any.whl", hash = "sha256:2230a95c12fa3d52a51e5229567adab8739a244e91dfc873564d923ff72feda5", size = 14406, upload-time = "2025-05-15T18:06:26.904Z" },
 ]
 
 [[package]]
@@ -789,7 +789,7 @@ version = "2025.7.7"
 source = { virtual = "." }
 dependencies = [
     { name = "bagit" },
-    { name = "clamd" },
+    { name = "clamav-client" },
     { name = "dateparser" },
     { name = "debugpy" },
     { name = "django" },
@@ -831,7 +831,7 @@ prod = [
 [package.metadata]
 requires-dist = [
     { name = "bagit", specifier = ">=1.8.1,<2" },
-    { name = "clamd", specifier = ">=1.0.2,<2" },
+    { name = "clamav-client", specifier = ">=0.7.1,<1" },
     { name = "dateparser", specifier = ">=1.2.0,<2" },
     { name = "debugpy", specifier = ">=1.8.2,<2" },
     { name = "django", specifier = "==4.2.*" },

--- a/uv.lock
+++ b/uv.lock
@@ -828,7 +828,7 @@ prod = [
 [package.metadata]
 requires-dist = [
     { name = "bagit", specifier = ">=1.9.0,<2" },
-    { name = "clamd", specifier = ">=1.0.2,<2" },
+    { name = "clamav-client", specifier = ">=0.7.1,<1" },
     { name = "dateparser", specifier = ">=1.2.0,<2" },
     { name = "debugpy", specifier = ">=1.8.2,<2" },
     { name = "django", specifier = "==4.2.*" },


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/813

Change notes:
- Raised relevant errors from `check_for_malware` and handled errors properly in `views.media.upload_or_list_files`
- Made ClamAV scan limits (see https://linux.die.net/man/5/clamd.conf) configurable using `envsubst`. I had to create a custom clamav image and install `gettext` (which comes with `envsubst`) in it to make this happen. This is unlike the `nginx` image, which already comes with `envsubst` installed, and variable replacement logic.