### PR TITLE
870 increase profile tables max height

### DIFF
--- a/app/recordtransfer/templates/includes/base_table.html
+++ b/app/recordtransfer/templates/includes/base_table.html
@@ -2,7 +2,7 @@
     <div class="overflow-x-auto rounded-box border border-base-content/10 bg-base-100 max-h-[80vh]">
         <table class="table table-sm md:table-md">
             <!-- head -->
-            <thead>
+            <thead class="sticky top-0 bg-base-100 z-10">
                 <tr>
                     {% block table_headers %}
                     {% endblock table_headers %}


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Secure-Record-Transfer/issues/870

By default, with PAGINATE_BY=10, all entries are displayed without the need for a scrollbar. However, when PAGINATE_BY is set to a value greater than 10, a scrollbar appears (Showing that many entries can overwhelm the user and may degrade readability). In this case, the table header remains fixed at the top while the user scrolls through the rows, which is the ideal behavior commonly seen in many scrollable tables.