### PR TITLE
905 home page styles break on short screens

### DIFF
--- a/app/recordtransfer/static/recordtransfer/css/base/base.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/base.css
@@ -33,8 +33,8 @@ body {
 .main-header-content,
 .main-content {
     width: 80%;
-    margin: 0 auto;
-
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .main-header-content {

--- a/app/recordtransfer/static/recordtransfer/css/base/base.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/base.css
@@ -33,8 +33,8 @@ body {
 .main-header-content,
 .main-content {
     width: 80%;
-    margin-left: auto;
-    margin-right: auto;
+    margin: 0 auto;
+
 }
 
 .main-header-content {

--- a/app/recordtransfer/static/recordtransfer/css/base/home.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/home.css
@@ -1,8 +1,5 @@
 #main-graphic-container {
     width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
     height: 97vh;
     position: relative;
 }
@@ -15,9 +12,9 @@
 
 .main-graphic-text-container {
     position: absolute;
-    top: max(100px, 25vh);
+    top: 50%;
     left: 50%;
-    transform: translateX(-50%);
+    transform: translate(-50%, -50%);
     color: white;
     font-family: "Merriweather", serif;
     width: 60%;
@@ -288,7 +285,6 @@
 
     .main-graphic-text {
         width: 100%;
-        font-size: 2.5em;
     }
 }
 

--- a/app/recordtransfer/static/recordtransfer/css/base/home.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/home.css
@@ -27,7 +27,7 @@
     font-size: 3em;
     margin-bottom: 30px;
     margin-right: 30px;
-    transition: all 3s ease;
+    transition: all 0.3s ease;
 }
 
 .hero-button,
@@ -59,7 +59,7 @@
     flex: 1;
     text-align: center;
     width: 30%;
-    transition: all 250ms ease;
+    transition: all 0.3s ease;
 }
 
 .hero-button:hover,

--- a/app/recordtransfer/static/recordtransfer/css/base/home.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/home.css
@@ -21,6 +21,7 @@
 }
 
 .main-graphic-text {
+    font-family: "Merriweather", serif;
     text-align: left;
     width: 60%;
     font-size: 3.75em;

--- a/app/recordtransfer/static/recordtransfer/css/base/home.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/home.css
@@ -1,5 +1,8 @@
 #main-graphic-container {
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     height: 97vh;
     position: relative;
 }
@@ -12,9 +15,9 @@
 
 .main-graphic-text-container {
     position: absolute;
-    top: 50%;
+    top: max(100px, 25vh);
     left: 50%;
-    transform: translate(-50%, -50%);
+    transform: translateX(-50%);
     color: white;
     font-family: "Merriweather", serif;
     width: 60%;
@@ -285,6 +288,7 @@
 
     .main-graphic-text {
         width: 100%;
+        font-size: 2.5em;
     }
 }
 

--- a/app/recordtransfer/static/recordtransfer/css/base/home.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/home.css
@@ -24,9 +24,10 @@
     font-family: "Merriweather", serif;
     text-align: left;
     width: 60%;
-    font-size: 3.75em;
+    font-size: 3em;
     margin-bottom: 30px;
     margin-right: 30px;
+    transition: all 3s ease;
 }
 
 .hero-button,
@@ -58,6 +59,7 @@
     flex: 1;
     text-align: center;
     width: 30%;
+    transition: all 250ms ease;
 }
 
 .hero-button:hover,

--- a/app/recordtransfer/static/recordtransfer/css/base/home.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/home.css
@@ -1,25 +1,3 @@
-#main-graphic-container {
-    width: 100%;
-    height: 97vh;
-    position: relative;
-}
-
-#main-graphic {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-}
-
-.main-graphic-text-container {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    color: white;
-    font-family: "Merriweather", serif;
-    width: 60%;
-}
-
 .main-graphic-text {
     font-family: "Merriweather", serif;
     text-align: left;
@@ -30,16 +8,14 @@
     transition: all 0.3s ease;
 }
 
