### PR TITLE
Sanitize uploaded html files

### DIFF
--- a/app/recordtransfer/management/commands/verify_settings.py
+++ b/app/recordtransfer/management/commands/verify_settings.py
@@ -347,13 +347,7 @@ def _check_for_html_files(inverted_formats: dict) -> None:
     Args:
         inverted_formats: Dictionary mapping extensions to their group names.
     """
-    found_html = []
-
-    for html_extension in ("htm", "html"):
-        if html_extension in inverted_formats:
-            found_html.append(html_extension)
-
-    if found_html:
+    if any(ext in inverted_formats for ext in ("htm", "html")):
         warning_msg = """
 ********************************************************************************
 ******* !! WARNING !!

--- a/app/recordtransfer/management/commands/verify_settings.py
+++ b/app/recordtransfer/management/commands/verify_settings.py
@@ -347,14 +347,20 @@ def _check_for_html_files(inverted_formats: dict) -> None:
     Args:
         inverted_formats: Dictionary mapping extensions to their group names.
     """
-    if "html" in inverted_formats:
+    found_html = []
+
+    for html_extension in ("htm", "html"):
+        if html_extension in inverted_formats:
+            found_html.append(html_extension)
+
+    if found_html:
         warning_msg = """
 ********************************************************************************
 ******* !! WARNING !!
 ******* You've enabled uploads of HTML files.
 ******* Allowing users to upload HTML files can expose you to Cross-Site-
 ******* Scripting (XSS) attacks.
