### PR TITLE
Check session limit atomically

### DIFF
--- a/app/recordtransfer/views/pre_submission.py
+++ b/app/recordtransfer/views/pre_submission.py
@@ -560,7 +560,12 @@ class SubmissionFormWizard(SessionWizardView):
             SubmissionStep(self.steps.next) == SubmissionStep.UPLOAD_FILES
             and "session_token" not in self.storage.extra_data
         ):
-            session = UploadSession.new_session(user=cast(User, self.request.user))
+            # Catch when another session would push the user over their limit.
+            try:
+                session = UploadSession.new_session(user, enforce_limit=True)
+            except UploadSession.SessionLimitExceeded:
+                return self._handle_session_limit_reached()
+
             self.storage.extra_data["session_token"] = session.token
 
         # get the form instance based on the data from the storage backend
@@ -579,6 +584,34 @@ class SubmissionFormWizard(SessionWizardView):
         # change the stored current step
         self.storage.current_step = next_step
         return self.render(new_form, **kwargs)
+
+    def _handle_session_limit_reached(self) -> HttpResponse:
+        """Save the in-progress form and redirect when a concurrent request consumed the last
+        available session slot.
+        """
+        redirect_to = reverse("recordtransfer:open_sessions")
+        profile_url = reverse("recordtransfer:user_profile")
+        message = mark_safe(
+            gettext(
+                "Your submission was saved, but you have reached your session limit. Go to "
+                "%(link_start)syour profile%(link_end)s to see your saved submissions."
+            )
+            % {
+                "link_start": mark_safe(
+                    f'<a class="link-primary font-semibold underline" href="{profile_url}">'
+                ),
+                "link_end": mark_safe("</a>"),
+            }
+        )
+
+        try:
+            self.save_form_data(self.request)
+            self.storage.reset()
+            messages.success(self.request, message)
+        except Exception:
+            messages.error(self.request, gettext("There was an error saving the submission."))
+
+        return HttpResponseClientRedirect(redirect_to)
 
     def trigger_contact_info_save_prompt(self, form: forms.ContactInfoForm) -> HttpResponse:
         """Trigger a prompt to save contact info using HTMX."""

--- a/app/upload/models.py
+++ b/app/upload/models.py
@@ -9,7 +9,7 @@ from typing import Optional
 from django.conf import settings
 from django.core.files import File
 from django.core.files.uploadedfile import UploadedFile
-from django.db import models
+from django.db import models, transaction
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 from django.urls import reverse
@@ -52,6 +52,9 @@ class UploadSession(models.Model):
        REMOVING_IN_PROGRESS --> CREATED
     """
 
+    class SessionLimitExceeded(Exception):
+        """Raised when creating a new session would exceed a user's open-session limit."""
+
     class SessionStatus(models.TextChoices):
         """The status of the session."""
 
@@ -78,11 +81,44 @@ class UploadSession(models.Model):
     objects = UploadSessionManager()
 
     @classmethod
-    def new_session(cls, user: Optional[User] = None) -> UploadSession:
-        """Start a new upload session."""
-        return cls.objects.create(
-            token=get_random_string(32), started_at=timezone.now(), user=user
-        )
+    def new_session(
+        cls, user: Optional[User] = None, enforce_limit: bool = False
+    ) -> UploadSession:
+        """Start a new upload session.
+
+        Args:
+            user: The user that will own the session.
+            enforce_limit:
+                If True (and a user is given), atomically check that creating this session
+                will not push the user over the
+                :ref:`UPLOAD_SESSION_MAX_CONCURRENT_OPEN` limit. The check and the insert
+                are performed inside a transaction with the user row locked
+                (``SELECT ... FOR UPDATE``), serializing concurrent attempts for the same
+                user and closing the time-of-check-to-time-of-use race window.
+
+        Raises:
+            UploadSession.SessionLimitExceeded:
+                If ``enforce_limit`` is True and creating this session would exceed the
+                user's open session limit.
+        """
+        if not enforce_limit or user is None:
+            return cls.objects.create(
+                token=get_random_string(32), started_at=timezone.now(), user=user
+            )
+
+        with transaction.atomic():
+            # Lock the user row so concurrent session-creation attempts for this user
+            # are serialized; the limit check below then sees a stable count.
+            # Access via ``_meta.model`` to support SimpleLazyObject-wrapped users
+            # (e.g. ``request.user``).
+            user._meta.model.objects.select_for_update().filter(pk=user.pk).first()
+            if not user.open_sessions_within_limit(will_add_new=True):
+                raise cls.SessionLimitExceeded(
+                    "Creating a new upload session would exceed the user's open-session limit"
+                )
+            return cls.objects.create(
+                token=get_random_string(32), started_at=timezone.now(), user=user
+            )
 
     @property
     def upload_size(self) -> int:

