### PR TITLE
Skip running `npm run build` when only discovering tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,9 +14,7 @@ def pytest_runtestloop(session: pytest.Session) -> None:
     run.
     """
     selected_items = session.items
-    if not session.config.option.collectonly and any(
-        "/e2e/" in item.nodeid for item in selected_items
-    ):
+    if any("/e2e/" in item.nodeid for item in selected_items):
         try:
             npm_cmd = shutil.which("npm") or "npm"
             subprocess.run(

--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,9 @@ def pytest_runtestloop(session: pytest.Session) -> None:
     run.
     """
     selected_items = session.items
-    if any("/e2e/" in item.nodeid for item in selected_items):
+    if not session.config.option.collectonly and any(
+        "/e2e/" in item.nodeid for item in selected_items
+    ):
         try:
             npm_cmd = shutil.which("npm") or "npm"
             subprocess.run(


### PR DESCRIPTION
Closes #969 

Checks if tests are only being collected (i.e., not run) and skips building static assets with Webpack if that's the case.