### PR TITLE
889 long file names overflow step 8 summary card on review step

### DIFF
--- a/app/recordtransfer/templates/recordtransfer/submission_form_review.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_form_review.html
@@ -40,9 +40,7 @@
                                                         <i class="fas fa-file text-primary/60"></i>
                                                         <a class="non-nav-link text-primary/60 font-medium underline hover:text-primary transition break-all block"
                                                            style="word-break: break-all;
-                                                                  overflow-wrap: anywhere;
-                                                                  max-width: 100%;
-                                                                  display: block"
+                                                                  max-width: 100%"
                                                            href="{{ file.url }}"
                                                            target="_blank">{{ file.name }}</a>
                                                     </div>

--- a/app/recordtransfer/templates/recordtransfer/submission_form_review.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_form_review.html
@@ -38,9 +38,11 @@
                                                 {% if forloop.counter <= 5 %}
                                                     <div class="file-entry mb-2 flex items-center gap-2">
                                                         <i class="fas fa-file text-primary/60"></i>
-                                                        <a class="non-nav-link text-primary/60 font-medium underline hover:text-primary transition block"
+                                                        <a class="non-nav-link text-primary/60 font-medium underline hover:text-primary transition break-all block"
                                                            style="word-break: break-all;
-                                                                  max-width: 100%"
+                                                                  overflow-wrap: anywhere;
+                                                                  max-width: 100%;
+                                                                  display: block"
                                                            href="{{ file.url }}"
                                                            target="_blank">{{ file.name }}</a>
                                                     </div>

--- a/app/recordtransfer/templates/recordtransfer/submission_form_review.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_form_review.html
@@ -38,7 +38,9 @@
                                                 {% if forloop.counter <= 5 %}
                                                     <div class="file-entry mb-2 flex items-center gap-2">
                                                         <i class="fas fa-file text-primary/60"></i>
-                                                        <a class="non-nav-link text-primary/60 font-medium underline hover:text-primary transition"
+                                                        <a class="non-nav-link text-primary/60 font-medium underline hover:text-primary transition block"
+                                                           style="word-break: break-all;
+                                                                  max-width: 100%"
                                                            href="{{ file.url }}"
                                                            target="_blank">{{ file.name }}</a>
                                                     </div>
@@ -56,7 +58,9 @@
                                                         {% if forloop.counter > 5 %}
                                                             <div class="file-entry mb-2 flex items-center gap-2">
                                                                 <i class="fas fa-file text-primary/60"></i>
-                                                                <a class="non-nav-link text-primary/60 font-medium underline hover:text-primary transition"
+                                                                <a class="non-nav-link text-primary/60 font-medium underline hover:text-primary transition break-all block"
+                                                                   style="word-break: break-all;
+                                                                          max-width: 100%"
                                                                    href="{{ file.url }}"
                                                                    target="_blank">{{ file.name }}</a>
                                                             </div>

--- a/app/recordtransfer/templates/recordtransfer/submission_form_review.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_form_review.html
@@ -38,9 +38,7 @@
                                                 {% if forloop.counter <= 5 %}
                                                     <div class="file-entry mb-2 flex items-center gap-2">
                                                         <i class="fas fa-file text-primary/60"></i>
-                                                        <a class="non-nav-link text-primary/60 font-medium underline hover:text-primary transition break-all block"
-                                                           style="word-break: break-all;
-                                                                  max-width: 100%"
+                                                        <a class="non-nav-link text-primary/60 font-medium underline hover:text-primary transition break-all max-w-full block"
                                                            href="{{ file.url }}"
                                                            target="_blank">{{ file.name }}</a>
                                                     </div>
@@ -58,9 +56,7 @@
                                                         {% if forloop.counter > 5 %}
                                                             <div class="file-entry mb-2 flex items-center gap-2">
                                                                 <i class="fas fa-file text-primary/60"></i>
-                                                                <a class="non-nav-link text-primary/60 font-medium underline hover:text-primary transition break-all block"
-                                                                   style="word-break: break-all;
-                                                                          max-width: 100%"
+                                                                <a class="non-nav-link text-primary/60 font-medium underline hover:text-primary transition break-all max-w-full block"
                                                                    href="{{ file.url }}"
                                                                    target="_blank">{{ file.name }}</a>
                                                             </div>


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/889

Long file names now break and wrap to the next line if they exceed the container width. They break at any character though.  Using word-break: break-all ensures that overly long names don’t overflow the layout.

I avoided using word-break: keep-all because in many browsers, file names (especially with underscores or no spaces) don’t break naturally, which could cause overflow issues again.

I also tried using overflow-wrap:break-word, it didn't work; it was still overflowing even after breaking, and it wasn't understanding the file-entry boundaries