### PR TITLE
Download SVG files that are uploaded

### DIFF
--- a/app/nginx/serve.py
+++ b/app/nginx/serve.py
@@ -15,7 +15,6 @@ MIME_RENDER_INLINE = {
     "image/gif",
     "image/jpeg",
     "image/png",
-    "image/svg+xml",
     "image/webp",
     "image/tiff",
     "audio/aac",

--- a/app/nginx/tests/unit/test_serve.py
+++ b/app/nginx/tests/unit/test_serve.py
@@ -33,3 +33,12 @@ class ServeMediaFileTests(TestCase):
         )
         self.assertEqual(response["Content-Disposition"], 'attachment; filename="file.zip"')
         self.assertEqual(response["X-Accel-Redirect"], file_url)
+
+    @override_settings(DEBUG=False)
+    def test_svg_not_rendered_inline(self) -> None:
+        """Test that image/svg+xml files are not rendered inline."""
+        file_url = "/media/temp/aaa/xss.svg"
+        response = serve_media_file(file_url)
+        self.assertEqual(response["Content-Type"], "image/svg+xml")
+        self.assertEqual(response["Content-Disposition"], 'attachment; filename="xss.svg"')
+        self.assertEqual(response["X-Accel-Redirect"], file_url)


### PR DESCRIPTION
Closes #1163

SVG files are not a default file type that can be uploaded but if someone decides to enable .svg uploads, downloading the file instead of rendering inline mitigates XSS attacks.