### PR TITLE
Remove upload session endpoint

### DIFF
--- a/app/fixtures/seed_data.json
+++ b/app/fixtures/seed_data.json
@@ -3,8 +3,8 @@
         "model": "recordtransfer.user",
         "pk": 1,
         "fields": {
-            "password": "pbkdf2_sha256$600000$tVZWP8Yn9AkcCGIgLhMfZY$9zOX3YJdG+7ayL1Aue0ZrRMIjWkx8hePgJ5Wa0Y+yk0=",
-            "last_login": "2025-07-15T14:29:05.516Z",
+            "password": "pbkdf2_sha256$1000000$mAchWqZoAdVnEvq4ZOkWh2$9wydfN9v2PMyik+nas7NmzoV1Nf9q6K6Z+8Hdkhhuz4=",
+            "last_login": "2025-08-29T16:21:57.191Z",
             "is_superuser": true,
             "username": "admin",
             "first_name": "",
@@ -12,9 +12,10 @@
             "email": "admin@demo.com",
             "is_staff": true,
             "is_active": true,
-            "date_joined": "2025-07-15T14:28:59.229Z",
+            "date_joined": "2025-08-29T16:20:27.783Z",
             "gets_submission_email_updates": false,
             "gets_notification_emails": true,
+            "language": "en",
             "phone_number": null,
             "address_line_1": null,
             "address_line_2": null,
@@ -34,7 +35,7 @@
             "key": "ARCHIVIST_EMAIL",
             "value": "archivist@example.com",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -45,7 +46,7 @@
             "key": "DO_NOT_REPLY_USERNAME",
             "value": "do-not-reply",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -56,7 +57,7 @@
             "key": "PAGINATE_BY",
             "value": "10",
             "value_type": "int",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -67,7 +68,7 @@
             "key": "CAAIS_DEFAULT_REPOSITORY",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -78,7 +79,7 @@
             "key": "CAAIS_DEFAULT_ACCESSION_TITLE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -89,7 +90,7 @@
             "key": "CAAIS_DEFAULT_ARCHIVAL_UNIT",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -100,7 +101,7 @@
             "key": "CAAIS_DEFAULT_DISPOSITION_AUTHORITY",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -111,7 +112,7 @@
             "key": "CAAIS_DEFAULT_ACQUISITION_METHOD",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -122,7 +123,7 @@
             "key": "CAAIS_DEFAULT_STATUS",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -133,7 +134,7 @@
             "key": "CAAIS_DEFAULT_SOURCE_CONFIDENTIALITY",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -144,7 +145,7 @@
             "key": "CAAIS_DEFAULT_PRELIMINARY_CUSTODIAL_HISTORY",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -155,7 +156,7 @@
             "key": "CAAIS_DEFAULT_DATE_OF_MATERIALS",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -166,7 +167,7 @@
             "key": "CAAIS_DEFAULT_EXTENT_TYPE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -177,7 +178,7 @@
             "key": "CAAIS_DEFAULT_QUANTITY_AND_UNIT_OF_MEASURE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -188,7 +189,7 @@
             "key": "CAAIS_DEFAULT_CONTENT_TYPE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -199,7 +200,7 @@
             "key": "CAAIS_DEFAULT_CARRIER_TYPE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -210,7 +211,7 @@
             "key": "CAAIS_DEFAULT_EXTENT_NOTE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -221,7 +222,7 @@
             "key": "CAAIS_DEFAULT_PRELIMINARY_SCOPE_AND_CONTENT",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -232,7 +233,7 @@
             "key": "CAAIS_DEFAULT_LANGUAGE_OF_MATERIAL",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -243,7 +244,7 @@
             "key": "CAAIS_DEFAULT_STORAGE_LOCATION",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -254,7 +255,7 @@
             "key": "CAAIS_DEFAULT_PRESERVATION_REQUIREMENTS_TYPE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -265,7 +266,7 @@
             "key": "CAAIS_DEFAULT_PRESERVATION_REQUIREMENTS_VALUE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -276,7 +277,7 @@
             "key": "CAAIS_DEFAULT_PRESERVATION_REQUIREMENTS_NOTE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -287,7 +288,7 @@
             "key": "CAAIS_DEFAULT_APPRAISAL_TYPE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -298,7 +299,7 @@
             "key": "CAAIS_DEFAULT_APPRAISAL_VALUE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -309,7 +310,7 @@
             "key": "CAAIS_DEFAULT_APPRAISAL_NOTE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -320,7 +321,7 @@
             "key": "CAAIS_DEFAULT_ASSOCIATED_DOCUMENTATION_TYPE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -331,7 +332,7 @@
             "key": "CAAIS_DEFAULT_ASSOCIATED_DOCUMENTATION_TITLE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -342,7 +343,7 @@
             "key": "CAAIS_DEFAULT_ASSOCIATED_DOCUMENTATION_NOTE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -353,7 +354,7 @@
             "key": "CAAIS_DEFAULT_GENERAL_NOTE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -364,7 +365,7 @@
             "key": "CAAIS_DEFAULT_RULES_OR_CONVENTIONS",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -375,7 +376,7 @@
             "key": "CAAIS_DEFAULT_LANGUAGE_OF_ACCESSION_RECORD",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -386,7 +387,7 @@
             "key": "CAAIS_DEFAULT_SUBMISSION_EVENT_TYPE",
             "value": "Transfer Submitted",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -397,7 +398,7 @@
             "key": "CAAIS_DEFAULT_SUBMISSION_EVENT_AGENT",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -408,7 +409,7 @@
             "key": "CAAIS_DEFAULT_SUBMISSION_EVENT_NOTE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -419,7 +420,7 @@
             "key": "CAAIS_DEFAULT_CREATION_TYPE",
             "value": "Creation",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -430,7 +431,7 @@
             "key": "CAAIS_DEFAULT_CREATION_AGENT",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -441,7 +442,7 @@
             "key": "CAAIS_DEFAULT_CREATION_NOTE",
             "value": "",
             "value_type": "str",
-            "change_date": "2025-07-15T14:26:25.197Z",
+            "change_date": "2025-08-29T16:20:02.454Z",
             "changed_by": null
         }
     },
