### PR TITLE
Set locale in air-datepicker

### DIFF
--- a/app/recordtransfer/static/recordtransfer/js/submission_form/widgets.js
+++ b/app/recordtransfer/static/recordtransfer/js/submission_form/widgets.js
@@ -1,7 +1,15 @@
 import "air-datepicker/air-datepicker.css";
 import AirDatepicker from "air-datepicker";
 import localeEn from "air-datepicker/locale/en";
+import localeFr from "air-datepicker/locale/fr";
 import IMask from "imask";
+
+const DEFAULT_LANGUAGE = "en";
+
+const LOCALE_MAP = {
+    "en": localeEn,
+    "fr": localeFr,
+};
 
 /**
  * Setup date pickers using AirDatepicker.
@@ -9,8 +17,19 @@ import IMask from "imask";
 export function setupDatePickers() {
     const dateInput = document.querySelector(".date-range-picker");
 
+    if (!dateInput) {
+        return;
+    }
+
+    const language = document.documentElement.lang ?? DEFAULT_LANGUAGE;
+    let localeObject = LOCALE_MAP[DEFAULT_LANGUAGE];
+
+    if (language in LOCALE_MAP) {
+        localeObject = LOCALE_MAP[language];
+    }
+
     new AirDatepicker(dateInput, {
-        locale: localeEn,
+        locale: localeObject,
         minDate: new Date(1800, 1, 1),
         maxDate: new Date(),
         autoClose: true,


### PR DESCRIPTION
Sets the locale object in air-datepicker based on the current HTML document's language.

Unfortunately, there is no `hi` locale, only `en` and `fr`. See here: https://github.com/t1m0n/air-datepicker/tree/v3/src/locale

Uses the English locale by default.