### PR TITLE
Remove debug context processor from all configurations

### DIFF
--- a/app/app/settings/base.py
+++ b/app/app/settings/base.py
@@ -76,7 +76,6 @@ TEMPLATES = [
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
-                "django.template.context_processors.debug",
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",


### PR DESCRIPTION
Closes #945 

The context provided by this context processor is not being used in any of our templates, which is why it is being removed.