@@ -449,115 +450,58 @@
         "model": "recordtransfer.uploadsession",
         "pk": 1,
         "fields": {
-            "token": "n0LaAeQRMCARm7E3a0jB0c03SdqaCVmM",
-            "started_at": "2025-07-15T14:38:12.593Z",
-            "status": "SD",
-            "user": 1,
-            "last_upload_interaction_time": "2025-07-15T14:38:12.645Z"
-        }
-    },
-    {
-        "model": "recordtransfer.uploadsession",
-        "pk": 2,
-        "fields": {
-            "token": "TDf3voxgiI2qOstbKYTfzYJnbk61xOXW",
-            "started_at": "2025-07-15T14:40:42.724Z",
+            "token": "g8bBjkKsEizHOmrKPe3xr7cHtJ6ibR60",
+            "started_at": "2025-08-29T16:28:15.856Z",
             "status": "UG",
             "user": 1,
-            "last_upload_interaction_time": "2025-07-15T14:40:45.635Z"
+            "last_upload_interaction_time": "2025-08-29T16:29:15.224Z"
         }
     },
     {
         "model": "recordtransfer.tempuploadedfile",
-        "pk": 2,
-        "fields": {
-            "name": "nctr_logo.jpg",
-            "session": 2,
-            "file_upload": "TDf3voxgiI2qOstbKYTfzYJnbk61xOXW/nctr_logo.jpg"
-        }
-    },
-    {
-        "model": "recordtransfer.permuploadedfile",
         "pk": 1,
         "fields": {
             "name": "nctr_logo.jpg",
             "session": 1,
-            "file_upload": "n0LaAeQRMCARm7E3a0jB0c03SdqaCVmM/nctr_logo.jpg"
+            "file_upload": "g8bBjkKsEizHOmrKPe3xr7cHtJ6ibR60/nctr_logo.jpg"
         }
     },
     {
         "model": "recordtransfer.submissiongroup",
         "pk": 1,
         "fields": {
-            "name": "TEST SUBMISSION GROUP",
+            "name": "TEST GROUP",
             "description": "This is a test submission group.",
             "created_by": 1,
-            "uuid": "76d20e5e-e9f4-4b0c-a302-86a2734b9f70"
+            "uuid": "b7cbf151-16d3-4878-a982-c56f64d347bf"
         }
     },
     {
-        "model": "recordtransfer.submission",
+        "model": "recordtransfer.inprogresssubmission",
         "pk": 1,
         "fields": {
-            "submission_date": "2025-07-15T14:38:19.622Z",
+            "uuid": "2c240c3f-7e18-4d68-a194-cb49dbbbd761",
             "user": 1,
-            "raw_form": "gASViQ0AAAAAAAB9lCiMEmFncmVlbWVudF9hY2NlcHRlZJSIjAxjb250YWN0X25hbWWUjAhKb2huIERvZZSMCWpvYl90aXRsZZSMAJSMDG9yZ2FuaXphdGlvbpRoBYwMcGhvbmVfbnVtYmVylIwRKzEgKDk5OSkgOTk5LTk5OTmUjAVlbWFpbJSMDmFkbWluQGRlbW8uY29tlIwOYWRkcmVzc19saW5lXzGUjAsxMjMgSG9tZSBTdJSMDmFkZHJlc3NfbGluZV8ylIwHVW5pdCA1QZSMBGNpdHmUjAhXaW5uaXBlZ5SMEXByb3ZpbmNlX29yX3N0YXRllIwCTUKUjBdvdGhlcl9wcm92aW5jZV9vcl9zdGF0ZZRoBYwScG9zdGFsX29yX3ppcF9jb2RllIwHWjBaIDBaMJSMB2NvdW50cnmUjAJDQZSMGGVudGVyX21hbnVhbF9zb3VyY2VfaW5mb5SMA3llc5SMC3NvdXJjZV9uYW1llIwISmFuZSBEb2WUjAtzb3VyY2VfdHlwZZSMFWRqYW5nby5kYi5tb2RlbHMuYmFzZZSMDm1vZGVsX3VucGlja2xllJOUjAVjYWFpc5SMClNvdXJjZVR5cGWUhpSFlFKUfZQojAZfc3RhdGWUaB2MCk1vZGVsU3RhdGWUk5QpgZR9lCiMBmFkZGluZ5SJjAJkYpSMB2RlZmF1bHSUjAxmaWVsZHNfY2FjaGWUfZR1YowCaWSUSwKMBG5hbWWUjApJbmRpdmlkdWFslIwLZGVzY3JpcHRpb26UjBVBbiBpbmRpdmlkdWFsIHBlcnNvbi6UjBZzb3J0X29yZGVyX290aGVyX2ZpcnN0lIwKSW5kaXZpZHVhbJSMD19kamFuZ29fdmVyc2lvbpSMBjQuMi4yMJR1YowRb3RoZXJfc291cmNlX3R5cGWUaAWMC3NvdXJjZV9yb2xllGgfaCCMClNvdXJjZVJvbGWUhpSFlFKUfZQoaCZoKCmBlH2UKGgriWgsaC1oLn2UdWJoMEsCaDGMBURvbm9ylGgzjCdUaGUgZW50aXR5IGlzIHRoZSBkb25vciBvZiB0aGUgcmVjb3Jkcy6UaDWMBURvbm9ylGg3aDh1YowRb3RoZXJfc291cmNlX3JvbGWUaAWMC3NvdXJjZV9ub3RllIwlVGhlIGRvbm9yIHdpc2hlcyB0byByZW1haW4gYW5vbnltb3VzLpSMD2FjY2Vzc2lvbl90aXRsZZSMD1RFU1QgU1VCTUlTU0lPTpSMEWRhdGVfb2ZfbWF0ZXJpYWxzlIwXMjAyNS0wNy0wMSAtIDIwMjUtMDctMDiUjBNkYXRlX2lzX2FwcHJveGltYXRllIiMFGxhbmd1YWdlX29mX21hdGVyaWFslIwHRW5nbGlzaJSMHXByZWxpbWluYXJ5X3Njb3BlX2FuZF9jb250ZW50lIwnVGhpcyBpcyBhIHRlc3QgdXBsb2FkIG9mIHRoZSBOQ1RSIGxvZ28ulIwdcHJlbGltaW5hcnlfY3VzdG9kaWFsX2hpc3RvcnmUaAWMDmZvcm1zZXQtcmlnaHRzlF2UfZRhjBhmb3Jtc2V0LW90aGVyaWRlbnRpZmllcnOUXZR9lCiMFW90aGVyX2lkZW50aWZpZXJfdHlwZZSMD1Rlc3QgSWRlbnRpZmllcpSMFm90aGVyX2lkZW50aWZpZXJfdmFsdWWUjBVUZXN0IElkZW50aWZpZXIgVmFsdWWUjBVvdGhlcl9pZGVudGlmaWVyX25vdGWUjBVUZXN0IElkZW50aWZpZXIgTm90ZXOUdWGMCmdyb3VwX3V1aWSUjAR1dWlklIwEVVVJRJSTlCmBlH2UjANpbnSUihBwn0tzooYCowxL9OleDtJ2c2KMEHN1Ym1pc3Npb25fZ3JvdXCUaB+MDnJlY29yZHRyYW5zZmVylIwPU3VibWlzc2lvbkdyb3VwlIaUhZRSlH2UKGgmaCgpgZR9lChoLn2UaCuJaCxoLXViaDBLAWgxjBVURVNUIFNVQk1JU1NJT04gR1JPVVCUaDOMIFRoaXMgaXMgYSB0ZXN0IHN1Ym1pc3Npb24gZ3JvdXAulIwNY3JlYXRlZF9ieV9pZJRLAWhgaGIpgZR9lGhlihBwn0tzooYCowxL9OleDtJ2c2JoN2g4dWKMDGdlbmVyYWxfbm90ZZSMEVRlc3QgZmluYWwgbm90ZXMulIwNc2Vzc2lvbl90b2tlbpSMIG4wTGFBZVFSTUNBUm03RTNhMGpCMGMwM1NkcWFDVm1NlIwccXVhbnRpdHlfYW5kX3VuaXRfb2ZfbWVhc3VyZZSMIDEgSW1hZ2UgZmlsZSwgdG90YWxsaW5nIDExLjcwIEtClIwHY2FwdGNoYZRYjgYAADAzQUZjV2VBNlRDaGNTR2hOVlRLX3c1eUs3RTVPRGxDRVVVT3hSdzctTTA4NFYxSkRzSnRjZHJ3WHRfT251ZTB0WUtMS1lqOTFWZ2FZYUJwNkdQSFVYbG45NHRiX09zZWJmZnYxRnpuVlBJSm42SlRYMnRBMWFzQmNiVWdYWWp2ZXpiSjFTUklhejdLY1VqNGIxZVVSZENfdWtSNDJPUnY3R3RMbXdJWGhpS1VOU09SZGkxMzVOdElqREVISnZnLWszenF5ckZYWFZqY1JKREtmd1lDRVpPWWgzekVNZUE2RlJrc2swZnpGSk00ZW5yS1hRYzNadm9VeFRKUXR4aWNLSjJmRldiX0VfRml3VkZqQVJMSXc1cnJKcktFYWR4X05qZ1NILTFqT1R1WDFPWlJpZFJ2dVhyUmpyNGc3Z0NZa2ZfX1lhalRCRDl3LTBRRlVKSEZDUy1fd2NZTlVaTFA4cUtncndtczJ0R2hoQjNPVkFJWUx0T25wU1ZaRmp5ZWxNUThQeE43ekxnN01NR19DM3E5TVlmeldPQk04bW9wX2ZtbldIQXh6YXFrSUhkcDJmRTVTQllRNEpEaGhOSWVpaFhaVm5SSWl1QlVqaVJiYXpEWHVfUFptYnVEZlc2QnhzTW5vTWdFclJ1VGxVMTkwNUpncWZvRTNYRzJ0aE01SnY2OEo3ZDkzdmllaXYydE9DX3h3U2UwaWFKWGRaejNoTUpDcUJoNWNJTlJFY21Ga0lLY0Q0Y3hFeXFvajRvQXFkZWxaQ3RoamhOTWRyNTNkQzFWMW5WYmJWQWdBYjd3a3pwdUJrN1lYWnBxeHpycHBIdWFlNzVQYjZHc1NqSmU2SFVSUXpfSm56dlc2cVlWSG9hM0pjUS1GZTlyZWplVjAzOVBMUkd4MTRJWjg5Z0JTb1U2aUYxSEZhVzI5ckJfU2dLbUpKam1YRDRoX1hZV21EamxUY0lIdm5tVXBIQWNPMG9CLWRXNEdKbzRDWUdsNExHNzhFNG1kRXVmMHJtd1BaSEt1aFA0eXZHd2pHLUE3cHJRR29tNm9nS0lzMUYweHcwd1A4SFdPalF5MTB6bU1vRS1SLVJzZEw5SHNkZWlreUlpYmhvWHNtbmMtS0JSVlNGVU1WbFdHdjhBY2JTdlhzRkxuZTBrQmtKZEItb3UzeFpxRi1KTlo0eEtRR2pkckFGRXU4Z1BHZk9qMnNGNG1ibms0bUQ4cXQzMTN5bFNDbWlUa1RybW1BTWE1Ui11MG04VU9nd1JSVjI2dG9oMGdBSWpTRF9VWHNNLVBqczZ4bGlaLXg4V2tuR3VVYzUtVWk5R1R3T1EwZ2VyeGx1dXQzQVNqU21OWldZTkFlbjFVaGs3cWFqcklHVHJJblFpQUd3aWRJb0E2YW14U0FPbGZtQ3lXczdPY1pCeGVIaEFIZ3RDdHdfY04zamNtSkZPcGlrd0lVT3hEallPUGpEWkxqaFpySEVyZExidHdvSGE1b0ltMkNUM085cy0xR0xNYTV0bUZvcnB3dTBBMC15bkMzcWE1VUUxdUFITThOdDhlYmFXdzJiT0gwLTM2ZUg2emhfVFgxZ2hDOXZ0bzRMdFNnZFF2YTgzUEtYQ2lFeUR1VFRYWVhkWGFlSVJHSXVCUWFtb3NqVFpjZjMwUFlUcWNBU2kwdXlHdWVHYTdmVEExRkk2YzBxTW5OckxTamVLb3ZkVnpsb0JpdVZwRzBodDRqQmtsRWVGNUtDM1JlZzdJX09wX2tacklhVlNUZnBrR3ZIcURoSzJMdmoyUVhkVldDNVF2NG13a3ZYVWdqSTM5NTY5X2pQZTV4b2FXRWpuQlcwN2EwVUJEYXNKWlRWZlZRWVRSclhDN2Fnd2Q5TjZPM2dQWmQwRFJRTzhqbGEtMy1lTUwxQ0xFckNOVjFyYm9fam9qQ0ZOTFVuZm80a0Y4bEJiYjZSTjF5ZF92cnhxdEhUS2piUlRubm1jNXJVZlBDd0FNTENZeFpTNlBkUmZsSVJ3bEJURFVhYkEzbTNsZzB3ZEEtVVp0NXZiQmhCaDc5NXBpcEVtRTNmSlpmUjItZUtmWnhCZW1fQXJZazBaajNNejVNWlFFWXRuaUpmNWR4VHJaYVU4TENMVlZwZGhYZmJ5ZHkwaFJRa3EyeVEyTXNQbFZ1Y1pBQ1ZONms1UVl1ZkNOdWFmSHRlYlEwWEJjWXA2Q3NUVS0td1lNM3VHdXRkT0d6aEFaOUZyMmaUdS4=",
-            "metadata": 1,
-            "part_of_group": 1,
-            "upload_session": 1,
-            "uuid": "a33be86f-74e9-4de4-a47f-34e7b4b4d1e5"
-        }
-    },
-    {
-        "model": "recordtransfer.inprogresssubmission",
-        "pk": 2,
-        "fields": {
-            "uuid": "966f8b63-20fe-4ed9-9d41-46f37049398b",
-            "user": 1,
-            "last_updated": "2025-07-15T14:40:45.640Z",
-            "current_step": "uploadfiles",
-            "step_data": "gASVsgoAAAAAAAB9lCiMBHBhc3SUfZQojARzdGVwlIwLdXBsb2FkZmlsZXOUjAlzdGVwX2RhdGGUfZQojAthY2NlcHRsZWdhbJR9lCiME2NzcmZtaWRkbGV3YXJldG9rZW6UXZSMQE5sUldEN1J5Uk5uWktXdk1xbEFzWGdwbDhRcXZPSlRGQTFuRDVvY0lTVDV2YmlnaUpLc0FKcXdGVUw1QUFGaUuUYYwjc3VibWlzc2lvbl9mb3JtX3dpemFyZC1jdXJyZW50X3N0ZXCUXZSMC2FjY2VwdGxlZ2FslGGMHmFjY2VwdGxlZ2FsLWFncmVlbWVudF9hY2NlcHRlZJRdlIwCb26UYXWMC2NvbnRhY3RpbmZvlH2UKGgJXZSMQDNKYkVVekVzRnJ0OFNKUWVJWkRsUWVEVTdoenJUS3JjUXBIbG1RWkNHeGJFajVCSzFvdnRDb0tlVGNld0ZHUWiUYWgMXZSMC2NvbnRhY3RpbmZvlGGMGGNvbnRhY3RpbmZvLWNvbnRhY3RfbmFtZZRdlIwISm9obiBEb2WUYYwVY29udGFjdGluZm8tam9iX3RpdGxllF2UjACUYYwYY29udGFjdGluZm8tb3JnYW5pemF0aW9ulF2UaB1hjBhjb250YWN0aW5mby1waG9uZV9udW1iZXKUXZSMESsxICg5OTkpIDk5OS05OTk5lGGMEWNvbnRhY3RpbmZvLWVtYWlslF2UjA5hZG1pbkBkZW1vLmNvbZRhjBpjb250YWN0aW5mby1hZGRyZXNzX2xpbmVfMZRdlIwLMTIzIEhvbWUgU3SUYYwaY29udGFjdGluZm8tYWRkcmVzc19saW5lXzKUXZSMB1VuaXQgNUGUYYwQY29udGFjdGluZm8tY2l0eZRdlIwIV2lubmlwZWeUYYwdY29udGFjdGluZm8tcHJvdmluY2Vfb3Jfc3RhdGWUXZSMAk1ClGGMI2NvbnRhY3RpbmZvLW90aGVyX3Byb3ZpbmNlX29yX3N0YXRllF2UaB1hjB5jb250YWN0aW5mby1wb3N0YWxfb3JfemlwX2NvZGWUXZSMB1owWiAwWjCUYYwTY29udGFjdGluZm8tY291bnRyeZRdlIwCQ0GUYXWMCnNvdXJjZWluZm+UfZQoaAldlIxAN2pOblU0OWlCV3IzY1h3WkhIV054UUthR2Y0RXFFQ3dVWmo0bWx1c0MyOXpEamh2MDZPVmowUnVzYUpKY0ExQpRhaAxdlIwKc291cmNlaW5mb5RhjCNzb3VyY2VpbmZvLWVudGVyX21hbnVhbF9zb3VyY2VfaW5mb5RdlIwCbm+UYYwWc291cmNlaW5mby1zb3VyY2VfbmFtZZRdlGgdYYwWc291cmNlaW5mby1zb3VyY2VfdHlwZZRdlGgdYYwcc291cmNlaW5mby1vdGhlcl9zb3VyY2VfdHlwZZRdlGgdYYwWc291cmNlaW5mby1zb3VyY2Vfcm9sZZRdlGgdYYwcc291cmNlaW5mby1vdGhlcl9zb3VyY2Vfcm9sZZRdlGgdYYwWc291cmNlaW5mby1zb3VyY2Vfbm90ZZRdlGgdYXWMEXJlY29yZGRlc2NyaXB0aW9ulH2UKGgJXZSMQHFldld2VlNpTHdBMDZYd0dTMVBKVlk4Y1pydDBWV090ZFUxRFhjZHNNQ2l3eGpoY2JxSFJIOGZ3TG04NUhTZHmUYWgMXZSMEXJlY29yZGRlc2NyaXB0aW9ulGGMIXJlY29yZGRlc2NyaXB0aW9uLWFjY2Vzc2lvbl90aXRsZZRdlIwlVEVTVCBFWFBJUkFCTEUgSU4tUFJPR1JFU1MgU1VCTUlTU0lPTpRhjCNyZWNvcmRkZXNjcmlwdGlvbi1kYXRlX29mX21hdGVyaWFsc5RdlIwXMjAyNS0wNy0wMSAtIDIwMjUtMDctMDiUYYwmcmVjb3JkZGVzY3JpcHRpb24tbGFuZ3VhZ2Vfb2ZfbWF0ZXJpYWyUXZSMB0VuZ2xpc2iUYYwvcmVjb3JkZGVzY3JpcHRpb24tcHJlbGltaW5hcnlfc2NvcGVfYW5kX2NvbnRlbnSUXZSMMFRoaXMgaXMgYSB0ZXN0IGV4cGlyYWJsZSBpbi1wcm9ncmVzcyBzdWJtaXNzaW9uLpRhjC9yZWNvcmRkZXNjcmlwdGlvbi1wcmVsaW1pbmFyeV9jdXN0b2RpYWxfaGlzdG9yeZRdlGgdYXWMBnJpZ2h0c5R9lChoCV2UjEA5aTFYZnVsc0VaTDdKTHBqdUY4SUxETjBRVkd0dk1wMFdZeEVITEdDRjV0RGE3YVBONDBReE5Va0NRbHloSU81lGFoDF2UjAZyaWdodHOUYYwScmlnaHRzLVRPVEFMX0ZPUk1TlF2UjAExlGGMFHJpZ2h0cy1JTklUSUFMX0ZPUk1TlF2UaGthjBRyaWdodHMtTUlOX05VTV9GT1JNU5RdlIwBMJRhjBRyaWdodHMtTUFYX05VTV9GT1JNU5RdlIwEMTAwMJRhjBRyaWdodHMtMC1yaWdodHNfdHlwZZRdlIwBNpRhjBpyaWdodHMtMC1vdGhlcl9yaWdodHNfdHlwZZRdlGgdYYwVcmlnaHRzLTAtcmlnaHRzX3ZhbHVllF2UjBFUZXN0IHJpZ2h0cyBub3Rlc5RhdYwQb3RoZXJpZGVudGlmaWVyc5R9lChoCV2UjEBIVVZDTFJSSTV0TW9ZZ1QycEpJdTVaMEVUNWJWRzloUHVBcmpkOGNTNnp1VXBDRXlJOEFDUjk3WUYwUTBzNUdVlGFoDF2UjBBvdGhlcmlkZW50aWZpZXJzlGGMHG90aGVyaWRlbnRpZmllcnMtVE9UQUxfRk9STVOUXZRoa2GMHm90aGVyaWRlbnRpZmllcnMtSU5JVElBTF9GT1JNU5RdlGhrYYweb3RoZXJpZGVudGlmaWVycy1NSU5fTlVNX0ZPUk1TlF2UaHBhjB5vdGhlcmlkZW50aWZpZXJzLU1BWF9OVU1fRk9STVOUXZSMBDEwMDCUYYwob3RoZXJpZGVudGlmaWVycy0wLW90aGVyX2lkZW50aWZpZXJfdHlwZZRdlGgdYYwpb3RoZXJpZGVudGlmaWVycy0wLW90aGVyX2lkZW50aWZpZXJfdmFsdWWUXZRoHWGMKG90aGVyaWRlbnRpZmllcnMtMC1vdGhlcl9pZGVudGlmaWVyX25vdGWUXZRoHWF1jA9ncm91cHN1Ym1pc3Npb26UfZQoaAldlIxAbmhzYjc0NGFQc2pwcjZ2TVUxWFF6ZWJYdElDamxVb0RhWFlTemxwa1F5MVZTc2dpZHFQWWxvaWhmRGhvN1FOSZRhaAxdlIwPZ3JvdXBzdWJtaXNzaW9ulGGMGmdyb3Vwc3VibWlzc2lvbi1ncm91cF91dWlklF2UaB1hdXWMCnN0ZXBfZmlsZXOUfZQoaAd9lGgSfZRoOn2UaE99lGhjfZRofH2UaJF9lHWMCmV4dHJhX2RhdGGUfZSMGnNhdmVfY29udGFjdF9pbmZvX3Byb21wdGVklIhzdYwHY3VycmVudJR9lCiMDGdlbmVyYWxfbm90ZZRoHYwNc2Vzc2lvbl90b2tlbpSMIFREZjN2b3hnaUkycU9zdGJLWVRmellKbmJrNjF4T1hXlHV1Lg==",
-            "title": "TEST EXPIRABLE IN-PROGRESS SUBMISSION",
-            "upload_session": 2,
-            "reminder_email_sent": false
-        }
-    },
-    {
-        "model": "recordtransfer.inprogresssubmission",
-        "pk": 3,
-        "fields": {
-            "uuid": "72a95fb8-fdfb-4fc8-9cd3-c601f3bea320",
-            "user": 1,
-            "last_updated": "2025-07-15T14:42:10.213Z",
+            "last_updated": "2025-08-29T16:26:17.591Z",
             "current_step": "recorddescription",
-            "step_data": "gASV/wUAAAAAAAB9lCiMBHBhc3SUfZQojARzdGVwlIwRcmVjb3JkZGVzY3JpcHRpb26UjAlzdGVwX2RhdGGUfZQojAthY2NlcHRsZWdhbJR9lCiME2NzcmZtaWRkbGV3YXJldG9rZW6UXZSMQEVjTHU1Z0pMcFBLY3REc3ZpN3JOTElZaUYwNFpwVWdzclNoYnh4NFZxVnNJVVpkMUJ3alZ4UzVDclZKNGJRRniUYYwjc3VibWlzc2lvbl9mb3JtX3dpemFyZC1jdXJyZW50X3N0ZXCUXZSMC2FjY2VwdGxlZ2FslGGMHmFjY2VwdGxlZ2FsLWFncmVlbWVudF9hY2NlcHRlZJRdlIwCb26UYXWMC2NvbnRhY3RpbmZvlH2UKGgJXZSMQFlYMmRESmZjc0U0RWJHN2ZzVmRhcXdYeDFrYVU1dU9FTER5VTUwQW10S01hQzJTTExrNWljRzRSTmZQWlJxZEqUYWgMXZSMC2NvbnRhY3RpbmZvlGGMGGNvbnRhY3RpbmZvLWNvbnRhY3RfbmFtZZRdlIwISm9obiBEb2WUYYwVY29udGFjdGluZm8tam9iX3RpdGxllF2UjACUYYwYY29udGFjdGluZm8tb3JnYW5pemF0aW9ulF2UaB1hjBhjb250YWN0aW5mby1waG9uZV9udW1iZXKUXZSMESs5ICg5OTkpIDk5OS05OTk5lGGMEWNvbnRhY3RpbmZvLWVtYWlslF2UjA5hZG1pbkBkZW1vLmNvbZRhjBpjb250YWN0aW5mby1hZGRyZXNzX2xpbmVfMZRdlIwLMTIzIEhvbWUgU3SUYYwaY29udGFjdGluZm8tYWRkcmVzc19saW5lXzKUXZRoHWGMEGNvbnRhY3RpbmZvLWNpdHmUXZSMCFdpbm5pcGVnlGGMHWNvbnRhY3RpbmZvLXByb3ZpbmNlX29yX3N0YXRllF2UjAJNQpRhjCNjb250YWN0aW5mby1vdGhlcl9wcm92aW5jZV9vcl9zdGF0ZZRdlGgdYYweY29udGFjdGluZm8tcG9zdGFsX29yX3ppcF9jb2RllF2UjAdaMFogMFowlGGME2NvbnRhY3RpbmZvLWNvdW50cnmUXZSMAkNBlGF1jApzb3VyY2VpbmZvlH2UKGgJXZSMQDUzWko3NFlyeEJrc1RxWGRQN1FXVTIwc1FyQU5PSFVjU0p2cXpsakJ5SDJZa01JSjh3STRHYzdNQ21mU0FEamiUYWgMXZSMCnNvdXJjZWluZm+UYYwjc291cmNlaW5mby1lbnRlcl9tYW51YWxfc291cmNlX2luZm+UXZSMAm5vlGGMFnNvdXJjZWluZm8tc291cmNlX25hbWWUXZRoHWGMFnNvdXJjZWluZm8tc291cmNlX3R5cGWUXZRoHWGMHHNvdXJjZWluZm8tb3RoZXJfc291cmNlX3R5cGWUXZRoHWGMFnNvdXJjZWluZm8tc291cmNlX3JvbGWUXZRoHWGMHHNvdXJjZWluZm8tb3RoZXJfc291cmNlX3JvbGWUXZRoHWGMFnNvdXJjZWluZm8tc291cmNlX25vdGWUXZRoHWF1dYwKc3RlcF9maWxlc5R9lChoB32UaBJ9lGg5fZR1jApleHRyYV9kYXRhlH2UjBpzYXZlX2NvbnRhY3RfaW5mb19wcm9tcHRlZJSIc3WMB2N1cnJlbnSUfZQojA9hY2Nlc3Npb25fdGl0bGWUjClOT04tRVhQSVJBQkxFIFRFU1QgSU4tUFJPR1JFU1MgU1VCTUlTU0lPTpSMEWRhdGVfb2ZfbWF0ZXJpYWxzlIwXMjAyNS0wNy0wMSAtIDIwMjUtMDctMDiUjBRsYW5ndWFnZV9vZl9tYXRlcmlhbJSMB0VuZ2xpc2iUjB1wcmVsaW1pbmFyeV9zY29wZV9hbmRfY29udGVudJSMNFRoaXMgaXMgYSBub24tZXhwaXJhYmxlIHRlc3QgaW4tcHJvZ3Jlc3Mgc3VibWlzc2lvbi6UjB1wcmVsaW1pbmFyeV9jdXN0b2RpYWxfaGlzdG9yeZRoHXV1Lg==",
+            "step_data": "gASVJAYAAAAAAAB9lCiMBHBhc3SUfZQojARzdGVwlIwRcmVjb3JkZGVzY3JpcHRpb26UjAlzdGVwX2RhdGGUfZQojAthY2NlcHRsZWdhbJR9lCiME2NzcmZtaWRkbGV3YXJldG9rZW6UXZSMQGxnYkE3R0xmQmY3akRkQ3d0SXc0cmI0WVpMblF4SU5MZ01UdHJBUDRaMVJJZFZjdFNIMGtuN0xWTEZOeTFQUHKUYYwjc3VibWlzc2lvbl9mb3JtX3dpemFyZC1jdXJyZW50X3N0ZXCUXZSMC2FjY2VwdGxlZ2FslGGMHmFjY2VwdGxlZ2FsLWFncmVlbWVudF9hY2NlcHRlZJRdlIwCb26UYXWMC2NvbnRhY3RpbmZvlH2UKGgJXZSMQFA2ZVZ0aHBpQUZ6VXY3R0FXTXJMNmpsUmVPejJnbUtaS0NXT05idDdZcmpqNVBneGxMVjEyZjJPMElaS0t0TUaUYWgMXZSMC2NvbnRhY3RpbmZvlGGMGGNvbnRhY3RpbmZvLWNvbnRhY3RfbmFtZZRdlIwISm9obiBEb2WUYYwVY29udGFjdGluZm8tam9iX3RpdGxllF2UjAlBcmNoaXZpc3SUYYwYY29udGFjdGluZm8tb3JnYW5pemF0aW9ulF2UjAROQ1RSlGGMGGNvbnRhY3RpbmZvLXBob25lX251bWJlcpRdlIwRKzEgKDk5OSkgOTk5LTk5OTmUYYwRY29udGFjdGluZm8tZW1haWyUXZSMDmFkbWluQGRlbW8uY29tlGGMGmNvbnRhY3RpbmZvLWFkZHJlc3NfbGluZV8xlF2UjAsxMjMgSG9tZSBTdJRhjBpjb250YWN0aW5mby1hZGRyZXNzX2xpbmVfMpRdlIwAlGGMEGNvbnRhY3RpbmZvLWNpdHmUXZSMCFdpbm5pcGVnlGGMHWNvbnRhY3RpbmZvLXByb3ZpbmNlX29yX3N0YXRllF2UjAJNQpRhjCNjb250YWN0aW5mby1vdGhlcl9wcm92aW5jZV9vcl9zdGF0ZZRdlGgsYYweY29udGFjdGluZm8tcG9zdGFsX29yX3ppcF9jb2RllF2UjAdaMFogMFowlGGME2NvbnRhY3RpbmZvLWNvdW50cnmUXZSMAkNBlGF1jApzb3VyY2VpbmZvlH2UKGgJXZSMQFhuSnYydUp4UzVyblZWWDVJVlBndFUwRmhlbzFaNGRhU1Ryb21vTm1nUmJNdkR4MjdVandwUUhDMzhPSnRiZlGUYWgMXZSMCnNvdXJjZWluZm+UYYwjc291cmNlaW5mby1lbnRlcl9tYW51YWxfc291cmNlX2luZm+UXZSMA3llc5RhjBZzb3VyY2VpbmZvLXNvdXJjZV9uYW1llF2UjAhKYW5lIERvZZRhjBZzb3VyY2VpbmZvLXNvdXJjZV90eXBllF2UjAEylGGMHHNvdXJjZWluZm8tb3RoZXJfc291cmNlX3R5cGWUXZRoLGGMFnNvdXJjZWluZm8tc291cmNlX3JvbGWUXZRoSWGMHHNvdXJjZWluZm8tb3RoZXJfc291cmNlX3JvbGWUXZRoLGGMFnNvdXJjZWluZm8tc291cmNlX25vdGWUXZRoLGF1dYwKc3RlcF9maWxlc5R9lChoB32UaBJ9lGg7fZR1jApleHRyYV9kYXRhlH2UjBpzYXZlX2NvbnRhY3RfaW5mb19wcm9tcHRlZJSIc3WMB2N1cnJlbnSUfZQojA9hY2Nlc3Npb25fdGl0bGWUjClOT04tRVhQSVJBQkxFIFRFU1QgSU4tUFJPR1JFU1MgU1VCTUlTU0lPTpSMFGxhbmd1YWdlX29mX21hdGVyaWFslIwHRW5nbGlzaJSMEWRhdGVfb2ZfbWF0ZXJpYWxzlIwXMjAyNS0wOC0wMSAtIDIwMjUtMDgtMTWUjB1wcmVsaW1pbmFyeV9zY29wZV9hbmRfY29udGVudJSMNFRoaXMgaXMgYSB0ZXN0IG5vbi1leHBpcmFibGUgaW4tcHJvZ3Jlc3Mgc3VibWlzc2lvbi6UjB1wcmVsaW1pbmFyeV9jdXN0b2RpYWxfaGlzdG9yeZRoLHWMBWV4dHJhlGhYdS4=",
             "title": "NON-EXPIRABLE TEST IN-PROGRESS SUBMISSION",
             "upload_session": null,
             "reminder_email_sent": false
         }
     },
     {
-        "model": "caais.metadata",
-        "pk": 1,
+        "model": "recordtransfer.inprogresssubmission",
+        "pk": 2,
         "fields": {
-            "repository": "",
-            "accession_title": "TEST SUBMISSION",
-            "acquisition_method": null,
-            "status": null,
-            "date_of_materials": "2025-07-01 - 2025-07-08",
-            "date_is_approximate": true,
-            "rules_or_conventions": "",
-            "language_of_accession_record": ""
-        }
-    },
-    {
-        "model": "caais.identifier",
-        "pk": 1,
-        "fields": {
-            "metadata": 1,
-            "identifier_type": "Test Identifier",
-            "identifier_value": "Test Identifier Value",
-            "identifier_note": "Test Identifier Notes"
+            "uuid": "ba8974ea-969d-4efb-ae14-71b98331c2d2",
+            "user": 1,
+            "last_updated": "2025-08-29T16:29:15.231Z",
+            "current_step": "uploadfiles",
+            "step_data": "gASVzgwAAAAAAAB9lCiMBHBhc3SUfZQojARzdGVwlIwLdXBsb2FkZmlsZXOUjAlzdGVwX2RhdGGUfZQojAthY2NlcHRsZWdhbJR9lCiME2NzcmZtaWRkbGV3YXJldG9rZW6UXZSMQGdneHNTM0prVzF6VnRZQUVFV1NTNnlWcWxlemxZeFFmYk1mbGNYTjlrTmprM0dhQjNWbTgydUNuNzhaM3NFU1aUYYwjc3VibWlzc2lvbl9mb3JtX3dpemFyZC1jdXJyZW50X3N0ZXCUXZSMC2FjY2VwdGxlZ2FslGGMHmFjY2VwdGxlZ2FsLWFncmVlbWVudF9hY2NlcHRlZJRdlIwCb26UYXWMC2NvbnRhY3RpbmZvlH2UKGgJXZSMQDVWS0U2elVHSWRjMnBEMlA2TFVBVGw2M1JUdVVPV2FKMHJzeHF0WXY2WldyWmxDTXZLb1FQaE4wRE5VQ2kzY3CUYWgMXZSMC2NvbnRhY3RpbmZvlGGMGGNvbnRhY3RpbmZvLWNvbnRhY3RfbmFtZZRdlIwISm9obiBEb2WUYYwVY29udGFjdGluZm8tam9iX3RpdGxllF2UjAlBcmNoaXZpc3SUYYwYY29udGFjdGluZm8tb3JnYW5pemF0aW9ulF2UjAROQ1RSlGGMGGNvbnRhY3RpbmZvLXBob25lX251bWJlcpRdlIwRKzEgKDk5OSkgOTk5LTk5OTmUYYwRY29udGFjdGluZm8tZW1haWyUXZSMDmFkbWluQGRlbW8uY29tlGGMGmNvbnRhY3RpbmZvLWFkZHJlc3NfbGluZV8xlF2UjAsxMjMgSG9tZSBTdJRhjBpjb250YWN0aW5mby1hZGRyZXNzX2xpbmVfMpRdlIwAlGGMEGNvbnRhY3RpbmZvLWNpdHmUXZSMCFdpbm5pcGVnlGGMHWNvbnRhY3RpbmZvLXByb3ZpbmNlX29yX3N0YXRllF2UjAJNQpRhjCNjb250YWN0aW5mby1vdGhlcl9wcm92aW5jZV9vcl9zdGF0ZZRdlGgsYYweY29udGFjdGluZm8tcG9zdGFsX29yX3ppcF9jb2RllF2UjAdaMFogMFowlGGME2NvbnRhY3RpbmZvLWNvdW50cnmUXZSMAkNBlGF1jApzb3VyY2VpbmZvlH2UKGgJXZSMQHllaHZFY3VTVG5rQ0hVektPSEUzdFBITjlDczlnVTZudEtab1k2eUhoOTQxaEM5SGRHOGpwTG9LVndTUksxODOUYWgMXZSMCnNvdXJjZWluZm+UYYwjc291cmNlaW5mby1lbnRlcl9tYW51YWxfc291cmNlX2luZm+UXZSMAm5vlGGMFnNvdXJjZWluZm8tc291cmNlX25hbWWUXZRoLGGMFnNvdXJjZWluZm8tc291cmNlX3R5cGWUXZRoLGGMHHNvdXJjZWluZm8tb3RoZXJfc291cmNlX3R5cGWUXZRoLGGMFnNvdXJjZWluZm8tc291cmNlX3JvbGWUXZRoLGGMHHNvdXJjZWluZm8tb3RoZXJfc291cmNlX3JvbGWUXZRoLGGMFnNvdXJjZWluZm8tc291cmNlX25vdGWUXZRoLGF1jBFyZWNvcmRkZXNjcmlwdGlvbpR9lChoCV2UjEBNNWllb0FMaU1kRXZFNERpVGExZG5jRmsweE5Wcnl4eUhCMDdJdVA3YVpvVWVNZGZpOXZ0ajhtaE1yZERWRnpllGFoDF2UjBFyZWNvcmRkZXNjcmlwdGlvbpRhjCFyZWNvcmRkZXNjcmlwdGlvbi1hY2Nlc3Npb25fdGl0bGWUXZSMJVRFU1QgRVhQSVJBQkxFIElOLVBST0dSRVNTIFNVQk1JU1NJT06UYYwmcmVjb3JkZGVzY3JpcHRpb24tbGFuZ3VhZ2Vfb2ZfbWF0ZXJpYWyUXZSMD0VuZ2xpc2gsIEZyZW5jaJRhjCNyZWNvcmRkZXNjcmlwdGlvbi1kYXRlX29mX21hdGVyaWFsc5RdlIwXMjAyNS0wOC0wMSAtIDIwMjUtMDgtMTWUYYwvcmVjb3JkZGVzY3JpcHRpb24tcHJlbGltaW5hcnlfc2NvcGVfYW5kX2NvbnRlbnSUXZSMMFRoaXMgaXMgYSB0ZXN0IGV4cGlyYWJsZSBpbi1wcm9ncmVzcyBzdWJtaXNzaW9uLpRhjC9yZWNvcmRkZXNjcmlwdGlvbi1wcmVsaW1pbmFyeV9jdXN0b2RpYWxfaGlzdG9yeZRdlGgsYXWMBnJpZ2h0c5R9lChoCV2UjEBlZGpZWGRsVFdwQTZJcG1sOEJxOVlvcDVQQ2pRT3EzRDlKMVJoN3BJa2Jrdmk3V2l4QVVwVWs2MkJ3SnlpeDVqlGFoDF2UjAZyaWdodHOUYYwScmlnaHRzLVRPVEFMX0ZPUk1TlF2UjAExlGGMFHJpZ2h0cy1JTklUSUFMX0ZPUk1TlF2UaGxhjBRyaWdodHMtTUlOX05VTV9GT1JNU5RdlIwBMJRhjBRyaWdodHMtTUFYX05VTV9GT1JNU5RdlIwEMTAwMJRhjBRyaWdodHMtMC1yaWdodHNfdHlwZZRdlIwBNpRhjBpyaWdodHMtMC1vdGhlcl9yaWdodHNfdHlwZZRdlGgsYYwVcmlnaHRzLTAtcmlnaHRzX3ZhbHVllF2UaCxhdYwQb3RoZXJpZGVudGlmaWVyc5R9lChoCV2UjEBubWp0eGx0YTIzc1dMSmdZZ3hyY0JaeHFNbUtUaFBGeWlTMW1SZnhacVBjbGxyUVZGd1ZzeFZlbnlnYUJMV0hllGFoDF2UjBBvdGhlcmlkZW50aWZpZXJzlGGMHG90aGVyaWRlbnRpZmllcnMtVE9UQUxfRk9STVOUXZRobGGMHm90aGVyaWRlbnRpZmllcnMtSU5JVElBTF9GT1JNU5RdlGhsYYweb3RoZXJpZGVudGlmaWVycy1NSU5fTlVNX0ZPUk1TlF2UaHFhjB5vdGhlcmlkZW50aWZpZXJzLU1BWF9OVU1fRk9STVOUXZSMBDEwMDCUYYwob3RoZXJpZGVudGlmaWVycy0wLW90aGVyX2lkZW50aWZpZXJfdHlwZZRdlIwPVGVzdCBJZGVudGlmaWVylGGMKW90aGVyaWRlbnRpZmllcnMtMC1vdGhlcl9pZGVudGlmaWVyX3ZhbHVllF2UjAlBQkMtMTIzNDWUYYwob3RoZXJpZGVudGlmaWVycy0wLW90aGVyX2lkZW50aWZpZXJfbm90ZZRdlGgsYXWMD2dyb3Vwc3VibWlzc2lvbpR9lChoCV2UjEBYVXpwSFE2aUJvVmI3Q3pYMWhkaWc1blkyQldaaWJTWVNxaGkxS2E3WmFGQUhrOVVxZ0h5YzE0Vk92bUhNaVVFlGFoDF2UjA9ncm91cHN1Ym1pc3Npb26UYYwaZ3JvdXBzdWJtaXNzaW9uLWdyb3VwX3V1aWSUXZSMJGI3Y2JmMTUxLTE2ZDMtNDg3OC1hOTgyLWM1NmY2NGQzNDdiZpRhdYwLdXBsb2FkZmlsZXOUfZQoaAldlIxAV291MVBaREV5S2F3RDlwdnNvbHE5c05sT2FUVEtUVlFSVWNVOVRIdFd3VVZkUlpzUm5QRzVvdWlBNGpCZTBYd5RhaAxdlIwLdXBsb2FkZmlsZXOUYYwYdXBsb2FkZmlsZXMtZ2VuZXJhbF9ub3RllF2UjBpUaGlzIGlzIGEgdGVzdCBmaW5hbCBub3RlLpRhjBl1cGxvYWRmaWxlcy1zZXNzaW9uX3Rva2VulF2UjCBnOGJCamtLc0VpekhPbXJLUGUzeHI3Y0h0SjZpYlI2MJRhjBB3aXphcmRfZ290b19zdGVwlF2UjAZyZXZpZXeUYXWMBnJldmlld5R9lChoCV2UjEBiV015Rk0wYk9QaWdHR05GMTlFRWxiWlE4NUUxc0JHbTZzdXJaRzQwY0IyRmdvbkNxODhVaDdHTlVaNEpXSUkylGFoDF2UjAZyZXZpZXeUYWioXZSMC3VwbG9hZGZpbGVzlGF1dYwKc3RlcF9maWxlc5R9lChoB32UaBJ9lGg7fZRoUH2UaGR9lGh8fZRok32UaJx9lGirfZR1jApleHRyYV9kYXRhlH2UKIwac2F2ZV9jb250YWN0X2luZm9fcHJvbXB0ZWSUiIwNc2Vzc2lvbl90b2tlbpSMIGc4YkJqa0tzRWl6SE9tcktQZTN4cjdjSHRKNmliUjYwlHV1jAdjdXJyZW50lH2UKIwMZ2VuZXJhbF9ub3RllIwaVGhpcyBpcyBhIHRlc3QgZmluYWwgbm90ZS6UjA1zZXNzaW9uX3Rva2VulIwgZzhiQmprS3NFaXpIT21yS1BlM3hyN2NIdEo2aWJSNjCUdYwFZXh0cmGUaL91Lg==",
+            "title": "TEST EXPIRABLE IN-PROGRESS SUBMISSION",
+            "upload_session": 1,
+            "reminder_email_sent": false
         }
     },
     {
@@ -589,30 +533,7 @@
         "pk": 2,
         "fields": {
             "name": "Donor",
-            "description": "The entity is the donor of the records."
-        }
-    },
-    {
-        "model": "caais.sourceofmaterial",
-        "pk": 1,
-        "fields": {
-            "metadata": 1,
-            "source_type": 2,
-            "source_name": "Jane Doe",
-            "contact_name": "John Doe",
-            "job_title": "",
-            "organization": "",
-            "phone_number": "+1 (999) 999-9999",
-            "email_address": "admin@demo.com",
-            "address_line_1": "123 Home St",
-            "address_line_2": "Unit 5A",
-            "city": "Winnipeg",
-            "region": "MB",
-            "postal_or_zip_code": "Z0Z 0Z0",
-            "country": "CA",
-            "source_role": 2,
-            "source_note": "The donor wishes to remain anonymous.",
-            "source_confidentiality": null
+            "description": "An entity that donates records."
         }
     },
     {
@@ -637,34 +558,6 @@
         "fields": {
             "name": "Extent removed",
             "description": "Extent of removed material"
-        }
-    },
-    {
-        "model": "caais.extentstatement",
-        "pk": 1,
-        "fields": {
-            "metadata": 1,
-            "extent_type": null,
-            "quantity_and_unit_of_measure": "1 Image file, totalling 11.70 KB",
-            "content_type": null,
-            "carrier_type": null,
-            "extent_note": ""
-        }
-    },
-    {
-        "model": "caais.preliminaryscopeandcontent",
-        "pk": 1,
-        "fields": {
-            "metadata": 1,
-            "preliminary_scope_and_content": "This is a test upload of the NCTR logo."
-        }
-    },
-    {
-        "model": "caais.languageofmaterial",
-        "pk": 1,
-        "fields": {
-            "metadata": 1,
-            "language_of_material": "English"
         }
     },
     {
@@ -721,52 +614,6 @@
         "fields": {
             "name": "Copyright",
             "description": "Access to material is based on fair dealing OR material is in the public domain"
-        }
-    },
-    {
-        "model": "caais.eventtype",
-        "pk": 1,
-        "fields": {
-            "name": "Transfer Submitted",
-            "description": ""
-        }
-    },
-    {
-        "model": "caais.event",
-        "pk": 1,
-        "fields": {
-            "metadata": 1,
-            "event_type": 1,
-            "event_date": "2025-07-15T14:38:19.685Z",
-            "event_agent": "",
-            "event_note": ""
-        }
-    },
-    {
-        "model": "caais.generalnote",
-        "pk": 1,
-        "fields": {
-            "metadata": 1,
-            "general_note": "Test final notes."
-        }
-    },
-    {
-        "model": "caais.creationorrevisiontype",
-        "pk": 1,
-        "fields": {
-            "name": "Creation",
-            "description": ""
-        }
-    },
-    {
-        "model": "caais.dateofcreationorrevision",
-        "pk": 1,
-        "fields": {
-            "metadata": 1,
-            "creation_or_revision_type": 1,
-            "creation_or_revision_date": "2025-07-15T14:38:19.692Z",
-            "creation_or_revision_agent": "",
-            "creation_or_revision_note": ""
         }
     }
 ]

