### PR TITLE
Compile messages on app start

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ example.dev.env
 example.prod.env
 node_modules
 ./static/
+*.mo

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,3 @@ example.dev.env
 example.prod.env
 node_modules
 ./static/
-*.mo

--- a/Containerfile
+++ b/Containerfile
@@ -25,9 +25,6 @@ RUN npm install --no-color
 # Copy application code to image
 COPY ./app ${APP_DIR}
 
-# Compile .mo files
-RUN uv run python app/manage.py compilemessages --ignore .venv
-
 # Make arg passed from compose files into environment variable
 ARG WEBPACK_MODE
 ENV WEBPACK_MODE ${WEBPACK_MODE}

--- a/Containerfile
+++ b/Containerfile
@@ -92,7 +92,7 @@ RUN useradd --create-home --uid 1000 myuser && \
 # Install required dependencies for mysqlclient and curl for health checks
 # Allow myuser to fix permissions on static and media volumes with sudo
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends default-mysql-client curl sudo && \
+    apt-get install -y --no-install-recommends default-mysql-client curl sudo gettext && \
     rm -rf /var/lib/apt/lists/* && \
     echo "myuser ALL=(ALL) NOPASSWD: /usr/bin/chown -R myuser\\:myuser /opt/secure-record-transfer/app/static/" >> /etc/sudoers && \
     echo "myuser ALL=(ALL) NOPASSWD: /usr/bin/chown -R myuser\\:myuser /opt/secure-record-transfer/app/media/" >> /etc/sudoers

--- a/Containerfile
+++ b/Containerfile
@@ -25,6 +25,9 @@ RUN npm install --no-color
 # Copy application code to image
 COPY ./app ${APP_DIR}
 
+# Compile .mo files
+RUN uv run python app/manage.py compilemessages --ignore .venv
+
 # Make arg passed from compose files into environment variable
 ARG WEBPACK_MODE
 ENV WEBPACK_MODE ${WEBPACK_MODE}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,6 +14,8 @@ if [ "$SERVICE_NAME" = 'rq' ]; then
   python manage.py migrate --no-input
   echo ">> Verifying settings."
   python manage.py verify_settings
+  echo ">> Compiling messages."
+  python manage.py compilemessages --ignore .venv
   echo ">> Starting RQ worker(s)"
 
 elif [ "$SERVICE_NAME" = 'rq-scheduler' ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,8 +14,16 @@ if [ "$SERVICE_NAME" = 'rq' ]; then
   python manage.py migrate --no-input
   echo ">> Verifying settings."
   python manage.py verify_settings
-  echo ">> Compiling messages."
-  python manage.py compilemessages --ignore .venv
+
+  # This is run in the containerfile for production. This is included here for
+  # dev because the locale/ directory is in the app/ folder, which gets shared
+  # as a volume locally with the container; this means the compiled messages
+  # would get overwritten when the volume is shared.
+  if [ "$ENV" = 'dev' ]; then
+    echo ">> Compiling messages."
+    python manage.py compilemessages --ignore .venv
+  fi
+
   echo ">> Starting RQ worker(s)"
 
 elif [ "$SERVICE_NAME" = 'rq-scheduler' ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,7 +15,7 @@ if [ "$SERVICE_NAME" = 'rq' ]; then
   echo ">> Verifying settings."
   python manage.py verify_settings
 
-  # This is run in the containerfile for production. This is included here for
+  # This runs in the containerfile for production. This is included here for
   # dev because the locale/ directory is in the app/ folder, which gets shared
   # as a volume locally with the container; this means the compiled messages
   # would get overwritten when the volume is shared.


### PR DESCRIPTION
Closes #878 

Runs `compilemessages` when the image is run so that `.mo` files are present when the app starts.

`gettext` was missing from the production container so I've added that in.