### PR TITLE
Add info to admin for finding files

### DIFF
--- a/app/recordtransfer/forms/admin_forms.py
+++ b/app/recordtransfer/forms/admin_forms.py
@@ -106,6 +106,10 @@ class SubmissionModelForm(RecordTransferModelForm):
             "uuid",
         )
 
+        help_texts: ClassVar[dict] = {
+            "upload_session": gettext("Click link to view uploaded files"),
+        }
+
     disabled_fields: ClassVar[list] = [
         "metadata",
         "upload_session",

--- a/app/recordtransfer/forms/admin_forms.py
+++ b/app/recordtransfer/forms/admin_forms.py
@@ -122,15 +122,13 @@ class SubmissionModelForm(RecordTransferModelForm):
         super().__init__(*args, **kwargs)
 
         if hasattr(self, "instance") and self.instance.metadata:
-            # TODO: This makes the tiny link by the Metadata title in the Submission form.
-            self.fields["metadata"].help_text = " | ".join(
-                [
-                    format_html('<a href="{}">{}</a>', url, gettext(text))
-                    for url, text in [
-                        (self.instance.get_admin_metadata_change_url(), "View or Change Metadata"),
-                    ]
-                ]
+            # This makes the tiny link by the Metadata title in the Submission form.
+            self.fields["metadata"].help_text = format_html(
+                '<a href="{}">{}</a>',
+                self.instance.get_admin_metadata_change_url(),
+                gettext("View or Change Metadata"),
             )
+
         self.fields["metadata"].widget.can_add_related = False
 
 

--- a/app/recordtransfer/models.py
+++ b/app/recordtransfer/models.py
@@ -954,8 +954,11 @@ class BaseUploadedFile(models.Model):
     def __str__(self):
         """Return a string representation of this object."""
         if self.exists:
-            return f"{self.name} | Session {self.session}"
-        return f"{self.name} Removed! | Session {self.session}"
+            return f"{self.name} | {self.session}"
+        return _("%(name)s Removed! | %(session)s") % {
+            "name": self.name,
+            "session": str(self.session),
+        }
 
 
 class TempUploadedFile(BaseUploadedFile):

--- a/app/recordtransfer/models.py
+++ b/app/recordtransfer/models.py
@@ -22,8 +22,10 @@ from django.forms import ValidationError
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.crypto import get_random_string
+from django.utils.formats import date_format
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 
 from recordtransfer.enums import SiteSettingKey, SiteSettingType, SubmissionStep
 from recordtransfer.managers import (
@@ -864,7 +866,27 @@ class UploadSession(models.Model):
 
     def __str__(self):
         """Return a string representation of this object."""
-        return f"{self.token} ({self.started_at}) | {self.status}"
+        token_substr = self.token[0:8] + "..." if len(self.token) > 8 else self.token
+
+        try:
+            file_count = self.file_count
+
+            return ngettext(
+                "Session %(token)s (%(count)s file, started: %(date)s)",
+                "Session %(token)s (%(count)s files, started: %(date)s)",
+                file_count,
+            ) % {
+                "token": token_substr,
+                "count": file_count,
+                "date": date_format(self.started_at, format="DATETIME_FORMAT", use_l10n=True),
+            }
+
+        except ValueError:
+            # An exception may be thrown if the session is in an in-between state
+            return _("%(token)s (started at %(date)s)") % {
+                "token": token_substr,
+                "date": self.started_at,
+            }
 
 
 def session_upload_location(instance: TempUploadedFile, filename: str) -> str:


### PR DESCRIPTION
Closes #884 

Unfortunately, since `PermUploadedFile` is not a foreign key of `Submission`, it's be very difficult to render an inline of these indirectly related models.

I've settled for a simpler solution: updating the `__str__` of the UploadSession to make it more human readable, and adding a help text that says to click the upload session's name to view files uploaded in that submission.

Before:

![upload_session_before](https://github.com/user-attachments/assets/58ed1a92-2567-419e-a20d-3bdca5b6585f)

After:

![upload_session_after](https://github.com/user-attachments/assets/db381b8a-e53a-4835-9010-affca8f33799)

It looks more friendly now, in my opinion.