--- a/app/recordtransfer/forms/submission_forms.py
+++ b/app/recordtransfer/forms/submission_forms.py
@@ -788,7 +788,7 @@ class UploadFilesForm(SubmissionForm):
             LOGGER.warning(
                 "**SUSPICIOUS OPERATION**: hidden session_token input was changed by %(username)s "
                 "in the upload files form",
-                self.user.username,
+                self.user.username if self.user else "unknown user",
             )
             self.add_error("session_token", _("Invalid upload session state. Please try again."))
             return cleaned_data

--- a/app/recordtransfer/forms/submission_forms.py
+++ b/app/recordtransfer/forms/submission_forms.py
@@ -741,6 +741,10 @@ class UploadFilesForm(SubmissionForm):
 
         submission_step = SubmissionStep.UPLOAD_FILES
 
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop("user", None)
+        super().__init__(*args, **kwargs)
+
     general_note = forms.CharField(
         required=False,
         min_length=4,
@@ -762,26 +766,23 @@ class UploadFilesForm(SubmissionForm):
         required=True,
         widget=forms.HiddenInput(),
         label="hidden",
-        error_messages={"required": "Upload session token is required"},
+        error_messages={"required": _("Upload session token is required")},
     )
 
     def clean(self) -> dict:
         """Check that the session token is valid and that at least one file has been uploaded."""
         cleaned_data = super().clean()
