### PR TITLE
Fix Issue: RQ worker auto-restart causes container to exit on exception

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -49,6 +49,7 @@ services:
           WEBPACK_MODE: development
     container_name: recordtransfer_rq_workers
     command: python manage.py devrqworker default
+    restart: unless-stopped
     volumes:
       - ./app/:/opt/secure-record-transfer/app/:z
       - temp-directory:/tmp


### PR DESCRIPTION
Closes #955 

The `app` service doesn't need a restart policy because Django's `runserver` handles all exceptions gracefully, so the container never exits. This is in contrast with the `rq` service, for which the container exits after the worker process crashes. To fix this, I've added a restart policy to the `rq` service.