### PR TITLE
Add CSV export to metadata admin

### DIFF
--- a/app/caais/admin.py
+++ b/app/caais/admin.py
@@ -1,15 +1,18 @@
 """CAAIS metadata administrator."""
 
 from datetime import datetime
-from typing import Any, Mapping, Optional
+from typing import Any, Callable, Mapping, Optional, Sequence
 
 from django.contrib import admin
 from django.contrib.admin.models import LogEntry
-from django.http import HttpRequest
+from django.db.models import QuerySet
+from django.http import HttpRequest, HttpResponse
 from django.template.response import TemplateResponse
+from django.utils.translation import gettext_lazy as _
 
 from caais import settings as caais_settings
 from caais.db import GroupConcat
+from caais.export import ExportVersion
 from caais.forms import (
     InlineAppraisalForm,
     InlineArchivalUnitForm,
@@ -27,6 +30,7 @@ from caais.forms import (
     InlineStorageLocationForm,
     MetadataForm,
 )
+from caais.managers import MetadataQuerySet
 from caais.models import (
     AcquisitionMethod,
     Appraisal,
@@ -248,6 +252,16 @@ class MetadataAdmin(admin.ModelAdmin):
         GeneralNoteInlineAdmin,
     ]
 
+    actions: (
+        Sequence[Callable[[Any, HttpRequest, QuerySet[Any]], HttpResponse | None] | str] | None
+    ) = [
+        "export_caais_csv",
+        "export_atom_2_6_csv",
+        "export_atom_2_3_csv",
+        "export_atom_2_2_csv",
+        "export_atom_2_1_csv",
+    ]
+
     def source_name(self, obj) -> Optional[str]:
         return obj.source_of_materials.aggregate(
             names_joined=GroupConcat("source_name", separator=", ")
@@ -297,6 +311,39 @@ class MetadataAdmin(admin.ModelAdmin):
             creation_or_revision_note=log_entry.get_change_message(),
         )
         return log_entry
+
+    @admin.action(description=_("Export CAAIS 1.0 CSV for Selected"))
+    def export_caais_csv(self, request: HttpRequest, queryset: MetadataQuerySet) -> HttpResponse:
+        """Export CAAIS 1.0 CSV for submissions in the selected queryset."""
+        return queryset.export_csv(version=ExportVersion.CAAIS_1_0)
+
+    @admin.action(description=_("Export AtoM 2.6 Accession CSV for Selected"))
+    def export_atom_2_6_csv(
+        self, request: HttpRequest, queryset: MetadataQuerySet
+    ) -> HttpResponse:
+        """Export AtoM 2.6 Accession CSV for submissions in the selected queryset."""
+        return queryset.export_csv(version=ExportVersion.ATOM_2_6)
+
+    @admin.action(description=_("Export AtoM 2.3 Accession CSV for Selected"))
+    def export_atom_2_3_csv(
+        self, request: HttpRequest, queryset: MetadataQuerySet
+    ) -> HttpResponse:
+        """Export AtoM 2.3 Accession CSV for submissions in the selected queryset."""
+        return queryset.export_csv(version=ExportVersion.ATOM_2_3)
+
+    @admin.action(description=_("Export AtoM 2.2 Accession CSV for Selected"))
+    def export_atom_2_2_csv(
+        self, request: HttpRequest, queryset: MetadataQuerySet
+    ) -> HttpResponse:
+        """Export AtoM 2.2 Accession CSV for submissions in the selected queryset."""
+        return queryset.export_csv(version=ExportVersion.ATOM_2_2)
+
+    @admin.action(description=_("Export AtoM 2.1 Accession CSV for Selected"))
+    def export_atom_2_1_csv(
+        self, request: HttpRequest, queryset: MetadataQuerySet
+    ) -> HttpResponse:
+        """Export AtoM 2.1 Accession CSV for submissions in the selected queryset."""
+        return queryset.export_csv(version=ExportVersion.ATOM_2_1)
 
 
 @admin.register(AcquisitionMethod)

--- a/app/caais/admin.py
+++ b/app/caais/admin.py
@@ -235,6 +235,16 @@ class MetadataAdmin(admin.ModelAdmin):
         "status",
     ]
 