-        session_token = cleaned_data.get("session_token")
+        token = cleaned_data.get("session_token")
 
-        if not session_token:
-            self.add_error("session_token", "Invalid upload. Please try again.")
-            return cleaned_data
+        upload_session = UploadSession.objects.filter(token=token, user=self.user).first()
 
-        try:
-            upload_session = UploadSession.objects.get(token=session_token)
-        except UploadSession.DoesNotExist:
-            self.add_error("session_token", "Invalid upload. Please try again.")
+        if not upload_session:
+            self.add_error("session_token", _("Invalid upload. Please try again."))
             return cleaned_data
 
         if upload_session.file_count == 0:
-            self.add_error("session_token", "You must upload at least one file")
+            self.add_error("session_token", _("You must upload at least one file"))
+            return cleaned_data
 
         cleaned_data["quantity_and_unit_of_measure"] = (
             upload_session.get_quantity_and_unit_of_measure()

--- a/app/recordtransfer/forms/submission_forms.py
+++ b/app/recordtransfer/forms/submission_forms.py
@@ -786,8 +786,8 @@ class UploadFilesForm(SubmissionForm):
 
         if upload_session.token != self.correct_session_token:
             LOGGER.warning(
-                "**SUSPICIOUS OPERATION**: hidden session_token input was changed by %(username)s "
-                "in the upload files form",
+                "**SUSPICIOUS OPERATION**: hidden session_token input was changed by %s in the "
+                "upload files form",
                 self.user.username if self.user else "unknown user",
             )
             self.add_error("session_token", _("Invalid upload session state. Please try again."))

--- a/app/recordtransfer/tests/unit/test_forms.py
+++ b/app/recordtransfer/tests/unit/test_forms.py
@@ -938,7 +938,7 @@ class UploadFilesFormTest(TestCase):
         self.upload_session = UploadSession.new_session()
         self.uploaded_file = TempUploadedFile.objects.create(
             session=self.upload_session,
-            file_upload=SimpleUploadedFile("test_file.txt", bytearray([1] * (1024**2))),
+            file_upload=SimpleUploadedFile("test_file.txt", bytearray(b"content")),
             name="test_file.txt",
         )
         self.uploaded_file.save()
@@ -949,7 +949,7 @@ class UploadFilesFormTest(TestCase):
             "session_token": self.upload_session.token,
             "general_note": "Some general note",
         }
