### PR TITLE
Conditionally show help for upload session

### DIFF
--- a/app/recordtransfer/admin.py
+++ b/app/recordtransfer/admin.py
@@ -547,6 +547,22 @@ class SubmissionAdmin(admin.ModelAdmin):
             *super().get_urls(),
         ]
 
+    def get_form(
+        self, request: HttpRequest, obj: Submission | None = None, change: bool = False, **kwargs
+    ) -> type[ModelForm]:
+        """Conditionally add help_text to upload_session if one exists."""
+        if not obj or not obj.upload_session:
+            return super().get_form(request, obj, change, **kwargs)
+
+        upload_session_help = "Click link to view uploaded files"
+
+        if "help_texts" in kwargs:
+            kwargs["help_texts"]["upload_session"] = upload_session_help
+        else:
+            kwargs.update({"help_texts": {"upload_session": upload_session_help}})
+
+        return super().get_form(request, obj, **kwargs)
+
     def create_zipped_bag(self, request: HttpRequest, object_id: str) -> HttpResponseRedirect:
         """Start a background job to create a downloadable bag.
 

--- a/app/recordtransfer/admin.py
+++ b/app/recordtransfer/admin.py
@@ -554,7 +554,7 @@ class SubmissionAdmin(admin.ModelAdmin):
         if not obj or not obj.upload_session:
             return super().get_form(request, obj, change, **kwargs)
 
-        upload_session_help = "Click link to view uploaded files"
+        upload_session_help = _("Click link to view uploaded files")
 
         if "help_texts" in kwargs:
             kwargs["help_texts"]["upload_session"] = upload_session_help

--- a/app/recordtransfer/forms/admin_forms.py
+++ b/app/recordtransfer/forms/admin_forms.py
@@ -113,10 +113,6 @@ class SubmissionModelForm(RecordTransferModelForm):
             "uuid",
         )
 
-        help_texts: ClassVar[dict] = {
-            "upload_session": gettext("Click link to view uploaded files"),
-        }
-
     disabled_fields: ClassVar[list] = [
         "metadata",
         "upload_session",


### PR DESCRIPTION
Closes #1027 

Shows the help text for an upload session only when an upload session exists.

This is done in the admin since upload_session is a read-only field, and does not technically exist as a field in the form.