### PR TITLE
Fix login redirects being ignored

### DIFF
--- a/app/app/urls.py
+++ b/app/app/urls.py
@@ -30,7 +30,7 @@ urlpatterns = [
     # Override the login view with redirect behavior
     path(
         "account/login/",
-        Login.as_view(redirect_authenticated_user=True),
+        Login.as_view(),
         name="login",
     ),
     path("account/", include("django.contrib.auth.urls")),

--- a/app/recordtransfer/templates/registration/login.html
+++ b/app/recordtransfer/templates/registration/login.html
@@ -13,7 +13,7 @@
             <!-- Form -->
             <div id="login-form-container">
                 <form class="space-y-4"
-                      hx-post="{% url 'login' %}"
+                      hx-post="{% url 'login' %}?next={{ next }}"
                       hx-target="#login-error-container"
                       hx-swap="innerHTML">
                     {% csrf_token %}

--- a/app/recordtransfer/tests/unit/views/test_account.py
+++ b/app/recordtransfer/tests/unit/views/test_account.py
@@ -4,12 +4,12 @@ import logging
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import AuthenticationForm
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
-from django.contrib.auth.forms import AuthenticationForm
 from recordtransfer.forms import SignUpForm
 from recordtransfer.tokens import account_activation_token
 
@@ -598,3 +598,15 @@ class TestLogin(TestCase):
         response = self.client.get(self.login_url)
         # Should redirect to index
         self.assertRedirects(response, reverse("recordtransfer:index"))
+
+    def test_redirect_to_next_parameter(self) -> None:
+        """Test that login redirects to next parameter if provided."""
+        next_url = reverse("recordtransfer:user_profile")
+        response = self.client.post(self.login_url + f"?next={next_url}", self.valid_credentials)
+
+        # Should redirect to the next URL
+        self.assertRedirects(response, next_url)
+
+        # User should be authenticated
+        self.assertTrue(response.wsgi_request.user.is_authenticated)
+        self.assertEqual(response.wsgi_request.user.username, "testloginuser")

--- a/app/recordtransfer/views/account.py
+++ b/app/recordtransfer/views/account.py
@@ -43,16 +43,14 @@ class CreateAccount(FormView):
         new_user.gets_submission_email_updates = False
         new_user.save()
         send_user_activation_email.delay(new_user)
-        if self.request.headers.get("HX-Request"):
-            response = HttpResponse()
-            response["HX-Redirect"] = self.get_success_url()
-            return response
+        if self.request.htmx:
+            return HttpResponseClientRedirect(self.get_success_url())
 
         return super().form_valid(form)
 
     def form_invalid(self, form: BaseModelForm) -> HttpResponse:
         """Handle invalid signup form submissions."""
-        if self.request.headers.get("HX-Request"):
+        if self.request.htmx:
             # Return only the error template for HTMX requests
             html = render_to_string(
                 "recordtransfer/signup_form.html",

--- a/app/recordtransfer/views/account.py
+++ b/app/recordtransfer/views/account.py
@@ -12,6 +12,7 @@ from django.utils.encoding import force_str
 from django.utils.http import urlsafe_base64_decode
 from django.views import View
 from django.views.generic import FormView, TemplateView
+from django_htmx.http import HttpResponseClientRedirect
 
 from recordtransfer.emails import send_user_activation_email
 from recordtransfer.forms import SignUpForm
@@ -112,19 +113,18 @@ class Login(LoginView):
     """Custom LoginView that supports HTMX requests for login forms."""
 
     template_name = "registration/login.html"
+    redirect_authenticated_user=True
 
     def form_valid(self, form: AuthenticationForm) -> HttpResponse:
-        """Successful login handler."""
+        """Handle successful login."""
         super().form_valid(form)
-        if self.request.headers.get("HX-Request"):
-            response = HttpResponse()
-            response["HX-Redirect"] = self.get_success_url()
-            return response
+        if self.request.htmx:
+            return HttpResponseClientRedirect(self.get_success_url())
         return redirect(self.get_success_url())
 
     def form_invalid(self, form: AuthenticationForm) -> HttpResponse:
         """Handle invalid login form submissions."""
-        if self.request.headers.get("HX-Request"):
+        if self.request.htmx:
             html = render_to_string(
                 "registration/login_errors.html",  # Changed to form-only template
                 {"form": form},


### PR DESCRIPTION
Closes #850 

The main issue was that the URL to which the login form data was posted to did not include the `?next=` query parameter.