-        form = UploadFilesForm(data=form_data)
+        form = UploadFilesForm(data=form_data, correct_session_token=self.upload_session.token)
         self.assertTrue(form.is_valid())
         self.assertEqual(
             form.cleaned_data["quantity_and_unit_of_measure"],
@@ -961,7 +961,7 @@ class UploadFilesFormTest(TestCase):
         form_data = {
             "general_note": "Some general note",
         }
-        form = UploadFilesForm(data=form_data)
+        form = UploadFilesForm(data=form_data, correct_session_token=self.upload_session.token)
         self.assertFalse(form.is_valid())
         self.assertIn("session_token", form.errors)
 
@@ -971,7 +971,7 @@ class UploadFilesFormTest(TestCase):
             "session_token": "invalidtoken",
             "general_note": "Some general note",
         }
-        form = UploadFilesForm(data=form_data)
+        form = UploadFilesForm(data=form_data, correct_session_token=self.upload_session.token)
         self.assertFalse(form.is_valid())
         self.assertIn("session_token", form.errors)
 
@@ -982,7 +982,7 @@ class UploadFilesFormTest(TestCase):
             "session_token": self.upload_session.token,
             "general_note": "Some general note",
         }
-        form = UploadFilesForm(data=form_data)
+        form = UploadFilesForm(data=form_data, correct_session_token=self.upload_session.token)
         self.assertFalse(form.is_valid())
         self.assertIn("session_token", form.errors)
 

