### PR TITLE
Fix Flickering by Enabling Transitions in HTMX Swaps

### DIFF
--- a/app/recordtransfer/templates/recordtransfer/submission_form_base.html
+++ b/app/recordtransfer/templates/recordtransfer/submission_form_base.html
@@ -59,7 +59,7 @@
                           hx-post="{{ request.get_full_path }}"
                           hx-target="#main-container"
                           hx-select="#main-container"
-                          hx-swap="outerHTML show:top"
+                          hx-swap="outerHTML transition:true show:top"
                           method="POST"
                           class="p-6 pt-0">
                         {% csrf_token %}


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/895

This update adds transition:true to the hx-swap attribute, allowing HTMX to automatically handle transitions before and after content swaps. This results in a much smoother visual experience and eliminates the flickering that was previously occurring during swaps.