-******* Consider removing this file type (html) from ACCEPTED_FILE_FORMATS
+******* Consider removing this file type (htm, html) from ACCEPTED_FILE_FORMATS
 ********************************************************************************
 """
         LOGGER.warning(warning_msg)

--- a/app/upload/html.py
+++ b/app/upload/html.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import nh3
+from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
+
+
+def is_html_file(file: UploadedFile) -> bool:
+    """Check if a file is an HTML file or not."""
+    file_extension = Path(file.name).suffix.lower()
+    return file_extension in (".htm", ".html") and file.content_type == "text/html"
+
+
+def sanitize_html_file(file: UploadedFile) -> UploadedFile:
+    """Sanitize uploaded HTML files using nh3.
+
+    HTML file content is sanitized so unsafe content, including script tags, is removed before the
+    file is saved.
+
+    Non-HTML files are returned as-is.
+    """
+    if not is_html_file(file):
+        return file
+
+    charset = file.charset or "utf-8"
+    file.seek(0)
+    content = file.read().decode(charset, errors="replace")
+    sanitized_content = nh3.clean(content).encode(charset)
+
+    sanitized_file = SimpleUploadedFile(
+        file.name,
+        sanitized_content,
+        content_type="text/html",
+    )
+    sanitized_file.charset = file.charset
+    return sanitized_file

--- a/app/upload/tests/unit/test_views.py
+++ b/app/upload/tests/unit/test_views.py
@@ -2,7 +2,7 @@ import logging
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
 from django.forms import ValidationError
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -137,6 +137,33 @@ class TestUploadFilesView(TestCase):
         self.assertEqual(self.session.file_count, 1)
         # Check that no error is raised if the uploaded file is looked up within the session
         self.session.get_file_by_name("File.pdf")
+
+    def test_html_file_is_sanitized_after_malware_scan(self) -> None:
+        """Test that HTML files are sanitized after malware scanning and before saving."""
+        html_content = b'<html><body><script>alert("xss")</script><p>Safe</p></body></html>'
+
+        def assert_unsanitized_during_malware_scan(file: UploadedFile) -> None:
+            """Assert malware scanning sees the original file content."""
+            file.seek(0)
+            self.assertIn(b"<script>", file.read())
+            file.seek(0)
+
+        self.patch_check_for_malware.side_effect = assert_unsanitized_during_malware_scan
+        response = self.client.post(
+            self.url,
+            {"file": SimpleUploadedFile("File.html", html_content, content_type="text/html")},
+        )
+
+        self.session.refresh_from_db()
+        uploaded_file = self.session.get_file_by_name("File.html")
+        uploaded_file.file_upload.open()
+        saved_content = uploaded_file.file_upload.read()
+        uploaded_file.file_upload.close()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(b"<script>", saved_content)
+        self.assertNotIn(b"alert", saved_content)
+        self.assertIn(b"<p>Safe</p>", saved_content)
 
     def test_error_from_invalid_token(self) -> None:
         """Test that a 400 error is received if the token is invalid."""

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -15,6 +15,7 @@ from nginx.serve import serve_media_file
 
 from .check import accept_file, accept_session
 from .clam import check_for_malware
+from .html import sanitize_html_file
 from .models import UploadSession
 
 User = settings.AUTH_USER_MODEL
@@ -134,6 +135,20 @@ def _handle_upload_file(request: HttpRequest, session: UploadSession) -> JsonRes
                 "accepted": False,
                 "uploadSessionToken": session.token,
                 "error": gettext("Unable to scan file for malware due to scanner error"),
+            },
+            status=500,
+        )
+
+    try:
+        _file = sanitize_html_file(_file)
+    except Exception as exc:
+        LOGGER.error("Error sanitizing HTML file %s", _file.name, exc_info=exc)
+        return JsonResponse(
+            {
+                "file": _file.name,
+                "accepted": False,
+                "uploadSessionToken": session.token,
+                "error": gettext("There was an error processing the file"),
             },
             status=500,
         )

--- a/docs/code/upload/html.rst
+++ b/docs/code/upload/html.rst
@@ -1,0 +1,7 @@
+upload.html - HTML upload sanitization
+======================================
+
+.. automodule:: upload.html
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/settings/index.rst
+++ b/docs/settings/index.rst
@@ -546,9 +546,9 @@ ACCEPTED_FILE_FORMATS
 
         **Security Warning: HTML Files**
 
-        Including HTML files in your accepted file formats may pose security risks. HTML files are
-        not sanitized for script tags which can expose you to XSS attacks. Be careful when enabling
-        HTML files.
+        Including HTML files in your accepted file formats may expose you to cross-site scripting
+        attacks. Note that HTML files *are* sanitized for script tags when uploaded. Use your
+        discretion when deciding to enable HTML uploads.
 
 
     Here are some examples based on what you might want to accept (note that you can only specify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "python-magic>=0.4.27,<0.5",
     "django-admin-interface>=0.30.1,<0.31",
     "redis[hiredis]>=6.4.0,<7.0.0",
+    "nh3>=0.3.0,<0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -603,6 +603,40 @@ wheels = [
 ]
 
 [[package]]
+name = "nh3"
+version = "0.3.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/5f/1d19bdc7d27238e37f3672cdc02cb77c56a4a86d140cd4f4f23c90df6e16/nh3-0.3.5.tar.gz", hash = "sha256:45855e14ff056064fec77133bfcf7cd691838168e5e17bbef075394954dc9dc8", size = 20743, upload-time = "2026-04-25T10:44:16.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/b0/8587ac42a9627ab88e7e221601f1dfccbf4db80b2a29222ea63266dc9abc/nh3-0.3.5-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:23a312224875f72cd16bde417f49071451877e29ef646a60e50fcb69407cc18a", size = 1420126, upload-time = "2026-04-25T10:43:39.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/1dbc4d0c43f12e8c1784ede17eaee6f061d4fbe5505757c65c49b2ceab95/nh3-0.3.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:387abd011e81959d5a35151a11350a0795c6edeb53ebfa02d2e882dc01299263", size = 793943, upload-time = "2026-04-25T10:43:41.363Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9f/d6758d7a14ee964bf439cc35ae4fa24a763a93399c8ef6f22bd11d532d29/nh3-0.3.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:48f45e3e914be93a596431aa143dedf1582557bf41a58153c296048d6e3798c9", size = 841150, upload-time = "2026-04-25T10:43:43.007Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/d5d1ae8374612c98f390e1ea7c610fa6c9716259a03bbf4d15b269f40073/nh3-0.3.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0a09f51806fd51b4fedbf9ea2b61fef388f19aef0d62fe51199d41648be14588", size = 1008415, upload-time = "2026-04-25T10:43:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8f/d13a9c3fd2d9c131a2a281737380e9379eb0f8c33fea24c2b923aaafbb15/nh3-0.3.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c357f1d042c67f135a5e6babb2b0e3b9d9224ff4a3543240f597767b01384ffd", size = 1092706, upload-time = "2026-04-25T10:43:45.653Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/57/2f3add7f8680fcc896afa6a675cb2bab09982853ee8af40bad621f6b61c4/nh3-0.3.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:38748140bf76383ab7ce2dce0ad4cb663855d8fbc9098f7f3483673d09616a17", size = 1048346, upload-time = "2026-04-25T10:43:46.974Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/c3/2f9e4ffa82863074d1361bfe949bc46393d91b3411579dfbbd090b24cac5/nh3-0.3.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:84bdeb082544fbcb77a12c034dd77d7da0556fdc0727b787eb6214b958c15e29", size = 1029038, upload-time = "2026-04-25T10:43:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/10/2804deb3f3315184c9cae41702e293c87524b5a21f766b07d7fe3ffbcfbb/nh3-0.3.5-cp314-cp314t-win32.whl", hash = "sha256:c3aae321f67ae66cff2a627115f106a377d4475d10b0e13d97959a13486b9a88", size = 603263, upload-time = "2026-04-25T10:43:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a2/f6685248b49f7548fc9a8c335ab3a52f68610b72e8a61576447151e4e2e6/nh3-0.3.5-cp314-cp314t-win_amd64.whl", hash = "sha256:c88605d8d468f7fc1b31e06129bc91d6c96f6c621776c9b504a0da9beac9df5f", size = 616866, upload-time = "2026-04-25T10:43:51.005Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b6/d8c9018635d4acfefde6b68470daa510eed715a350cbaa2f928ba0609f81/nh3-0.3.5-cp314-cp314t-win_arm64.whl", hash = "sha256:72c5bdedec27fa33de6a5326346ea8aa3fe54f6ac294d54c4b204fb66a9f1e79", size = 602566, upload-time = "2026-04-25T10:43:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/85/30/d162e99746a2fb1d98bb0ef23af3e201b156cf09f7de867c7390c8fe1c06/nh3-0.3.5-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3bb854485c9b33e5bb143ff3e49e577073bc6bc320f0ff8fc316dd89c0d3c101", size = 1442393, upload-time = "2026-04-25T10:43:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8c/072120d506978ab053e1732d0efa7c86cb478fee0ee098fda0ac0d31cb34/nh3-0.3.5-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50d401ab2d8e86d59e2126e3ab2a2f45840c405842b626d9a51624b3a33b6878", size = 837722, upload-time = "2026-04-25T10:43:55.073Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/d4e06e28c5ad1c4b065f89737d02631bd49f1660b6ebcf17a87ffcd201da/nh3-0.3.5-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:acfd354e61accbe4c74f8017c6e397a776916dfe47c48643cf7fd84ade826f93", size = 822872, upload-time = "2026-04-25T10:43:56.581Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/62/50659255213f241ec5797ae7427464c969397373e83b3659372b341ae869/nh3-0.3.5-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:52d877980d7ca01dc3baf3936bf844828bc6f332962227a684ed79c18cce14c3", size = 1100031, upload-time = "2026-04-25T10:43:58.098Z" },
+    { url = "https://files.pythonhosted.org/packages/00/7a/a12ae77593b2fcf3be25df7bc1c01967d0de448bdb4b6c7ec80fe4f5a74f/nh3-0.3.5-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:207c01801d3e9bb8ec08f08689346bdd30ce15b8bf60013a925d08b5388962a4", size = 1057669, upload-time = "2026-04-25T10:43:59.328Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/71/5647dc04c0233192a3956fc91708822b21403a06508cacf78083c68e7bf0/nh3-0.3.5-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea232933394d1d58bf7c4bb348dc4660eae6604e1ae81cd2ba6d9ed80d390f3b", size = 914795, upload-time = "2026-04-25T10:44:00.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/0e/bf298920729f216adcb002acf7ea01b90842603d2e4e2ce9b900d9ee8fab/nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe3a787dc76b50de6bee54ef242f26c41dfe47654428e3e94f0fae5bb6dd2cc1", size = 806976, upload-time = "2026-04-25T10:44:01.743Z" },
+    { url = "https://files.pythonhosted.org/packages/85/01/26761e1dc2b848e65a62c19e5d39ad446283287cd4afddc89f364ab86bc9/nh3-0.3.5-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:488928988caad25ba14b1eb5bc74e25e21f3b5e40341d956f3ce4a8bc19460dc", size = 834904, upload-time = "2026-04-25T10:44:03.454Z" },
+    { url = "https://files.pythonhosted.org/packages/33/53/0766113e679540ac1edc1b82b1295aecd321eeb75d6fead70109a838b6ee/nh3-0.3.5-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c069570b06aa848457713ad7af4a9905691291548c4466a9ad78ee95808382b", size = 857159, upload-time = "2026-04-25T10:44:05.003Z" },
+    { url = "https://files.pythonhosted.org/packages/58/36/734d353dfaf292fed574b8b3092f0ef79dc6404f3879f7faaa61a4701fad/nh3-0.3.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:eeedc90ed8c42c327e8e10e621ccfa314fc6cce35d5929f4297ff1cdb89667c4", size = 1018600, upload-time = "2026-04-25T10:44:06.18Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/aa/d9c59c1b49669fcb7bababa55df82385f029ad5c2651f583c3a1141cfdd1/nh3-0.3.5-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:de8e8621853b6470fe928c684ee0d3f39ea8086cebafe4c416486488dea7b68d", size = 1103530, upload-time = "2026-04-25T10:44:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b0/cdd210bfb8d9d43fb02fc3c868336b9955934d8e15e66eb1d15a147b8af0/nh3-0.3.5-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:6ea58cc44d274c643b83547ca9654a0b1a817609b160601356f76a2b744c49ad", size = 1061754, upload-time = "2026-04-25T10:44:09.362Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/cb/7a39e72e668c8445bdd95e494b3e21cfdddc68329be8ea3522c8befb46c4/nh3-0.3.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e49c9b564e6bcb03ecd2f057213df9a0de15a95812ac9db9600b590db23d3ae9", size = 1040938, upload-time = "2026-04-25T10:44:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4c/fc2f9ed208a3801a319f59b5fea03cdc20cf3bd8af14be930d3a8de01224/nh3-0.3.5-cp38-abi3-win32.whl", hash = "sha256:559e4c73b689e9a7aa97ac9760b1bc488038d7c1a575aa4ab5a0e19ee9630c0f", size = 611445, upload-time = "2026-04-25T10:44:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1a/e4c9b5e2ae13e6092c9ec16d8ca30646cb01fcdea245f36c5b08fd21fbd5/nh3-0.3.5-cp38-abi3-win_amd64.whl", hash = "sha256:45e6a65dc88a300a2e3502cb9c8e6d1d6b831d6fba7470643333609c6aab1f30", size = 626502, upload-time = "2026-04-25T10:44:13.682Z" },
+    { url = "https://files.pythonhosted.org/packages/80/7c/19cd0671d1ba2762fb388fc149697d20d0568ccfeef833b11280a619e526/nh3-0.3.5-cp38-abi3-win_arm64.whl", hash = "sha256:8f85285700a18e9f3fc5bff41fe573fa84f81542ef13b48a89f9fecca0474d3b", size = 611069, upload-time = "2026-04-25T10:44:14.934Z" },
+]
+
+[[package]]
 name = "outcome"
 version = "1.3.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1026,6 +1060,7 @@ dependencies = [
     { name = "django-rq" },
     { name = "django-webpack-loader" },
     { name = "django-widget-tweaks" },
+    { name = "nh3" },
     { name = "python-decouple" },
     { name = "python-magic" },
     { name = "redis", extra = ["hiredis"] },
@@ -1076,6 +1111,7 @@ requires-dist = [
     { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.5.1,<2" },
     { name = "gunicorn", marker = "extra == 'prod'", specifier = ">=23.0.0,<24" },
     { name = "mysqlclient", marker = "extra == 'prod'", specifier = ">=2.2.7,<3" },
+    { name = "nh3", specifier = ">=0.3.0,<0.4" },
     { name = "podman-compose", marker = "extra == 'podman'", specifier = ">=1.3.0" },
     { name = "pytest-django", marker = "extra == 'dev'", specifier = ">=4.9.0,<5" },
     { name = "python-decouple", specifier = "~=3.8" },


### PR DESCRIPTION
If HTML file uploads are enabled, sanitize them before being stored using the [nh3](https://nh3.readthedocs.io/en/latest/) library.

Expand list of extensions of HTML files to include `.htm`.