--- a/app/recordtransfer/tests/unit/views/test_pre_submission.py
+++ b/app/recordtransfer/tests/unit/views/test_pre_submission.py
@@ -3,8 +3,10 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 from caais.models import RightsType, SourceRole, SourceType
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import RequestFactory, TestCase
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 
 from recordtransfer.enums import SubmissionStep
 from recordtransfer.models import InProgressSubmission, SubmissionGroup, UploadSession, User
@@ -21,6 +23,16 @@ class SubmissionFormWizardTests(TestCase):
         )
         self.client.force_login(self.user)
         self.url = reverse("recordtransfer:submit")
+
+        self.mock_session_creation = patch(
+            "recordtransfer.views.pre_submission.UploadSession.new_session"
+        ).start()
+
+        self.mock_session_creation.return_value = UploadSession.objects.create(
+            token="1234567890abcdef",
+            started_at=timezone.now(),
+            user=self.user,
+        )
 
         self.test_data = [
             (SubmissionStep.ACCEPT_LEGAL.value, {"agreement_accepted": "on"}),
@@ -91,6 +103,7 @@ class SubmissionFormWizardTests(TestCase):
                 SubmissionStep.UPLOAD_FILES.value,
                 {
                     "general_note": "Test General Note",
+                    "session_token": "1234567890abcdef",
                 },
             ),
             (
@@ -99,30 +112,22 @@ class SubmissionFormWizardTests(TestCase):
             ),
         ]
 
