### PR TITLE
Ensure .conf templates have LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.sh text=auto eol=lf
 *.conf text=auto eol=lf
+*.conf.template text=auto eol=lf


### PR DESCRIPTION
Closes #972 

Fixes .conf file parsing errors by ensuring that .conf templates have LF line endings.

After making this change, the clamav container doesn't fail to parse the conf file.

![fixed_clamav](https://github.com/user-attachments/assets/cefee549-b480-4c99-864c-df56db7650c3)