--- a/app/upload/tests/unit/test_models.py
+++ b/app/upload/tests/unit/test_models.py
@@ -8,9 +8,10 @@ from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models.manager import BaseManager
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from upload.models import PermUploadedFile, TempUploadedFile, UploadSession
 
@@ -80,7 +81,7 @@ class TestUploadSession(TestCase):
 
     def setUp(self) -> None:
         """Set up test."""
-        self.session = UploadSession.new_session()
+        self.session = UploadSession.new_session(enforce_limit=False)
 
         self.test_temp_file = get_mock_temp_uploaded_file(
             "test.pdf", size=1000, session=self.session
@@ -909,6 +910,97 @@ class TestUploadSession(TestCase):
         """Restore logging settings."""
         super().tearDownClass()
         logging.disable(logging.NOTSET)
+
+
+class TestNewSessionLimitEnforcement(TestCase):
+    """Tests for the ``enforce_limit`` behaviour of :meth:`UploadSession.new_session`."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Set up test class."""
+        super().setUpClass()
+        logging.disable(logging.CRITICAL)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Restore logging settings."""
+        super().tearDownClass()
+        logging.disable(logging.NOTSET)
+
+    def setUp(self) -> None:
+        """Create a test user for each test."""
+        self.user = get_user_model().objects.create_user(
+            username="limituser", password="1X<ISRUkw+tuK"
+        )
+
+    @override_settings(UPLOAD_SESSION_MAX_CONCURRENT_OPEN=2)
+    def test_new_session_default_does_not_enforce_limit(self) -> None:
+        """Without ``enforce_limit``, ``new_session`` should create sessions even when the user is
+        already at or past the limit.
+        """
+        for _ in range(3):
+            UploadSession.new_session(user=self.user)
+        self.assertEqual(self.user.open_upload_sessions().count(), 3)
+
+    @override_settings(UPLOAD_SESSION_MAX_CONCURRENT_OPEN=2)
+    def test_new_session_enforce_limit_within_limit(self) -> None:
+        """Should create the session when the user is below the limit."""
+        UploadSession.new_session(user=self.user)
+        session = UploadSession.new_session(user=self.user, enforce_limit=True)
+        self.assertIsInstance(session, UploadSession)
+        self.assertEqual(self.user.open_upload_sessions().count(), 2)
+
+    @override_settings(UPLOAD_SESSION_MAX_CONCURRENT_OPEN=2)
+    def test_new_session_enforce_limit_exceeded_raises(self) -> None:
+        """``SessionLimitExceeded`` should be raised and a new session should not be created."""
+        for _ in range(2):
+            UploadSession.new_session(user=self.user)
+
+        with self.assertRaises(UploadSession.SessionLimitExceeded):
+            UploadSession.new_session(user=self.user, enforce_limit=True)
+
+        self.assertEqual(self.user.open_upload_sessions().count(), 2)
+
+    @override_settings(UPLOAD_SESSION_MAX_CONCURRENT_OPEN=1)
+    def test_new_session_enforce_limit_no_user_skips_check(self) -> None:
+        """``enforce_limit=True`` with ``user=None`` should skip the per-user check and always
+        create the session, since the limit is per-user.
+        """
+        session = UploadSession.new_session(user=None, enforce_limit=True)
+        self.assertIsInstance(session, UploadSession)
+        self.assertIsNone(session.user)
+
+    @override_settings(UPLOAD_SESSION_MAX_CONCURRENT_OPEN=-1)
+    def test_new_session_enforce_limit_disabled_via_setting(self) -> None:
+        """When ``UPLOAD_SESSION_MAX_CONCURRENT_OPEN`` is -1 the limit is disabled, and
+        ``enforce_limit=True`` should never raise.
+        """
+        for _ in range(5):
+            session = UploadSession.new_session(user=self.user, enforce_limit=True)
+            self.assertIsInstance(session, UploadSession)
+        self.assertEqual(self.user.open_upload_sessions().count(), 5)
+
+    @override_settings(UPLOAD_SESSION_MAX_CONCURRENT_OPEN=2)
+    def test_new_session_enforce_limit_ignores_non_open_sessions(self) -> None:
+        """Only sessions in the "open" statuses count towards the limit. Closed sessions (e.g.
+        STORED, EXPIRED) should not block creation when ``enforce_limit=True``.
+        """
+        stored = UploadSession.new_session(user=self.user)
+        stored.status = UploadSession.SessionStatus.STORED
+        stored.save()
+
+        expired = UploadSession.new_session(user=self.user)
+        expired.status = UploadSession.SessionStatus.EXPIRED
+        expired.save()
+
+        # Two non-open sessions plus two open should still fit within the limit of 2
+        UploadSession.new_session(user=self.user)
+        session = UploadSession.new_session(user=self.user, enforce_limit=True)
+        self.assertIsInstance(session, UploadSession)
+
+        # And a third open session should now be rejected
+        with self.assertRaises(UploadSession.SessionLimitExceeded):
+            UploadSession.new_session(user=self.user, enforce_limit=True)
 
 
 class TestPermUploadedFile(TestCase):

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "css-minimizer-webpack-plugin": "^8.0.0",
         "daisyui": "^5.0.35",
         "htmx-ext-head-support": "^2.0.4",
-        "htmx.org": "^2.0.4",
+        "htmx.org": "^2.0.10",
         "imask": "^7.6.1",
         "mini-css-extract-plugin": "^2.9.2",
         "postcss": "^8.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4
       htmx.org:
-        specifier: ^2.0.4
-        version: 2.0.6
+        specifier: ^2.0.10
+        version: 2.0.10
       imask:
         specifier: ^7.6.1
         version: 7.6.1
@@ -1188,8 +1188,8 @@ packages:
   htmx-ext-head-support@2.0.4:
     resolution: {integrity: sha512-CGGicOzu3VlHCqjhdHjlU4i4SQ19WwYnl2+1jX3SdOJX1gKOrJrtlED95FMgWyGrlZZ/qo0y/RpOE7KZA2X9kg==}
 
-  htmx.org@2.0.6:
-    resolution: {integrity: sha512-7ythjYneGSk3yCHgtCnQeaoF+D+o7U2LF37WU3O0JYv3gTZSicdEFiI/Ai/NJyC5ZpYJWMpUb11OC5Lr6AfAqA==}
+  htmx.org@2.0.10:
+    resolution: {integrity: sha512-kdeJe7ZVwaS6QMz/ebBIVtZdpwen6L0OQ5GOhPV9MKBb196TCZeZu4yA7ZIQsaLKv7EpXz+So7KSXNuHXhj7Cw==}
 
   icss-utils@5.1.0:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
@@ -3593,9 +3593,9 @@ snapshots:
 
   htmx-ext-head-support@2.0.4:
     dependencies:
-      htmx.org: 2.0.6
+      htmx.org: 2.0.10
 
-  htmx.org@2.0.6: {}
+  htmx.org@2.0.10: {}
 
   icss-utils@5.1.0(postcss@8.5.6):
     dependencies:


### PR DESCRIPTION
Closes #1157

Ensures `new_session()` is used atomically when checking a user's currently open sessions.

Also update HTMX to fix annoying errors in console.