+    search_fields: Sequence[str] = [
+        "identifiers__identifier_value",
+        "source_of_materials__source_name",
+        "source_of_materials__contact_name",
+        "source_of_materials__organization",
+        "status__name",
+        "accession_title",
+        "repository",
+    ]
+
     inlines = [
         IdentifierInlineAdmin,
         ArchivalUnitInlineAdmin,

--- a/app/caais/managers.py
+++ b/app/caais/managers.py
@@ -66,36 +66,6 @@ class MetadataQuerySet(models.QuerySet):
         return response
 
 
-class MetadataManager(models.Manager):
-    def get_queryset(self) -> MetadataQuerySet:
-        return MetadataQuerySet(self.model, using=self._db)
-
-    def flatten(self, version=ExportVersion.CAAIS_1_0) -> dict:
-        """Convert this model and all related models into a flat dictionary
-        suitable to be written to a CSV or used as the metadata fields for a
-        BagIt bag.
-        """
-        return [metadata.create_flat_representation(version) for metadata in self.get_queryset()]
-
-    def export_csv(
-        self,
-        version: ExportVersion = ExportVersion.CAAIS_1_0,
-        filename_prefix: str | None = None,
-    ) -> HttpResponse:
-        """Create an HttpResponse that contains a CSV representation of all metadata objects in the
-        queryset.
-
-        Args:
-            version: The type/version of the CSV to export
-            filename_prefix:
-                Prefix for the generated CSV filename. If not provided, a default is used.
-
-        Returns:
-            An HTTP response to download the CSV.
-        """
-        return self.get_queryset().export_csv(version=version, filename_prefix=filename_prefix)
-
-
 class CaaisModelManager(models.Manager, ABC):
     ''' Custom manager for CAAIS models that require the flatten() function.
     '''

--- a/app/caais/models.py
+++ b/app/caais/models.py
@@ -40,7 +40,7 @@ from caais.managers import (
     GeneralNoteManager,
     IdentifierManager,
     LanguageOfMaterialManager,
-    MetadataManager,
+    MetadataQuerySet,
     PreliminaryCustodialHistoryManager,
     PreliminaryScopeAndContentManager,
     PreservationRequirementsManager,
@@ -228,7 +228,7 @@ class Metadata(models.Model):
         verbose_name_plural = gettext("CAAIS metadata")
         verbose_name = gettext("CAAIS metadata")
 
-    objects = MetadataManager()
+    objects = MetadataQuerySet.as_manager()
 
     @property
     def accession_identifier(self) -> str:

--- a/app/recordtransfer/admin.py
+++ b/app/recordtransfer/admin.py
@@ -417,27 +417,27 @@ class SubmissionGroupAdmin(ReadOnlyAdmin):
         metadata_queryset = Metadata.objects.filter(submission__in=related_submissions)
         return metadata_queryset.export_csv(version=version)
 
-    @admin.action(description=_("Export CAAIS 1.0 CSV for Metadata in Selected"))
+    @admin.action(description=_("Export CAAIS 1.0 CSV for Submissions in Selected"))
     def export_caais_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse | None:
         """Export CAAIS 1.0 CSV for submissions in the selected queryset."""
         return self._export_submissions_csv(request, queryset, ExportVersion.CAAIS_1_0)
 
-    @admin.action(description=_("Export AtoM 2.6 Accession CSV for Metadata in Selected"))
+    @admin.action(description=_("Export AtoM 2.6 Accession CSV for Submissions in Selected"))
     def export_atom_2_6_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse | None:
         """Export AtoM 2.6 Accession CSV for submissions in the selected queryset."""
         return self._export_submissions_csv(request, queryset, ExportVersion.ATOM_2_6)
 
-    @admin.action(description=_("Export AtoM 2.3 Accession CSV for Metadata in Selected"))
+    @admin.action(description=_("Export AtoM 2.3 Accession CSV for Submissions in Selected"))
     def export_atom_2_3_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse | None:
         """Export AtoM 2.3 Accession CSV for submissions in the selected queryset."""
         return self._export_submissions_csv(request, queryset, ExportVersion.ATOM_2_3)
 
-    @admin.action(description=_("Export AtoM 2.2 Accession CSV for Metadata in Selected"))
+    @admin.action(description=_("Export AtoM 2.2 Accession CSV for Submissions in Selected"))
     def export_atom_2_2_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse | None:
         """Export AtoM 2.2 Accession CSV for submissions in the selected queryset."""
         return self._export_submissions_csv(request, queryset, ExportVersion.ATOM_2_2)
 
-    @admin.action(description=_("Export AtoM 2.1 Accession CSV for Metadata in Selected"))
+    @admin.action(description=_("Export AtoM 2.1 Accession CSV for Submissions in Selected"))
     def export_atom_2_1_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse | None:
         """Export AtoM 2.1 Accession CSV for submissions in the selected queryset."""
         return self._export_submissions_csv(request, queryset, ExportVersion.ATOM_2_1)
@@ -593,35 +593,35 @@ class SubmissionAdmin(admin.ModelAdmin):
         admin_url = reverse("admin:index", current_app=self.admin_site.name)
         return HttpResponseRedirect(admin_url)
 
-    @admin.action(description=_("Export CAAIS 1.0 CSV for Submissions in Selected"))
+    @admin.action(description=_("Export CAAIS 1.0 CSV for Metadata in Selected"))
     def export_caais_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse:
         """Export CAAIS 1.0 CSV for submissions in the selected queryset."""
         return Metadata.objects.filter(submission__in=queryset).export_csv(
             version=ExportVersion.CAAIS_1_0
         )
 
-    @admin.action(description=_("Export AtoM 2.6 Accession CSV for Submissions in Selected"))
+    @admin.action(description=_("Export AtoM 2.6 Accession CSV for Metadata in Selected"))
     def export_atom_2_6_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse:
         """Export AtoM 2.6 Accession CSV for submissions in the selected queryset."""
         return Metadata.objects.filter(submission__in=queryset).export_csv(
             version=ExportVersion.ATOM_2_6
         )
 
-    @admin.action(description=_("Export AtoM 2.3 Accession CSV for Submissions in Selected"))
+    @admin.action(description=_("Export AtoM 2.3 Accession CSV for Metadata in Selected"))
     def export_atom_2_3_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse:
         """Export AtoM 2.3 Accession CSV for submissions in the selected queryset."""
         return Metadata.objects.filter(submission__in=queryset).export_csv(
             version=ExportVersion.ATOM_2_3
         )
 
-    @admin.action(description=_("Export AtoM 2.2 Accession CSV for Submissions in Selected"))
+    @admin.action(description=_("Export AtoM 2.2 Accession CSV for Metadata in Selected"))
     def export_atom_2_2_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse:
         """Export AtoM 2.2 Accession CSV for submissions in the selected queryset."""
         return Metadata.objects.filter(submission__in=queryset).export_csv(
             version=ExportVersion.ATOM_2_2
         )
 
-    @admin.action(description=_("Export AtoM 2.1 Accession CSV for Submissions in Selected"))
+    @admin.action(description=_("Export AtoM 2.1 Accession CSV for Metadata in Selected"))
     def export_atom_2_1_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse:
         """Export AtoM 2.1 Accession CSV for submissions in the selected queryset."""
         return Metadata.objects.filter(submission__in=queryset).export_csv(

--- a/app/recordtransfer/admin.py
+++ b/app/recordtransfer/admin.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Any, Callable, Sequence, cast
 
 from caais.export import ExportVersion
+from caais.models import Metadata
 from django.contrib import admin, messages
 from django.contrib.admin import display
 from django.contrib.admin.options import InlineModelAdmin
@@ -412,29 +413,31 @@ class SubmissionGroupAdmin(ReadOnlyAdmin):
                 messages.WARNING,
             )
             return None
-        return related_submissions.export_csv(version=version)
 
-    @admin.action(description=_("Export CAAIS 1.0 CSV for Submissions in Selected"))
+        metadata_queryset = Metadata.objects.filter(submission__in=related_submissions)
+        return metadata_queryset.export_csv(version=version)
+
+    @admin.action(description=_("Export CAAIS 1.0 CSV for Metadata in Selected"))
     def export_caais_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse | None:
         """Export CAAIS 1.0 CSV for submissions in the selected queryset."""
         return self._export_submissions_csv(request, queryset, ExportVersion.CAAIS_1_0)
 
-    @admin.action(description=_("Export AtoM 2.6 Accession CSV for Submissions in Selected"))
+    @admin.action(description=_("Export AtoM 2.6 Accession CSV for Metadata in Selected"))
     def export_atom_2_6_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse | None:
         """Export AtoM 2.6 Accession CSV for submissions in the selected queryset."""
         return self._export_submissions_csv(request, queryset, ExportVersion.ATOM_2_6)
 
-    @admin.action(description=_("Export AtoM 2.3 Accession CSV for Submissions in Selected"))
+    @admin.action(description=_("Export AtoM 2.3 Accession CSV for Metadata in Selected"))
     def export_atom_2_3_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse | None:
         """Export AtoM 2.3 Accession CSV for submissions in the selected queryset."""
         return self._export_submissions_csv(request, queryset, ExportVersion.ATOM_2_3)
 
-    @admin.action(description=_("Export AtoM 2.2 Accession CSV for Submissions in Selected"))
+    @admin.action(description=_("Export AtoM 2.2 Accession CSV for Metadata in Selected"))
     def export_atom_2_2_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse | None:
         """Export AtoM 2.2 Accession CSV for submissions in the selected queryset."""
         return self._export_submissions_csv(request, queryset, ExportVersion.ATOM_2_2)
 
-    @admin.action(description=_("Export AtoM 2.1 Accession CSV for Submissions in Selected"))
+    @admin.action(description=_("Export AtoM 2.1 Accession CSV for Metadata in Selected"))
     def export_atom_2_1_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse | None:
         """Export AtoM 2.1 Accession CSV for submissions in the selected queryset."""
         return self._export_submissions_csv(request, queryset, ExportVersion.ATOM_2_1)
@@ -591,37 +594,39 @@ class SubmissionAdmin(admin.ModelAdmin):
         return HttpResponseRedirect(admin_url)
 
     @admin.action(description=_("Export CAAIS 1.0 CSV for Submissions in Selected"))
-    def export_caais_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponseRedirect:
+    def export_caais_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse:
         """Export CAAIS 1.0 CSV for submissions in the selected queryset."""
-        return queryset.export_csv(version=ExportVersion.CAAIS_1_0)
+        return Metadata.objects.filter(submission__in=queryset).export_csv(
+            version=ExportVersion.CAAIS_1_0
+        )
 
     @admin.action(description=_("Export AtoM 2.6 Accession CSV for Submissions in Selected"))
-    def export_atom_2_6_csv(
-        self, request: HttpRequest, queryset: QuerySet
-    ) -> HttpResponseRedirect:
+    def export_atom_2_6_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse:
         """Export AtoM 2.6 Accession CSV for submissions in the selected queryset."""
-        return queryset.export_csv(version=ExportVersion.ATOM_2_6)
+        return Metadata.objects.filter(submission__in=queryset).export_csv(
+            version=ExportVersion.ATOM_2_6
+        )
 
     @admin.action(description=_("Export AtoM 2.3 Accession CSV for Submissions in Selected"))
-    def export_atom_2_3_csv(
-        self, request: HttpRequest, queryset: QuerySet
-    ) -> HttpResponseRedirect:
+    def export_atom_2_3_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse:
         """Export AtoM 2.3 Accession CSV for submissions in the selected queryset."""
-        return queryset.export_csv(version=ExportVersion.ATOM_2_3)
+        return Metadata.objects.filter(submission__in=queryset).export_csv(
+            version=ExportVersion.ATOM_2_3
+        )
 
     @admin.action(description=_("Export AtoM 2.2 Accession CSV for Submissions in Selected"))
-    def export_atom_2_2_csv(
-        self, request: HttpRequest, queryset: QuerySet
-    ) -> HttpResponseRedirect:
+    def export_atom_2_2_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse:
         """Export AtoM 2.2 Accession CSV for submissions in the selected queryset."""
-        return queryset.export_csv(version=ExportVersion.ATOM_2_2)
+        return Metadata.objects.filter(submission__in=queryset).export_csv(
+            version=ExportVersion.ATOM_2_2
+        )
 
     @admin.action(description=_("Export AtoM 2.1 Accession CSV for Submissions in Selected"))
-    def export_atom_2_1_csv(
-        self, request: HttpRequest, queryset: QuerySet
-    ) -> HttpResponseRedirect:
+    def export_atom_2_1_csv(self, request: HttpRequest, queryset: QuerySet) -> HttpResponse:
         """Export AtoM 2.1 Accession CSV for submissions in the selected queryset."""
-        return queryset.export_csv(version=ExportVersion.ATOM_2_1)
+        return Metadata.objects.filter(submission__in=queryset).export_csv(
+            version=ExportVersion.ATOM_2_1
+        )
 
 
 @admin.register(Job)

--- a/app/recordtransfer/managers.py
+++ b/app/recordtransfer/managers.py
@@ -1,58 +1,8 @@
-import csv
-from io import StringIO
-from typing import Optional
-
-from caais.export import ExportVersion
 from django.apps import apps
 from django.conf import settings
 from django.db import models
 from django.db.models import Q, query
-from django.http import HttpResponse
 from django.utils import timezone
-
-
-class SubmissionQuerySet(query.QuerySet):
-    """Adds the ability to export a queryset as a CSV."""
-
-    def export_csv(
-        self,
-        version: ExportVersion = ExportVersion.CAAIS_1_0,
-        filename_prefix: Optional[str] = None,
-    ) -> HttpResponse:
-        """Create an HttpResponse that contains a CSV representation of all submissions in the
-        queryset.
-
-        Args:
-            version (ExportVersion): The type/version of the CSV to export
-            filename_prefix (str, optional): Prefix for the generated CSV filename.
-                If not provided, a default is used.
-        """
-        csv_file = StringIO()
-        writer = csv.writer(csv_file)
-        first_row = True
-
-        for submission in self:
-            row = submission.metadata.create_flat_representation(version)
-            if first_row:
-                writer.writerow(row.keys())
-                first_row = False
-            writer.writerow(row.values())
-
-        csv_file.seek(0)
-
-        response = HttpResponse(csv_file, content_type="text/csv")
-
-        local_time = timezone.localtime(timezone.now()).strftime(r"%Y%m%d_%H%M%S")
-        if not filename_prefix:
-            version_bits = str(version).split("_")
-            filename_prefix = "{0}_v{1}_".format(
-                version_bits[0], ".".join([str(x) for x in version_bits[1:]])
-            )
-
-        filename = f"{filename_prefix}{local_time}.csv"
-        response["Content-Disposition"] = f"attachment; filename={filename}"
-        csv_file.close()
-        return response
 
 
 class UploadSessionManager(models.Manager):

--- a/app/recordtransfer/models.py
+++ b/app/recordtransfer/models.py
@@ -28,11 +28,7 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
 from recordtransfer.enums import SiteSettingKey, SiteSettingType, SubmissionStep
-from recordtransfer.managers import (
-    InProgressSubmissionManager,
-    SubmissionQuerySet,
-    UploadSessionManager,
-)
+from recordtransfer.managers import InProgressSubmissionManager, UploadSessionManager
 from recordtransfer.storage import OverwriteStorage, TempFileStorage, UploadedFileStorage
 from recordtransfer.utils import get_human_readable_file_count, get_human_readable_size
 
@@ -1141,8 +1137,6 @@ class Submission(models.Model):
     )
     upload_session = models.ForeignKey(UploadSession, null=True, on_delete=models.SET_NULL)
     uuid = models.UUIDField(default=uuid.uuid4)
-
-    objects = SubmissionQuerySet.as_manager()
 
     @property
     def bag_name(self) -> str:

--- a/app/recordtransfer/tests/unit/views/test_post_submission.py
+++ b/app/recordtransfer/tests/unit/views/test_post_submission.py
@@ -181,15 +181,16 @@ class TestSubmissionCsvExport(TestCase):
         response = self.client.get(self.submission_csv_url)
         self.assertEqual(response.status_code, 404)
 
-    @patch("recordtransfer.managers.SubmissionQuerySet.export_csv")
+    @patch("caais.managers.MetadataQuerySet.export_csv")
     def test_access_staff_user(self, mock_export: MagicMock) -> None:
         """Test that a staff user can access the view."""
         mock_export.return_value = HttpResponse("csv_content", content_type="text/csv")
         self.client.login(username="staffuser", password="password")
         response = self.client.get(self.submission_csv_url)
         self.assertEqual(response.status_code, 200)
+        mock_export.assert_called_once()
 
-    @patch("recordtransfer.managers.SubmissionQuerySet.export_csv")
+    @patch("caais.managers.MetadataQuerySet.export_csv")
     def test_csv_generation(self, mock_export: MagicMock) -> None:
         """Test that the CSV export is called with correct parameters."""
         mock_export.return_value = HttpResponse("csv_content", content_type="text/csv")
@@ -244,15 +245,16 @@ class TestSubmissionGroupBulkCsvExport(TestCase):
         response = self.client.get(self.submission_group_csv_url)
         self.assertEqual(response.status_code, 404)
 
-    @patch("recordtransfer.managers.SubmissionQuerySet.export_csv")
+    @patch("caais.managers.MetadataQuerySet.export_csv")
     def test_access_staff_user(self, mock_export: MagicMock) -> None:
         """Test that a staff user can access the view."""
         mock_export.return_value = HttpResponse("csv_content", content_type="text/csv")
         self.client.login(username="staffuser", password="password")
         response = self.client.get(self.submission_group_csv_url)
         self.assertEqual(response.status_code, 200)
+        mock_export.assert_called_once()
 
-    @patch("recordtransfer.managers.SubmissionQuerySet.export_csv")
+    @patch("caais.managers.MetadataQuerySet.export_csv")
     def test_invalid_group_uuid(self, mock_export: MagicMock) -> None:
         """Test that accessing a nonexistent submission group returns 404."""
         invalid_csv_url = reverse(
@@ -261,8 +263,9 @@ class TestSubmissionGroupBulkCsvExport(TestCase):
         )
         response = self.client.get(invalid_csv_url)
         self.assertEqual(response.status_code, 404)
+        mock_export.assert_not_called()
 
-    @patch("recordtransfer.managers.SubmissionQuerySet.export_csv")
+    @patch("caais.managers.MetadataQuerySet.export_csv")
     def test_non_staff_user_owns_group_but_not_submissions(self, mock_export: MagicMock) -> None:
         """Test that a non-staff user is redirected to profile page with error message if they own
         the group but not the submissions.
@@ -283,6 +286,7 @@ class TestSubmissionGroupBulkCsvExport(TestCase):
         )
         # Now redirects to profile page with error message
         self.assertRedirects(response, reverse("recordtransfer:user_profile"))
+        mock_export.assert_not_called()
 
 
 class TestGetUserSubmissionGroups(TestCase):

--- a/app/recordtransfer/views/post_submission.py
+++ b/app/recordtransfer/views/post_submission.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Optional, cast
 
 from caais.export import ExportVersion
+from caais.models import Metadata
 from django.contrib import messages
 from django.core.exceptions import BadRequest
 from django.db.models import QuerySet
@@ -84,7 +85,9 @@ def submission_csv_export(request: HttpRequest, uuid: str) -> HttpResponse:
     else:
         prefix = "export-"
 
-    return submission_queryset.export_csv(version=ExportVersion.CAAIS_1_0, filename_prefix=prefix)
+    return Metadata.objects.filter(submission__in=submission_queryset).export_csv(
+        version=ExportVersion.CAAIS_1_0, filename_prefix=prefix
+    )
 
 
 require_http_methods(["GET"])
@@ -130,7 +133,9 @@ def submission_group_bulk_csv_export(request: HttpRequest, uuid: str) -> HttpRes
 
         return redirect("recordtransfer:user_profile")
 
-    return related_submissions.export_csv(version=ExportVersion.CAAIS_1_0, filename_prefix=prefix)
+    return Metadata.objects.filter(submission__in=related_submissions).export_csv(
+        version=ExportVersion.CAAIS_1_0, filename_prefix=prefix
+    )
 
 
 class SubmissionGroupDetailView(UpdateView):


### PR DESCRIPTION
Closes #1011

Adds CSV export to the Metadata admin.

You can now export a CSV from six different places:

- **From the metadata admin**
- From the user profile submission table
- From the user profile submission group table
- From the submission group detail view
- From the submission group admin
- From the submission admin

Since all the fields that are exported are in the Metadata model, I've moved the `export_csv` out of `recordtransfer` and into the `caais` app. A CSV can now be exported from both the Metadata manager, and any Metadata queryset.