### PR TITLE
Move uploads to permanent storage asynchronously

### DIFF
--- a/app/recordtransfer/jobs.py
+++ b/app/recordtransfer/jobs.py
@@ -10,7 +10,13 @@ from django.db.models.query import QuerySet
 from django.utils import timezone
 
 from recordtransfer import utils
-from recordtransfer.emails import send_user_in_progress_submission_expiring
+from recordtransfer.emails import (
+    send_submission_creation_failure,
+    send_submission_creation_success,
+    send_thank_you_for_your_submission,
+    send_user_in_progress_submission_expiring,
+    send_your_submission_did_not_go_through,
+)
 from recordtransfer.handlers import JobLogHandler
 from recordtransfer.models import LOGGER as RECORDTRANSFER_MODELS_LOGGER
 from recordtransfer.models import InProgressSubmission, Job, Submission, UploadSession, User
@@ -92,9 +98,26 @@ def create_downloadable_bag(submission: Submission, user_triggered: User) -> Non
 
 
 @django_rq.job
-def move_uploads_to_permanent_storage(session: UploadSession) -> None:
-    """Move the temp files in the given session to the permanent storage space."""
-    LOGGER.info("Triggered moving files to permanent storage for session %s", session.token)
+def move_uploads_and_send_emails(submission: Submission, form_data: dict) -> None:
+    """Move the temp files in the given session to the permanent storage space and send emails.
+
+    If there is no upload session, just send emails.
+    """
+    if not submission.user:
+        LOGGER.error("There is no user associated with the submission %s!", submission)
+        return
+
+    if not submission.upload_session:
+        send_thank_you_for_your_submission(form_data, submission)
+        send_submission_creation_success(form_data, submission)
+        return
+
+    LOGGER.info(
+        "Triggered moving files to permanent storage for session %s",
+        submission.upload_session.token,
+    )
+
+    session = submission.upload_session
 
     try:
         max_attempts = 2
@@ -124,12 +147,17 @@ def move_uploads_to_permanent_storage(session: UploadSession) -> None:
     finally:
         if session.status == UploadSession.SessionStatus.STORED:
             LOGGER.info("All files in session %s are now in permanent storage.", session.token)
+            send_thank_you_for_your_submission(form_data, submission)
+            send_submission_creation_success(form_data, submission)
+
         else:
             LOGGER.error(
                 "Could not move files in session %s to permanent storage! Final session state is: %s",
                 session.token,
                 session.status,
             )
+            send_your_submission_did_not_go_through(form_data, submission.user)
+            send_submission_creation_failure(form_data, submission.user)
 
 
 @django_rq.job

--- a/app/recordtransfer/models.py
+++ b/app/recordtransfer/models.py
@@ -821,8 +821,7 @@ class UploadSession(models.Model):
             for uploaded_file in files:
                 # Get temp directory from first file
                 if temp_dir_path is None:
-                    temp_root = Path(uploaded_file.file_upload.storage.location)
-                    temp_dir_path = (temp_root / uploaded_file.file_upload.name).parent
+                    temp_dir_path = Path(uploaded_file.file_upload.path).parent
 
                 LOGGER.info(
                     'Moving file "%s" (size: %d bytes) to permanent storage...',

--- a/app/recordtransfer/models.py
+++ b/app/recordtransfer/models.py
@@ -815,13 +815,15 @@ class UploadSession(models.Model):
             self.token,
         )
 
-        # Track the temp directory path before moving files
-        temp_dir_path = None
-        if files:
-            temp_dir_path = Path(settings.TEMP_STORAGE_FOLDER) / self.token
-
         try:
+            temp_dir_path = None
+
             for uploaded_file in files:
+                # Get temp directory from first file
+                if temp_dir_path is None:
+                    temp_root = Path(uploaded_file.file_upload.storage.location)
+                    temp_dir_path = (temp_root / uploaded_file.file_upload.name).parent
+
                 LOGGER.info(
                     'Moving file "%s" (size: %d bytes) to permanent storage...',
                     uploaded_file.file_upload.name,
@@ -911,7 +913,7 @@ class UploadSession(models.Model):
             A human readable count and size of all files in this session.
         """
         if not settings.FILE_UPLOAD_ENABLED:
-            return
+            return ""
 
         if self.status not in (
             self.SessionStatus.CREATED,

--- a/app/recordtransfer/tests/e2e/test_submission_form_e2e.py
+++ b/app/recordtransfer/tests/e2e/test_submission_form_e2e.py
@@ -558,8 +558,10 @@ class SubmissionFormWizardTest(SeleniumLiveServerTestCase):
 
     @patch("recordtransfer.views.pre_submission.send_submission_creation_success.delay")
     @patch("recordtransfer.views.pre_submission.send_thank_you_for_your_submission.delay")
+    @patch("recordtransfer.views.pre_submission.move_uploads_to_permanent_storage.delay")
     def test_submit_form(
         self,
+        mock_move_uploads: MagicMock,
         mock_creation_success: MagicMock,
         mock_thank_you: MagicMock,
     ) -> None:
@@ -584,6 +586,10 @@ class SubmissionFormWizardTest(SeleniumLiveServerTestCase):
 
         # Verify the submission success message is displayed
         self.assertIn("Thank you for your Submission", driver.page_source)
+
+        mock_move_uploads.assert_called_once()
+        mock_creation_success.assert_called_once()
+        mock_thank_you.assert_called_once()
 
     def test_previous_saves_form(self) -> None:
         """Test that the form data is saved when going to the previous step. Uses the Contact

--- a/app/recordtransfer/tests/unit/views/test_pre_submission.py
+++ b/app/recordtransfer/tests/unit/views/test_pre_submission.py
@@ -148,7 +148,7 @@ class SubmissionFormWizardTests(TestCase):
         mock_thank_you: MagicMock,
         mock_creation_success: MagicMock,
     ) -> None:
-        """Test the SubmissionFormWizard view from start to finish. This test will fill out the =
+        """Test the SubmissionFormWizard view from start to finish. This test will fill out the
         form with the test data and submit it, making sure no errors are raised.
         """
         mock_thank_you.return_value = None


### PR DESCRIPTION
Closes #1042 

Adds a new `django_rq.job` for copying uploads to perm storage. Two new additions were made:

1. The copy is tried one more time if it fails the first time
2. The temp storage folder is removed after moving all the files