### PR TITLE
Disable html uploads by default

### DIFF
--- a/app/app/settings/base.py
+++ b/app/app/settings/base.py
@@ -226,7 +226,7 @@ APPROXIMATE_DATE_FORMAT = config("APPROXIMATE_DATE_FORMAT", default="[ca. {date}
 ACCEPTED_FILE_FORMATS = config(
     "ACCEPTED_FILE_FORMATS",
     cast=AcceptedFileTypes(),
-    default="Audio:mp3,wav,flac|Document:docx,odt,pdf,txt,html|Image:jpg,jpeg,png,gif|Spreadsheet:xlsx,csv|Video:mkv,mp4",
+    default="Audio:mp3,wav,flac|Document:docx,odt,pdf,txt|Image:jpg,jpeg,png,gif|Spreadsheet:xlsx,csv|Video:mkv,mp4",
 )
 
 # Media file storage locations

--- a/app/recordtransfer/management/commands/verify_settings.py
+++ b/app/recordtransfer/management/commands/verify_settings.py
@@ -308,6 +308,7 @@ def verify_accepted_file_formats() -> None:
             inverted_formats[extension] = group_name
 
     _check_for_compressed_files(inverted_formats)
+    _check_for_html_files(inverted_formats)
 
 
 def _check_for_compressed_files(inverted_formats: dict) -> None:
@@ -338,6 +339,25 @@ def _check_for_compressed_files(inverted_formats: dict) -> None:
         ]
 
         LOGGER.warning("\n".join(warning_msg))
+
+
+def _check_for_html_files(inverted_formats: dict) -> None:
+    """Check for HTML files in uploads.
+
+    Args:
+        inverted_formats: Dictionary mapping extensions to their group names.
+    """
+    if "html" in inverted_formats:
+        warning_msg = """
+********************************************************************************
+******* !! WARNING !!
+******* You've enabled uploads of HTML files.
+******* Allowing users to upload HTML files can expose you to Cross-Site-
+******* Scripting (XSS) attacks.
+******* Consider removing this file type (html) from ACCEPTED_FILE_FORMATS
+********************************************************************************
+"""
+        LOGGER.warning(warning_msg)
 
 
 def _validate_cron(cron_str: str) -> None:

--- a/docs/settings/index.rst
+++ b/docs/settings/index.rst
@@ -503,7 +503,6 @@ ACCEPTED_FILE_FORMATS
         - odt
         - pdf
         - txt
-        - html
     - Image
         - jpg
         - jpeg
@@ -542,6 +541,16 @@ ACCEPTED_FILE_FORMATS
 
         Consider carefully whether you need to accept compressed file formats, and if possible, restrict uploads to uncompressed file types only.
 
+
+    .. warning::
+
+        **Security Warning: HTML Files**
+
+        Including HTML files in your accepted file formats may pose security risks. HTML files are
+        not sanitized for script tags which can expose you to XSS attacks. Be careful when enabling
+        HTML files.
+
+
     Here are some examples based on what you might want to accept (note that you can only specify
     the ACCEPTED_FILE_FORMATS variable *once*):
 
@@ -559,7 +568,7 @@ ACCEPTED_FILE_FORMATS
         ACCEPTED_FILE_FORMATS="Excel Workbook:xlsx|Excel Macro Workbook:xlsm|Excel 1997-2003 Workbook:xls"
 
         # Images and documents
-        ACCEPTED_FILE_FORMATS="PDF:pdf,docx,txt|Image:jpeg,jpg,png,gif,tif,tiff"
+        ACCEPTED_FILE_FORMATS="Document:pdf,docx,txt|Image:jpeg,jpg,png,gif,tif,tiff"
 
 
 


### PR DESCRIPTION
Disable uploading HTML files by default, and add warnings in container logs & docs regarding the risks of HTML files.