-.hero-button,
-.homepage-button {
+.hero-button {
     font-family: "Merriweather", serif;
     display: inline-block;
     border-radius: 3px;
     margin-bottom: 20px;
 }
 
-.hero-button a,
-.homepage-button a {
+.hero-button a {
     color: white;
     text-decoration: none;
 }
@@ -69,21 +45,7 @@
     transition: background-color 0.3s, color 0.3s;
 }
 
-.homepage-button {
-    margin-bottom: 0;
-    padding: 10px;
-    border: 2px solid #89140a;
-    background-color: #89140a;
-    font-size: 1em;
-    font-weight: bold;
-}
 
-.homepage-header {
-    font-family: "Merriweather", serif;
-    margin-top: 40px;
-    color: #89140a;
-    text-align: center;
-}
 
 .lead-text {
     font-size: 1.25rem;
@@ -278,14 +240,6 @@
 }
 
 @media (max-width: 1199px) {
-    .main-graphic-text-container {
-        width: 80%;
-    }
-
-    #main-graphic-container {
-        height: 70vh;
-    }
-
     .main-graphic-text {
         width: 100%;
     }

--- a/app/recordtransfer/static/recordtransfer/css/base/navbar.css
+++ b/app/recordtransfer/static/recordtransfer/css/base/navbar.css
@@ -7,8 +7,8 @@ header {
 }
 
 header.homepage {
-    position: absolute;
-    background-color: transparent;
+    position: relative;
+    background-color: primary;
     box-shadow: none;
 }
 

--- a/app/recordtransfer/templates/recordtransfer/home.html
+++ b/app/recordtransfer/templates/recordtransfer/home.html
@@ -8,7 +8,7 @@
     {% include "recordtransfer/header.html" %}
 {% endblock header %}
 {% block focused_content %}
-    <div class="hero min-h-[70vh] md:min-h-[85vh]"
+    <div class="hero min-h-[95vh]"
          style="background-image: url('{% static 'hero4-scaled.webp' %}')">
         <div class="hero-overlay bg-black/10"></div>
         <div class="hero-content w-full">

--- a/app/recordtransfer/templates/recordtransfer/home.html
+++ b/app/recordtransfer/templates/recordtransfer/home.html
@@ -4,135 +4,144 @@
 {% block title %}
     {% trans "NCTR Record Transfer Portal" %}
 {% endblock title %}
+{% block header %}
+    {% include "recordtransfer/header.html" %}
+{% endblock header %}
 {% block focused_content %}
-    <div id="main-graphic-container">
-        {% include "recordtransfer/header.html" %}
-        <img id="main-graphic"
-             src="{% static 'hero4-scaled.webp' %}"
-             alt="{% trans "NCTR Record Transfer Portal main graphic" %}">
-        <div class="main-graphic-text-container">
-            <div class="main-graphic-text">{% trans "Securely Send Your Records to the NCTR" %}</div>
-            <div class="hero-button-container">
-                <a href="{% url 'recordtransfer:submit' %}" class="hero-button">{% trans "Submit Your Records" %}</a>
-                {% if not user.is_authenticated %}
-                    {% if SIGN_UP_ENABLED %}
-                        <a href="{% url 'recordtransfer:create_account' %}" class="hero-button">{% trans "Sign up Now" %}</a>
-                    {% endif %}
-                    <a href="{% url 'login' %}" class="hero-button">{% trans "Log In" %}</a>
-                {% endif %}
+    <div class="hero min-h-[70vh] md:min-h-[85vh]"
+         style="background-image: url('{% static 'hero4-scaled.webp' %}')">
+        <div class="hero-overlay bg-black/10"></div>
+        <div class="hero-content w-full">
+            <div class="w-full">
+                <div class="max-w-6xl mx-auto px-4 md:px-6">
+                    <div class="text-base-100">
+                        <div class="main-graphic-text">{% trans "Securely Send Your Records to the NCTR" %}</div>
+                        <div class="hero-button-container">
+                            <a href="{% url 'recordtransfer:submit' %}" class="hero-button">{% trans "Submit Your Records" %}</a>
+                            {% if not user.is_authenticated %}
+                                {% if SIGN_UP_ENABLED %}
+                                    <a href="{% url 'recordtransfer:create_account' %}" class="hero-button">{% trans "Sign up Now" %}</a>
+                                {% endif %}
+                                <a href="{% url 'login' %}" class="hero-button">{% trans "Log In" %}</a>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 {% endblock focused_content %}
 {% block content %}
-    <div style="font-family: 'Merriweather', serif"
-         class="text-4xl mb-4 text-primary text-center mt-4">{% trans "Preserve History, Share Truth" %}</div>
-    <p class="lead-text">
-        {% blocktrans %}
-    Join us in building a comprehensive digital archive that honors and preserves vital historical records.
-    Our secure transfer portal makes it simple to contribute to this important collection.
-    {% endblocktrans %}
-    </p>
-    <div class="features-grid">
-        <div class="feature-box">
-            <div style="font-family: 'Merriweather', serif"
-                 class="text-2xl mb-4 text-primary">{% trans "Simple &amp; Secure" %}</div>
-            <p>
-                {% blocktrans %}
-            Upload your digital records with confidence through our encrypted, user-friendly
-            platform.
-            {% endblocktrans %}
-            </p>
-        </div>
-        <div class="feature-box">
-            <div style="font-family: 'Merriweather', serif"
-                 class="text-2xl mb-4 text-primary">{% trans "Standards-Based" %}</div>
-            <p>
-                {% blocktrans %}
-            Your contributions are preserved following CAAIS (Canadian Archival Accession
-            Information Standard), ensuring long-term accessibility and value.
-            {% endblocktrans %}
-            </p>
-        </div>
-        <div class="feature-box">
-            <div style="font-family: 'Merriweather', serif"
-                 class="text-2xl mb-4 text-primary">{% trans "Make an Impact" %}</div>
-            <p>
-                {% blocktrans %}
-            Every record shared helps build a more complete historical narrative for future
-            generations.
-            {% endblocktrans %}
-            </p>
-        </div>
-    </div>
-    <section class="cta-section">
+    <div class="max-w-6xl mx-auto px-4 md:px-6">
         <div style="font-family: 'Merriweather', serif"
-             class="text-2xl mb-4 text-primary">{% trans "Ready to Contribute?" %}</div>
-        <p>
+             class="text-4xl mb-4 text-primary text-center mt-4">{% trans "Preserve History, Share Truth" %}</div>
+        <p class="lead-text">
             {% blocktrans %}
-        We welcome both individual and organizational contributions. For large-scale donations or
-        physical records, please get in contact with us.
-        {% endblocktrans %}
+            Join us in building a comprehensive digital archive that honors and preserves vital historical records.
+            Our secure transfer portal makes it simple to contribute to this important collection.
+            {% endblocktrans %}
         </p>
-        <div class="cta-buttons">
-            {% if user.is_authenticated %}
-                <a href="{% url 'recordtransfer:submit' %}" class="primary-button">{% trans "Submit Your Records" %}</a>
-            {% elif SIGN_UP_ENABLED %}
-                <a href="{% url 'recordtransfer:create_account' %}"
-                   class="primary-button">{% trans "Sign Up Now" %}</a>
-            {% endif %}
-            <a href="https://nctr.ca/contact/" class="secondary-button">{% trans "Contact Us" %}</a>
-        </div>
-    </section>
-    <section class="related-section">
-        <div class="related-content">
-            <div class="related-links">
+        <div class="features-grid">
+            <div class="feature-box">
                 <div style="font-family: 'Merriweather', serif"
-                     class="text-2xl mb-4 text-primary">{% trans "More NCTR Resources" %}</div>
-                <div class="links-list">
-                    <a href="https://nctr.ca/records/view-your-records/" class="link-item">
-                        <span class="link-title">{% trans "View Your Records" %}</span>
-                        <span class="link-description">{% trans "Access your personal or family records held in the NCTR archives" %}</span>
-                    </a>
-                    <a href="https://nctr.ca/about" class="link-item">
-                        <span class="link-title">{% trans "About NCTR" %}</span>
-                        <span class="link-description">{% trans "Learn about our mission, mandate and the work we do" %}</span>
-                    </a>
-                    <a href="https://archives.nctr.ca" class="link-item">
-                        <span class="link-title">{% trans "Public Records" %}</span>
-                        <span class="link-description">{% trans "Browse our public collection of records" %}</span>
-                    </a>
-                </div>
+                     class="text-2xl mb-4 text-primary">{% trans "Simple &amp; Secure" %}</div>
+                <p>
+                    {% blocktrans %}
+                    Upload your digital records with confidence through our encrypted, user-friendly
+                    platform.
+                    {% endblocktrans %}
+                </p>
             </div>
-            <div class="related-image">
-                <img src="{% static 'PHABNE_00281.webp' %}"
-                     alt="Individuals making a donation to the Bentwood Box">
+            <div class="feature-box">
+                <div style="font-family: 'Merriweather', serif"
+                     class="text-2xl mb-4 text-primary">{% trans "Standards-Based" %}</div>
+                <p>
+                    {% blocktrans %}
+                    Your contributions are preserved following CAAIS (Canadian Archival Accession
+                    Information Standard), ensuring long-term accessibility and value.
+                    {% endblocktrans %}
+                </p>
+            </div>
+            <div class="feature-box">
+                <div style="font-family: 'Merriweather', serif"
+                     class="text-2xl mb-4 text-primary">{% trans "Make an Impact" %}</div>
+                <p>
+                    {% blocktrans %}
+                    Every record shared helps build a more complete historical narrative for future
+                    generations.
+                    {% endblocktrans %}
+                </p>
             </div>
         </div>
-    </section>
-    <section class="github-section">
-        <div class="github-container">
-            <div class="flex flex-col">
-                <div style="font-family: 'Merriweather', serif"
-                     class="text-2xl mb-4 text-primary">{% trans "Fully Open Source" %}</div>
-                <div class="github-content">
-                    <p>
-                        {% blocktrans %}
-                This project is open source, demonstrating our commitment to transparency and
-                collaboration. Join our community on GitHub to explore the code, contribute
-                improvements, or adapt it for your organization's needs.
+        <section class="cta-section">
+            <div style="font-family: 'Merriweather', serif"
+                 class="text-2xl mb-4 text-primary">{% trans "Ready to Contribute?" %}</div>
+            <p>
+                {% blocktrans %}
+                We welcome both individual and organizational contributions. For large-scale donations or
+                physical records, please get in contact with us.
                 {% endblocktrans %}
-                    </p>
-                    <a href="https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer"
-                       class="github-button">
-                        <i class="fab fa-github"></i>
-                        {% trans "View on GitHub" %}
-                    </a>
+            </p>
+            <div class="cta-buttons">
+                {% if user.is_authenticated %}
+                    <a href="{% url 'recordtransfer:submit' %}" class="primary-button">{% trans "Submit Your Records" %}</a>
+                {% elif SIGN_UP_ENABLED %}
+                    <a href="{% url 'recordtransfer:create_account' %}"
+                       class="primary-button">{% trans "Sign Up Now" %}</a>
+                {% endif %}
+                <a href="https://nctr.ca/contact/" class="secondary-button">{% trans "Contact Us" %}</a>
+            </div>
+        </section>
+        <section class="related-section">
+            <div class="related-content">
+                <div class="related-links">
+                    <div style="font-family: 'Merriweather', serif"
+                         class="text-2xl mb-4 text-primary">{% trans "More NCTR Resources" %}</div>
+                    <div class="links-list">
+                        <a href="https://nctr.ca/records/view-your-records/" class="link-item">
+                            <span class="link-title">{% trans "View Your Records" %}</span>
+                            <span class="link-description">{% trans "Access your personal or family records held in the NCTR archives" %}</span>
+                        </a>
+                        <a href="https://nctr.ca/about" class="link-item">
+                            <span class="link-title">{% trans "About NCTR" %}</span>
+                            <span class="link-description">{% trans "Learn about our mission, mandate and the work we do" %}</span>
+                        </a>
+                        <a href="https://archives.nctr.ca" class="link-item">
+                            <span class="link-title">{% trans "Public Records" %}</span>
+                            <span class="link-description">{% trans "Browse our public collection of records" %}</span>
+                        </a>
+                    </div>
+                </div>
+                <div class="related-image">
+                    <img src="{% static 'PHABNE_00281.webp' %}"
+                         alt="Individuals making a donation to the Bentwood Box">
                 </div>
             </div>
-            <div class="github-graphic">
-                <i class="fab fa-github"></i>
+        </section>
+        <section class="github-section">
+            <div class="github-container">
+                <div class="flex flex-col">
+                    <div style="font-family: 'Merriweather', serif"
+                         class="text-2xl mb-4 text-primary">{% trans "Fully Open Source" %}</div>
+                    <div class="github-content">
+                        <p>
+                            {% blocktrans %}
+                            This project is open source, demonstrating our commitment to transparency and
+                            collaboration. Join our community on GitHub to explore the code, contribute
+                            improvements, or adapt it for your organization's needs.
+                            {% endblocktrans %}
+                        </p>
+                        <a href="https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer"
+                           class="github-button">
+                            <i class="fab fa-github"></i>
+                            {% trans "View on GitHub" %}
+                        </a>
+                    </div>
+                </div>
+                <div class="github-graphic">
+                    <i class="fab fa-github"></i>
+                </div>
             </div>
-        </div>
-    </section>
+        </section>
+    </div>
 {% endblock content %}


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/905

Change notes-

- Moved the navbar outside of the #main-container to prevent layout overlap.
- Applied DaisyUI styling enhancements to home.html.
- Removed unused CSS from home.css as it was no longer needed due to DaisyUI.
- Added smooth transitions to improve responsiveness when switching between different screen sizes.