-    def _upload_test_file(self) -> str:
-        """Upload a test file to the server. Returns the upload session token used to upload the
-        file.
-        """
-        response = self.client.post(reverse("recordtransfer:create_upload_session"))
-        self.assertEqual(201, response.status_code)
-        session_token = response.json()["uploadSessionToken"]
-
-        test_file = SimpleUploadedFile("test_file.txt", b"file_content", content_type="text/plain")
+    def _upload_test_file(self) -> None:
+        """Upload a test file to the server using the provided session token."""
         response = self.client.post(
-            reverse("recordtransfer:upload_files", kwargs={"session_token": session_token}),
-            {"file": test_file},
+            reverse("recordtransfer:upload_files", kwargs={"session_token": "1234567890abcdef"}),
+            {"file": SimpleUploadedFile("test_file.txt", b"contents", content_type="text/plain")},
         )
         self.assertEqual(200, response.status_code)
 
-        return session_token
-
-    def _process_test_data(self, step: str, step_data: dict) -> dict:
+    def _process_test_data(
+        self, step: str, step_data: dict, response: HttpResponse | None = None
+    ) -> dict:
         """Process the test data for the given step for form submission."""
         submit_data = {"submission_form_wizard-current_step": step}
 
         if step == SubmissionStep.UPLOAD_FILES.value:
-            session_token = self._upload_test_file()
-            submit_data[f"{step}-session_token"] = session_token
+            self._upload_test_file()
 
         if type(step_data) is dict:
             submit_data.update(
@@ -138,20 +143,21 @@ class SubmissionFormWizardTests(TestCase):
 
         return submit_data
 
-    @patch("django.conf.settings.FILE_UPLOAD_ENABLED", True)
+    @override_settings(FILE_UPLOAD_ENABLED=True)
     @patch("recordtransfer.views.pre_submission.send_submission_creation_success.delay")
     @patch("recordtransfer.views.pre_submission.send_thank_you_for_your_submission.delay")
-    def test_wizard(
-        self, mock_thank_you: MagicMock, mock_creation_success: MagicMock
-    ) -> None:
-        """Test the SubmissionFormWizard view from start to finish. This test will fill out the form
-        with the test data and submit it, making sure no errors are raised.
+    def test_wizard(self, mock_thank_you: MagicMock, mock_creation_success: MagicMock) -> None:
+        """Test the SubmissionFormWizard view from start to finish. This test will fill out the
+        form with the test data and submit it, making sure no errors are raised.
         """
         mock_thank_you.return_value = None
         mock_creation_success.return_value = None
+
         self.assertEqual(200, self.client.get(self.url).status_code)
         self.assertFalse(self.user.submission_set.exists())
+
         response = None
+
         for step, step_data in self.test_data:
             submit_data = self._process_test_data(step, step_data)
 
@@ -160,7 +166,9 @@ class SubmissionFormWizardTests(TestCase):
 
             if response.context and "form" in response.context:
                 self.assertFalse(response.context["form"].errors)
+
         self.assertTrue(self.user.submission_set.exists())
+
         if response:
             self.assertEqual(200, response.status_code)
             # Check that response tells HTMX on client side to redirect to Submission Sent page
@@ -170,8 +178,7 @@ class SubmissionFormWizardTests(TestCase):
             response = self.client.get(hx_redirect, follow=True)
             self.assertEqual(200, response.status_code)
 
-    @patch("django.conf.settings.UPLOAD_SESSION_EXPIRE_AFTER_INACTIVE_MINUTES", 60)
-    @patch("django.conf.settings.FILE_UPLOAD_ENABLED", True)
+    @override_settings(FILE_UPLOAD_ENABLED=True, UPLOAD_SESSION_EXPIRE_AFTER_INACTIVE_MINUTES=60)
     def test_saving_expirable_in_progress_submission(self) -> None:
         """Test that saving an expirable in-progress submission. Saves the form on the
         Upload Files step after uploading a file.
@@ -182,6 +189,7 @@ class SubmissionFormWizardTests(TestCase):
 
         for step, step_data in self.test_data:
             submit_data = self._process_test_data(step, step_data)
+
             if step == SubmissionStep.UPLOAD_FILES.value:
                 submit_data["save_form_step"] = step
                 response = self.client.post(self.url, submit_data, follow=True)
@@ -198,11 +206,12 @@ class SubmissionFormWizardTests(TestCase):
                 self.assertTrue(self.user.inprogresssubmission_set.exists())
                 self.assertFalse(self.user.inprogresssubmission_set.first().upload_session_expired)
                 break
+
             else:
                 response = self.client.post(self.url, submit_data, follow=True)
                 self.assertEqual(200, response.status_code)
 
-    @patch("django.conf.settings.UPLOAD_SESSION_EXPIRE_AFTER_INACTIVE_MINUTES", 60)
+    @override_settings(UPLOAD_SESSION_EXPIRE_AFTER_INACTIVE_MINUTES=60)
     def test_saving_unexpirable_in_progress_submission(self) -> None:
         """Test saving an unexpirable in-progress submission. Saves the form on the Rights step
         after filling out the form.
@@ -213,6 +222,7 @@ class SubmissionFormWizardTests(TestCase):
 
         for step, step_data in self.test_data:
             submit_data = self._process_test_data(step, step_data)
+
             if step == SubmissionStep.RIGHTS.value:
                 submit_data["save_form_step"] = step
                 response = self.client.post(self.url, submit_data, follow=True)
@@ -228,6 +238,7 @@ class SubmissionFormWizardTests(TestCase):
                 self.assertTrue(self.user.inprogresssubmission_set.exists())
                 self.assertFalse(self.user.inprogresssubmission_set.first().upload_session_expired)
                 break
+
             else:
                 response = self.client.post(self.url, submit_data, follow=True)
                 self.assertEqual(200, response.status_code)

--- a/app/recordtransfer/tests/unit/views/test_pre_submission.py
+++ b/app/recordtransfer/tests/unit/views/test_pre_submission.py
@@ -24,11 +24,7 @@ class SubmissionFormWizardTests(TestCase):
         self.client.force_login(self.user)
         self.url = reverse("recordtransfer:submit")
 
-        self.mock_session_creation = patch(
-            "recordtransfer.views.pre_submission.UploadSession.new_session"
-        ).start()
-
-        self.mock_session_creation.return_value = UploadSession.objects.create(
+        self.session = UploadSession.objects.create(
             token="1234567890abcdef",
             started_at=timezone.now(),
             user=self.user,
@@ -146,10 +142,17 @@ class SubmissionFormWizardTests(TestCase):
     @override_settings(FILE_UPLOAD_ENABLED=True)
     @patch("recordtransfer.views.pre_submission.send_submission_creation_success.delay")
     @patch("recordtransfer.views.pre_submission.send_thank_you_for_your_submission.delay")
-    def test_wizard(self, mock_thank_you: MagicMock, mock_creation_success: MagicMock) -> None:
+    @patch("recordtransfer.views.pre_submission.UploadSession.new_session")
+    def test_wizard(
+        self,
+        mock_session_create: MagicMock,
+        mock_thank_you: MagicMock,
+        mock_creation_success: MagicMock,
+    ) -> None:
         """Test the SubmissionFormWizard view from start to finish. This test will fill out the
         form with the test data and submit it, making sure no errors are raised.
         """
+        mock_session_create.return_value = self.session
         mock_thank_you.return_value = None
         mock_creation_success.return_value = None
 

--- a/app/recordtransfer/tests/unit/views/test_profile.py
+++ b/app/recordtransfer/tests/unit/views/test_profile.py
@@ -7,13 +7,13 @@ from typing import Optional, cast
 from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
 
+from caais.models import Metadata
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from freezegun import freeze_time
 
-from caais.models import Metadata
 from recordtransfer.constants import FormFieldNames, QueryParameters
 from recordtransfer.enums import SubmissionStep
 from recordtransfer.models import (
@@ -277,12 +277,6 @@ class TestInProgressSubmissionTableView(TestCase):
         self.htmx_headers = {
             "HX-Request": "true",
         }
-
-    def tearDown(self) -> None:
-        """Clean up after each test."""
-        UploadSession.objects.all().delete()
-        InProgressSubmission.objects.all().delete()
-        User.objects.all().delete()
 
     def _create_in_progress_submission(
         self,

--- a/app/recordtransfer/urls.py
+++ b/app/recordtransfer/urls.py
@@ -116,11 +116,6 @@ if settings.TESTING or settings.FILE_UPLOAD_ENABLED:
     urlpatterns.extend(
         [
             path(
-                "upload-session/",
-                login_required(views.media.create_upload_session),
-                name="create_upload_session",
-            ),
-            path(
                 "upload-session/<session_token>/files/",
                 login_required(views.media.upload_or_list_files),
                 name="upload_files",

--- a/app/recordtransfer/views/pre_submission.py
+++ b/app/recordtransfer/views/pre_submission.py
@@ -545,7 +545,7 @@ class SubmissionFormWizard(SessionWizardView):
         """Add data to inject when initializing the form."""
         kwargs = super().get_form_kwargs(step)
 
-        if step == SubmissionStep.GROUP_SUBMISSION.value:
+        if SubmissionStep(step) in (SubmissionStep.GROUP_SUBMISSION, SubmissionStep.UPLOAD_FILES):
             kwargs["user"] = self.request.user
 
         elif step == SubmissionStep.SOURCE_INFO.value:

--- a/app/recordtransfer/views/pre_submission.py
+++ b/app/recordtransfer/views/pre_submission.py
@@ -786,7 +786,7 @@ class SubmissionFormWizard(SessionWizardView):
 
             if settings.FILE_UPLOAD_ENABLED and (
                 upload_session := UploadSession.objects.filter(
-                    token=form_data["session_token"]
+                    token=self.storage.extra_data.get("session_token"), user=self.request.user
                 ).first()
             ):
                 submission.upload_session = upload_session

--- a/app/recordtransfer/views/pre_submission.py
+++ b/app/recordtransfer/views/pre_submission.py
@@ -379,8 +379,8 @@ class SubmissionFormWizard(SessionWizardView):
             SubmissionStep(self.steps.next) == SubmissionStep.UPLOAD_FILES
             and "session_token" not in self.storage.extra_data
         ):
-            # TODO: Actually create a session here
-            self.storage.extra_data["session_token"] = "abc"
+            session = UploadSession.new_session(user=cast(User, self.request.user))
+            self.storage.extra_data["session_token"] = session.token
 
         # get the form instance based on the data from the storage backend
         # (if available).
@@ -535,6 +535,9 @@ class SubmissionFormWizard(SessionWizardView):
             initial["other_province_or_state"] = user.other_province_or_state or ""
             initial["postal_or_zip_code"] = user.postal_or_zip_code or ""
             initial["country"] = user.country or ""
+
+        if SubmissionStep(step) == SubmissionStep.UPLOAD_FILES:
+            initial["session_token"] = self.storage.extra_data.get("session_token", "")
 
         return initial
 

--- a/app/recordtransfer/views/pre_submission.py
+++ b/app/recordtransfer/views/pre_submission.py
@@ -285,6 +285,7 @@ class SubmissionFormWizard(SessionWizardView):
         ### Gather information to save ###
 
         current_data = SubmissionFormWizard.format_step_data(self.current_step, request.POST)
+
         form_data = {
             "past": self.storage.data,
             "current": current_data,
@@ -292,17 +293,13 @@ class SubmissionFormWizard(SessionWizardView):
         }
 
         title = None
-        session_token = None
         # See if the title and session token are in the current data
         if isinstance(current_data, dict):
             title = current_data.get("accession_title")
-            session_token = current_data.get("session_token")
 
         # Look in past data if not found in current data
         if not title:
             title = self.get_form_value(SubmissionStep.RECORD_DESCRIPTION, "accession_title")
-        if not session_token:
-            session_token = self.get_form_value(SubmissionStep.UPLOAD_FILES, "session_token")
 
         ### Save the information ###
 
@@ -312,7 +309,11 @@ class SubmissionFormWizard(SessionWizardView):
             self.in_progress_submission = InProgressSubmission()
 
         self.in_progress_submission.title = title
-        session = UploadSession.objects.filter(token=session_token, user=self.request.user).first()
+
+        session = UploadSession.objects.filter(
+            token=self.storage.extra_data.get("session_token"), user=self.request.user
+        ).first()
+
         if session:
             self.in_progress_submission.upload_session = session
 

--- a/app/recordtransfer/views/pre_submission.py
+++ b/app/recordtransfer/views/pre_submission.py
@@ -244,7 +244,10 @@ class SubmissionFormWizard(SessionWizardView):
         if not self.in_progress_submission:
             raise ValueError("No in-progress submission to load")
 
-        self.storage.data = pickle.loads(self.in_progress_submission.step_data)["past"]
+        step_data = pickle.loads(self.in_progress_submission.step_data)
+
+        self.storage.data = step_data["past"]
+        self.storage.extra_data = step_data["extra"]
         self.storage.current_step = self.in_progress_submission.current_step
 
     @method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True))
@@ -282,7 +285,11 @@ class SubmissionFormWizard(SessionWizardView):
         ### Gather information to save ###
 
         current_data = SubmissionFormWizard.format_step_data(self.current_step, request.POST)
-        form_data = {"past": self.storage.data, "current": current_data}
+        form_data = {
+            "past": self.storage.data,
+            "current": current_data,
+            "extra": self.storage.extra_data or {},
+        }
 
         title = None
         session_token = None

--- a/app/recordtransfer/views/pre_submission.py
+++ b/app/recordtransfer/views/pre_submission.py
@@ -374,6 +374,14 @@ class SubmissionFormWizard(SessionWizardView):
             self.storage.extra_data["save_contact_info_prompted"] = True
             return self.trigger_contact_info_save_prompt(form)
 
+        # Assign a new session token if one hasn't been created yet
+        if (
+            SubmissionStep(self.steps.next) == SubmissionStep.UPLOAD_FILES
+            and "session_token" not in self.storage.extra_data
+        ):
+            # TODO: Actually create a session here
+            self.storage.extra_data["session_token"] = "abc"
+
         # get the form instance based on the data from the storage backend
         # (if available).
         next_step = self.steps.next
@@ -726,6 +734,7 @@ class SubmissionFormWizard(SessionWizardView):
         elif step == SubmissionStep.UPLOAD_FILES:
             js_context.update(
                 {
+                    "SESSION_TOKEN": self.storage.extra_data.get("session_token", ""),
                     "MAX_TOTAL_UPLOAD_SIZE_MB": settings.MAX_TOTAL_UPLOAD_SIZE_MB,
                     "MAX_SINGLE_UPLOAD_SIZE_MB": settings.MAX_SINGLE_UPLOAD_SIZE_MB,
                     "MAX_TOTAL_UPLOAD_COUNT": settings.MAX_TOTAL_UPLOAD_COUNT,

--- a/app/recordtransfer/views/pre_submission.py
+++ b/app/recordtransfer/views/pre_submission.py
@@ -552,8 +552,12 @@ class SubmissionFormWizard(SessionWizardView):
         """Add data to inject when initializing the form."""
         kwargs = super().get_form_kwargs(step)
 
-        if SubmissionStep(step) in (SubmissionStep.GROUP_SUBMISSION, SubmissionStep.UPLOAD_FILES):
+        if step == SubmissionStep.GROUP_SUBMISSION.value:
             kwargs["user"] = self.request.user
+
+        elif step == SubmissionStep.UPLOAD_FILES.value:
+            kwargs["user"] = self.request.user
+            kwargs["correct_session_token"] = self.storage.extra_data["session_token"]
 
         elif step == SubmissionStep.SOURCE_INFO.value:
             source_type, _ = SourceType.objects.get_or_create(name="Individual")


### PR DESCRIPTION
Closes #1040 

Removes the upload session creation endpoint, and handles creating the upload session internally.

Uses the `extra_data` field on the session storage to store the session token, and passes that token via the JS context to the template. Instead of the uppy form loading the session token from the input field, it's now loaded via context.

When the submission form is saved, the extra data is also saved. And of course, when the submission form is loaded, this extra data is also loaded.

I've additionally added some more security measures to the UploadFilesForm, namely:

1. The UploadSession objects weren't being filtered by user in the `clean()` function, and now they are.
2. Catches errors where the user tampers with the hidden session_token input.