### PR TITLE
Refactor upload logic

### DIFF
--- a/app/app/urls.py
+++ b/app/app/urls.py
@@ -80,6 +80,6 @@ if settings.DEBUG and not settings.TESTING:
     urlpatterns += debug_toolbar_urls()
 
 if settings.TESTING or settings.FILE_UPLOAD_ENABLED:
-    urlpatterns += [path("", include("upload.urls"))]
+    urlpatterns += [path("", include("upload.urls", namespace="upload"))]
 elif not settings.FILE_UPLOAD_ENABLED:
-    urlpatterns += [path("", include("upload.urls_readonly"))]
+    urlpatterns += [path("", include("upload.urls_readonly", namespace="upload"))]

--- a/app/frontend/main/js/submission_form/uppyForm.js
+++ b/app/frontend/main/js/submission_form/uppyForm.js
@@ -31,7 +31,7 @@ const UPPY_LOCALE_MAP = {
 export async function setupUppy(context) {
     const reviewButton = document.getElementById("form-review-button");
     const submissionForm = document.getElementById("submission-form");
-    const token = context["SESSION_TOKEN"];
+    const uploadHandle = context["UPLOAD_HANDLE"];
     const issueFileIds = [];
 
     /**
@@ -89,9 +89,12 @@ export async function setupUppy(context) {
         })
         .use(XHR, {
             method: "POST",
-            endpoint: `/upload-session/${token}/files/`,
+            endpoint: "/upload-session/files/",
             formData: true,
-            headers: { "X-CSRFToken": getCookie("csrftoken") },
+            headers: {
+                "X-CSRFToken": getCookie("csrftoken"),
+                "X-Upload-Handle": uploadHandle,
+            },
             bundle: false,
             timeout: 180000,
             limit: 2,
@@ -144,7 +147,7 @@ export async function setupUppy(context) {
             const index = issueFileIds.indexOf(file.id);
             issueFileIds.splice(index, 1);
         }
-        sendDeleteRequestForFile(file.name, token);
+        sendDeleteRequestForFile(file.name, uploadHandle);
     });
 
     reviewButton.addEventListener("click", async (event) => {
@@ -176,7 +179,7 @@ export async function setupUppy(context) {
     });
 
     // Add mock files to represent files that have already been uploaded to the upload session
-    const uploadedFiles = await fetchUploadedFiles(token);
+    const uploadedFiles = await fetchUploadedFiles(uploadHandle);
 
     if (uploadedFiles) {
         uploadedFiles.forEach((file) => {

--- a/app/frontend/main/js/submission_form/utils.js
+++ b/app/frontend/main/js/submission_form/utils.js
@@ -23,18 +23,26 @@ export const getCookie = (name) => {
  * Fetches the list of uploaded files for the current upload session.
  * This function sends a GET request to the server to retrieve the list of uploaded files.
  * Uses exponential backoff to retry a total of 3 times if getting a 500 or more status.
- * @param {string} token - The upload session token
+ * @param {string} uploadHandle - The opaque per-wizard upload handle
  * @returns {Promise<object|null>} - A promise that resolves to the JSON response containing the
- * list of uploaded files, or null if the request fails or the session token is not available.
+ * list of uploaded files, or null if the request fails or the upload handle is not available.
  */
-export const fetchUploadedFiles = async (token) => {
+export const fetchUploadedFiles = async (uploadHandle) => {
+    if (!uploadHandle) {
+        console.error("Cannot fetch uploaded files: missing upload handle");
+        return null;
+    }
+
     const maxRetries = 3;
     let attempt = 0;
     let response;
 
     while (attempt < maxRetries) {
-        response = await fetch(`/upload-session/${token}/files/`, {
+        response = await fetch("/upload-session/files/", {
             method: "GET",
+            headers: {
+                "X-Upload-Handle": uploadHandle,
+            },
         });
 
         if (response.ok) {
@@ -72,16 +80,24 @@ export const makeMockBlob = (size) => {
 
 /**
  * Sends a DELETE request to remove an uploaded file from the server.
+ *
+ * The upload session is identified server-side via the opaque per-wizard
+ * upload handle passed in the X-Upload-Handle header.
  * @param {string} filename - The name of the file to delete.
- * @param {string} token - The upload session token
+ * @param {string} uploadHandle - The opaque per-wizard upload handle
  * @returns {Promise<Response|null>} - A promise that resolves to the response of the request or
- * null if the session token was not found.
+ * null if the upload handle was not found.
  */
-export const sendDeleteRequestForFile = async (filename, token) => {
-    const response = await fetch(`/upload-session/${token}/files/${filename}/`, {
+export const sendDeleteRequestForFile = async (filename, uploadHandle) => {
+    if (!uploadHandle) {
+        console.error("Cannot delete file: missing upload handle");
+        return null;
+    }
+    const response = await fetch(`/upload-session/files/${encodeURIComponent(filename)}/`, {
         method: "DELETE",
         headers: {
             "X-CSRFToken": getCookie("csrftoken"),
+            "X-Upload-Handle": uploadHandle,
         },
     });
     if (!response.ok) {

--- a/app/locale/en/LC_MESSAGES/django.po
+++ b/app/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 21:44-0500\n"
+"POT-Creation-Date: 2026-06-02 11:59-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: app/settings/base.py:144
+#: app/settings/base.py:186
 msgid "English"
 msgstr ""
 
-#: app/settings/base.py:145
+#: app/settings/base.py:187
 msgid "French"
 msgstr ""
 
-#: app/settings/base.py:146
+#: app/settings/base.py:188
 msgid "Hindi"
 msgstr ""
 
@@ -90,32 +90,32 @@ msgid "Record an identifier to uniquely identify this accession"
 msgstr ""
 
 #: caais/forms.py:171 caais/forms.py:208
-#: recordtransfer/forms/submission_forms.py:365
-#: recordtransfer/forms/submission_forms.py:402
+#: recordtransfer/forms/submission_forms.py:374
+#: recordtransfer/forms/submission_forms.py:411
 msgid "Invalid date format"
 msgstr ""
 
-#: caais/forms.py:190 recordtransfer/forms/submission_forms.py:384
+#: caais/forms.py:190 recordtransfer/forms/submission_forms.py:393
 msgid "Date cannot be in the future"
 msgstr ""
 
-#: caais/forms.py:192 recordtransfer/forms/submission_forms.py:386
+#: caais/forms.py:192 recordtransfer/forms/submission_forms.py:395
 msgid "End date cannot be in the future"
 msgstr ""
 
-#: caais/forms.py:198 recordtransfer/forms/submission_forms.py:392
+#: caais/forms.py:198 recordtransfer/forms/submission_forms.py:401
 msgid "Date cannot be before 1800"
 msgstr ""
 
-#: caais/forms.py:200 recordtransfer/forms/submission_forms.py:394
+#: caais/forms.py:200 recordtransfer/forms/submission_forms.py:403
 msgid "End date cannot be before 1800"
 msgstr ""
 
-#: caais/forms.py:210 recordtransfer/forms/submission_forms.py:404
+#: caais/forms.py:210 recordtransfer/forms/submission_forms.py:413
 msgid "Invalid date format for end date"
 msgstr ""
 
-#: caais/forms.py:220 recordtransfer/forms/submission_forms.py:414
+#: caais/forms.py:220 recordtransfer/forms/submission_forms.py:423
 msgid "End date must be later than start date"
 msgstr ""
 
@@ -124,24 +124,24 @@ msgstr ""
 msgid "'%(id)s' is a reserved Identifier type - please use another type name"
 msgstr ""
 
-#: caais/forms.py:365 recordtransfer/forms/mixins.py:17
-#: recordtransfer/forms/mixins.py:145
-#: recordtransfer/forms/submission_forms.py:186
-#: recordtransfer/forms/submission_forms.py:197
-#: recordtransfer/forms/submission_forms.py:212
-#: recordtransfer/forms/submission_forms.py:442
+#: caais/forms.py:365 recordtransfer/forms/mixins.py:35
+#: recordtransfer/forms/mixins.py:163
+#: recordtransfer/forms/submission_forms.py:195
+#: recordtransfer/forms/submission_forms.py:206
+#: recordtransfer/forms/submission_forms.py:221
+#: recordtransfer/forms/submission_forms.py:451
 msgid "This field is required."
 msgstr ""
 
-#: caais/forms.py:366 recordtransfer/forms/mixins.py:18
+#: caais/forms.py:366 recordtransfer/forms/mixins.py:36
 msgid "Phone number must look like \"+1 (999) 999-9999\""
 msgstr ""
 
-#: caais/forms.py:374 caais/models.py:950 recordtransfer/forms/mixins.py:25
+#: caais/forms.py:374 caais/models.py:950 recordtransfer/forms/mixins.py:43
 msgid "Phone number"
 msgstr ""
 
-#: caais/forms.py:378 recordtransfer/forms/submission_forms.py:125
+#: caais/forms.py:378 recordtransfer/forms/submission_forms.py:134
 #: recordtransfer/forms/user_forms.py:36
 #: recordtransfer/templates/includes/account_info_form.html:12
 msgid "Email"
@@ -215,7 +215,7 @@ msgid ""
 "not it has yet been determined"
 msgstr ""
 
-#: caais/models.py:309 recordtransfer/forms/submission_forms.py:452
+#: caais/models.py:309 recordtransfer/forms/submission_forms.py:461
 msgid "Date of materials"
 msgstr ""
 
@@ -309,7 +309,7 @@ msgid "Source types"
 msgstr ""
 
 #: caais/models.py:759 caais/models.py:910
-#: recordtransfer/forms/submission_forms.py:260
+#: recordtransfer/forms/submission_forms.py:269
 msgid "Source type"
 msgstr ""
 
@@ -324,7 +324,7 @@ msgid "Source roles"
 msgstr ""
 
 #: caais/models.py:784 caais/models.py:1002
-#: recordtransfer/forms/submission_forms.py:297
+#: recordtransfer/forms/submission_forms.py:306
 msgid "Source role"
 msgstr ""
 
@@ -363,15 +363,15 @@ msgid ""
 "standard"
 msgstr ""
 
-#: caais/models.py:929 recordtransfer/forms/submission_forms.py:107
+#: caais/models.py:929 recordtransfer/forms/submission_forms.py:116
 msgid "Contact name"
 msgstr ""
 
-#: caais/models.py:936 recordtransfer/forms/submission_forms.py:114
+#: caais/models.py:936 recordtransfer/forms/submission_forms.py:123
 msgid "Job title"
 msgstr ""
 
-#: caais/models.py:943 recordtransfer/forms/submission_forms.py:121
+#: caais/models.py:943 recordtransfer/forms/submission_forms.py:130
 msgid "Organization"
 msgstr ""
 
@@ -379,15 +379,15 @@ msgstr ""
 msgid "Email address"
 msgstr ""
 
-#: caais/models.py:964 recordtransfer/forms/mixins.py:32
+#: caais/models.py:964 recordtransfer/forms/mixins.py:50
 msgid "Address line 1"
 msgstr ""
 
-#: caais/models.py:971 recordtransfer/forms/mixins.py:39
+#: caais/models.py:971 recordtransfer/forms/mixins.py:57
 msgid "Address line 2"
 msgstr ""
 
-#: caais/models.py:978 recordtransfer/forms/mixins.py:45
+#: caais/models.py:978 recordtransfer/forms/mixins.py:63
 #: recordtransfer/models.py:73
 msgid "City"
 msgstr ""
@@ -400,7 +400,7 @@ msgstr ""
 msgid "Postal or zip code"
 msgstr ""
 
-#: caais/models.py:995 recordtransfer/forms/mixins.py:161
+#: caais/models.py:995 recordtransfer/forms/mixins.py:179
 msgid "Country"
 msgstr ""
 
@@ -792,41 +792,41 @@ msgstr ""
 msgid "No other details listed"
 msgstr ""
 
-#: recordtransfer/admin.py:218
+#: recordtransfer/admin.py:220
 msgid ""
 "The selected submission group(s) do not contain any submissions to export."
 msgstr ""
 
-#: recordtransfer/admin.py:229
+#: recordtransfer/admin.py:231
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export CAAIS 1.0 CSV for Submissions in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:239
+#: recordtransfer/admin.py:241
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export AtoM 2.6 Accession CSV for Submissions in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:249
+#: recordtransfer/admin.py:251
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export AtoM 2.3 Accession CSV for Submissions in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:259
+#: recordtransfer/admin.py:261
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export AtoM 2.2 Accession CSV for Submissions in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:269
+#: recordtransfer/admin.py:271
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export AtoM 2.1 Accession CSV for Submissions in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:388
+#: recordtransfer/admin.py:390
 msgid "Click link to view uploaded files"
 msgstr ""
 
-#: recordtransfer/admin.py:412
+#: recordtransfer/admin.py:414
 #, python-format
 msgid ""
 "A downloadable bag is being generated. Visit the %(link_start)sjobs "
@@ -834,119 +834,119 @@ msgid ""
 "Submission page for a download link"
 msgstr ""
 
-#: recordtransfer/admin.py:428
+#: recordtransfer/admin.py:430
 msgid ""
 "There are no files associated with this submission, it is not possible to "
 "create a Bag"
 msgstr ""
 
-#: recordtransfer/admin.py:437
+#: recordtransfer/admin.py:439
 #, python-format
 msgid "Submission with ID '%(id)s' doesn't exist. Perhaps it was deleted?"
 msgstr ""
 
-#: recordtransfer/admin.py:447
+#: recordtransfer/admin.py:449
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export CAAIS 1.0 CSV for Metadata in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:459
+#: recordtransfer/admin.py:461
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export AtoM 2.6 Accession CSV for Metadata in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:471
+#: recordtransfer/admin.py:473
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export AtoM 2.3 Accession CSV for Metadata in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:483
+#: recordtransfer/admin.py:485
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export AtoM 2.2 Accession CSV for Metadata in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:495
+#: recordtransfer/admin.py:497
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export AtoM 2.1 Accession CSV for Metadata in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:545 upload/admin.py:54
+#: recordtransfer/admin.py:547 upload/admin.py:54
 msgid "File Link"
 msgstr ""
 
-#: recordtransfer/admin.py:551
+#: recordtransfer/admin.py:553
 msgid "No file attached"
 msgstr ""
 
-#: recordtransfer/admin.py:578
+#: recordtransfer/admin.py:580
 #: recordtransfer/templates/includes/profile_forms.html:18
-#: recordtransfer/views/pre_submission.py:181
+#: recordtransfer/views/pre_submission.py:177
 msgid "Contact Information"
 msgstr ""
 
-#: recordtransfer/admin.py:593
+#: recordtransfer/admin.py:595
 msgid "Language Preferences"
 msgstr ""
 
-#: recordtransfer/admin.py:599
+#: recordtransfer/admin.py:601
 msgid "Email Updates"
 msgstr ""
 
-#: recordtransfer/admin.py:653 recordtransfer/views/account.py:324
+#: recordtransfer/admin.py:655 recordtransfer/views/account.py:324
 msgid "Password updated"
 msgstr ""
 
-#: recordtransfer/admin.py:654 recordtransfer/views/account.py:325
+#: recordtransfer/admin.py:656 recordtransfer/views/account.py:325
 #: recordtransfer/views/account.py:366
 msgid "password"
 msgstr ""
 
-#: recordtransfer/admin.py:655 recordtransfer/admin.py:685
+#: recordtransfer/admin.py:657 recordtransfer/admin.py:687
 #: recordtransfer/management/commands/send_test_email.py:178
 #: recordtransfer/views/account.py:326
 msgid "updated"
 msgstr ""
 
-#: recordtransfer/admin.py:666
+#: recordtransfer/admin.py:668
 msgid "Non-superusers cannot modify superuser accounts."
 msgstr ""
 
-#: recordtransfer/admin.py:677
+#: recordtransfer/admin.py:679
 msgid "Account Deactivated"
 msgstr ""
 
-#: recordtransfer/admin.py:678 recordtransfer/admin.py:684
+#: recordtransfer/admin.py:680 recordtransfer/admin.py:686
 #: recordtransfer/management/commands/send_test_email.py:177
 msgid "account"
 msgstr ""
 
-#: recordtransfer/admin.py:679
+#: recordtransfer/admin.py:681
 msgid "deactivated"
 msgstr ""
 
-#: recordtransfer/admin.py:683
+#: recordtransfer/admin.py:685
 #: recordtransfer/management/commands/send_test_email.py:176
 msgid "Account updated"
 msgstr ""
 
-#: recordtransfer/admin.py:696
+#: recordtransfer/admin.py:698
 msgid "Superuser privileges have been added to your account."
 msgstr ""
 
-#: recordtransfer/admin.py:698
+#: recordtransfer/admin.py:700
 msgid "Superuser privileges have been removed from your account."
 msgstr ""
 
-#: recordtransfer/admin.py:701
+#: recordtransfer/admin.py:703
 #: recordtransfer/management/commands/send_test_email.py:179
 msgid "Staff privileges have been added to your account."
 msgstr ""
 
-#: recordtransfer/admin.py:703
+#: recordtransfer/admin.py:705
 msgid "Staff privileges have been removed from your account."
 msgstr ""
 
-#: recordtransfer/admin.py:760
+#: recordtransfer/admin.py:762
 #, python-format
 msgid "Setting \"%(key)s\" has been reset to its default value of %(value)s."
 msgstr ""
@@ -1304,388 +1304,387 @@ msgstr ""
 msgid "%(setting)s must be a valid email address."
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:31
+#: recordtransfer/forms/mixins.py:11
+msgid "HTML is not allowed in this field."
+msgstr ""
+
+#: recordtransfer/forms/mixins.py:49
 msgid "Street, and street number"
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:38
+#: recordtransfer/forms/mixins.py:56
 msgid "Unit Number, RPO, PO BOX... (optional)"
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:56
+#: recordtransfer/forms/mixins.py:74
 msgid "Select your province"
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:127 recordtransfer/models.py:79
+#: recordtransfer/forms/mixins.py:145 recordtransfer/models.py:79
 msgid "Province or state"
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:139
+#: recordtransfer/forms/mixins.py:157
 msgid "Other province or state"
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:147
+#: recordtransfer/forms/mixins.py:165
 msgid ""
 "Postal code must look like \"Z0Z 0Z0\", zip code must look like \"12345\" or "
 "\"12345-1234\""
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:156
+#: recordtransfer/forms/mixins.py:174
 msgid "Postal / Zip code"
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:159
+#: recordtransfer/forms/mixins.py:177
 msgid "Select your Country"
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:175
+#: recordtransfer/forms/mixins.py:193
 msgid "Address line 1 is required if address line 2 is provided."
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:181
+#: recordtransfer/forms/mixins.py:199
 msgid ""
 "You must select a province or state, use \"Other\" to enter a custom location"
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:187
+#: recordtransfer/forms/mixins.py:205
 msgid ""
 "This field must be filled out if \"Other\" province or state is selected"
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:205
+#: recordtransfer/forms/mixins.py:223
 msgid "Please verify you are human"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:71
+#: recordtransfer/forms/submission_forms.py:80
 msgid "I accept these terms"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:201
+#: recordtransfer/forms/submission_forms.py:210
 msgid "If \"Source type\" is Other, enter your own source type"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:216
+#: recordtransfer/forms/submission_forms.py:225
 msgid "If \"Source role\" is Other, enter your own source role"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:225
+#: recordtransfer/forms/submission_forms.py:234
 #: recordtransfer/templates/includes/delete_in_progress_submission_modal.html:21
 #: recordtransfer/templates/includes/delete_submission_group_modal.html:19
 #: recordtransfer/templates/recordtransfer/submission_form_review.html:64
 msgid "Yes"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:226
+#: recordtransfer/forms/submission_forms.py:235
 #: recordtransfer/templates/recordtransfer/submission_form_review.html:66
 msgid "No"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:231
+#: recordtransfer/forms/submission_forms.py:240
 msgid "Fill out this section?"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:244
+#: recordtransfer/forms/submission_forms.py:253
 msgid "Name of source"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:245
+#: recordtransfer/forms/submission_forms.py:254
 msgid "The organization or entity submitting the records"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:259
-#: recordtransfer/forms/submission_forms.py:296
+#: recordtransfer/forms/submission_forms.py:268
+#: recordtransfer/forms/submission_forms.py:305
 msgid "Please select one"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:262
+#: recordtransfer/forms/submission_forms.py:271
 msgid ""
 "How would you describe <b>what</b> the source entity is? i.e., The source is "
 "a(n) ______"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:277
+#: recordtransfer/forms/submission_forms.py:286
 msgid "A source type not covered by the other choices"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:282
+#: recordtransfer/forms/submission_forms.py:291
 msgid "Other source type"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:298
+#: recordtransfer/forms/submission_forms.py:307
 msgid "How does the source relate to the records? "
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:311
+#: recordtransfer/forms/submission_forms.py:320
 msgid "A source role not covered by the other choices"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:316
+#: recordtransfer/forms/submission_forms.py:325
 msgid "Other source role"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:326
+#: recordtransfer/forms/submission_forms.py:335
 msgid ""
 "Enter any notes you think may be useful for the archives to have about this "
 "entity (optional)"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:331
+#: recordtransfer/forms/submission_forms.py:340
 msgid "Source notes"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:332
+#: recordtransfer/forms/submission_forms.py:341
 msgid "e.g., The donor wishes to remain anonymous"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:423
+#: recordtransfer/forms/submission_forms.py:432
 msgid "e.g., Committee Meeting Minutes"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:424
+#: recordtransfer/forms/submission_forms.py:433
 msgid "Title"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:431
+#: recordtransfer/forms/submission_forms.py:440
 msgid "English, French"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:432
+#: recordtransfer/forms/submission_forms.py:441
 msgid "Enter all relevant languages here"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:433
+#: recordtransfer/forms/submission_forms.py:442
 msgid "Language(s)"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:443
+#: recordtransfer/forms/submission_forms.py:452
 msgid "Date must be in the format YYYY-MM-DD or YYYY-MM-DD - YYYY-MM-DD"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:447
+#: recordtransfer/forms/submission_forms.py:456
 msgid "2000-03-14 - 2001-05-06"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:454
+#: recordtransfer/forms/submission_forms.py:463
 msgid ""
 "Enter the range of dates that the materials cover, or a single date if there "
 "is no range."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:462
+#: recordtransfer/forms/submission_forms.py:471
 msgid "Date is approximated"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:464
+#: recordtransfer/forms/submission_forms.py:473
 msgid ""
 "Check this box if the date is approximate, or if you are unsure of the date."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:473
+#: recordtransfer/forms/submission_forms.py:482
 msgid "e.g., These files contain images from ..."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:475
+#: recordtransfer/forms/submission_forms.py:484
 msgid "Description of contents"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:477
+#: recordtransfer/forms/submission_forms.py:486
 msgid ""
 "Briefly describe the content of the files you are submitting. What do the "
 "files contain?"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:489
+#: recordtransfer/forms/submission_forms.py:498
 msgid ""
 "Enter any information you have on the history of who has had custody of the "
 "records or who has kept the records in the past (optional)"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:495
+#: recordtransfer/forms/submission_forms.py:504
 msgid "Custodial history"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:496
+#: recordtransfer/forms/submission_forms.py:505
 msgid "e.g., John Doe held these records before donating them in 1960"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:512
+#: recordtransfer/forms/submission_forms.py:521
 msgid ""
 "Record how many files and of what type they are that you are planning on "
 "submitting (optional)"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:517
+#: recordtransfer/forms/submission_forms.py:526
 msgid "For example, &quot;200 PDF documents, totalling 2.0GB&quot;"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:518
+#: recordtransfer/forms/submission_forms.py:527
 msgid "Quantity and type of files"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:554
+#: recordtransfer/forms/submission_forms.py:563
 msgid ""
 "If \"Other type of rights\" is empty, you must choose one of the Rights "
 "types here"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:560
+#: recordtransfer/forms/submission_forms.py:569
 msgid "If \"Type of rights\" is empty, you must enter a different type here"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:578
+#: recordtransfer/forms/submission_forms.py:587
 msgid "Type of rights"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:579
+#: recordtransfer/forms/submission_forms.py:588
 msgid "Select a rights type (optional)"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:587
+#: recordtransfer/forms/submission_forms.py:596
 msgid "Other type of rights not covered by other choices"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:591
+#: recordtransfer/forms/submission_forms.py:600
 msgid "For example: &quot;UK Human Rights Act 1998&quot;"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:592
+#: recordtransfer/forms/submission_forms.py:601
 msgid "Other type of rights"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:601
+#: recordtransfer/forms/submission_forms.py:610
 msgid "Any notes on these rights or which files they may apply to (optional)"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:606
+#: recordtransfer/forms/submission_forms.py:615
 msgid ""
 "For example: &quot;Copyright until 2050&quot;, &quot;Only applies to "
 "images&quot;, etc."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:608
+#: recordtransfer/forms/submission_forms.py:617
 msgid "Notes for rights"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:637
+#: recordtransfer/forms/submission_forms.py:646
 msgid "This identifier type is reserved and cannot be used"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:641
-#: recordtransfer/forms/submission_forms.py:646
+#: recordtransfer/forms/submission_forms.py:650
+#: recordtransfer/forms/submission_forms.py:655
 msgid "Must enter a value for this identifier"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:643
-#: recordtransfer/forms/submission_forms.py:645
+#: recordtransfer/forms/submission_forms.py:652
+#: recordtransfer/forms/submission_forms.py:654
 msgid "Must enter a type for this identifier"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:648
+#: recordtransfer/forms/submission_forms.py:657
 msgid "Cannot enter a note without entering a value and type"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:656
+#: recordtransfer/forms/submission_forms.py:665
 msgid "The type of the identifier"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:659
+#: recordtransfer/forms/submission_forms.py:668
 msgid ""
 "For example: &quot;Receipt number&quot;, &quot;LAC Record ID&quot;, etc."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:660
+#: recordtransfer/forms/submission_forms.py:669
 msgid "Type of identifier"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:667
-#: recordtransfer/forms/submission_forms.py:670
+#: recordtransfer/forms/submission_forms.py:676
+#: recordtransfer/forms/submission_forms.py:679
 msgid "Identifier value"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:679
+#: recordtransfer/forms/submission_forms.py:688
 msgid "Any notes on this identifier or which files it may apply to (optional)."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:683
+#: recordtransfer/forms/submission_forms.py:692
 msgid "Notes for identifier"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:708
+#: recordtransfer/forms/submission_forms.py:717
 msgid "Select a group"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:735
+#: recordtransfer/forms/submission_forms.py:744
 msgid "Assigned group"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:759
-#: recordtransfer/forms/submission_forms.py:824
+#: recordtransfer/forms/submission_forms.py:774
+#: recordtransfer/forms/submission_forms.py:822
 msgid "Record any general notes you have about the records here (optional)"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:764
-#: recordtransfer/forms/submission_forms.py:829
+#: recordtransfer/forms/submission_forms.py:779
+#: recordtransfer/forms/submission_forms.py:827
 msgid ""
 "These should be notes that did not fit in any of the previous steps of this "
 "form"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:766
-#: recordtransfer/forms/submission_forms.py:831
+#: recordtransfer/forms/submission_forms.py:781
+#: recordtransfer/forms/submission_forms.py:829
 msgid "Other notes"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:773
-msgid "Upload session token is required"
-msgstr ""
-
-#: recordtransfer/forms/submission_forms.py:784
-#: recordtransfer/forms/submission_forms.py:793
+#: recordtransfer/forms/submission_forms.py:791
 msgid "Invalid upload session state. Please try again."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:797
+#: recordtransfer/forms/submission_forms.py:795
 msgid "You must upload at least one file"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:914
+#: recordtransfer/forms/submission_forms.py:908
 msgid "No identifiers were provided."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:916
+#: recordtransfer/forms/submission_forms.py:910
 msgid "No record rights or restrictions were provided."
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:19
+#: recordtransfer/forms/submission_group_form.py:20
 #: recordtransfer/templates/includes/submission_group_table.html:4
 #: recordtransfer/views/profile.py:173
 msgid "Group Name"
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:26
+#: recordtransfer/forms/submission_group_form.py:27
 msgid "Enter group description"
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:31
+#: recordtransfer/forms/submission_group_form.py:32
 #: recordtransfer/templates/includes/submission_group_table.html:5
 #: recordtransfer/templates/recordtransfer/submission_form_groupsubmission.html:31
 #: recordtransfer/views/profile.py:174
 msgid "Group Description"
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:49
+#: recordtransfer/forms/submission_group_form.py:50
 msgid "Form is empty."
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:58
+#: recordtransfer/forms/submission_group_form.py:60
 msgid "Required"
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:72
+#: recordtransfer/forms/submission_group_form.py:74
 msgid "You have already created a group with this name."
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:78
+#: recordtransfer/forms/submission_group_form.py:80
 msgid "No changes detected."
 msgstr ""
 
@@ -2095,7 +2094,7 @@ msgstr ""
 
 #: recordtransfer/templates/includes/open_session_table.html:30
 #: recordtransfer/templates/includes/submission_table.html:24
-#: upload/admin.py:51 upload/admin.py:258 upload/admin.py:268
+#: upload/admin.py:51 upload/admin.py:259 upload/admin.py:269
 msgid "N/A"
 msgstr ""
 
@@ -2159,7 +2158,7 @@ msgid "Language"
 msgstr ""
 
 #: recordtransfer/templates/includes/save_contact_info_modal.html:9
-#: recordtransfer/views/pre_submission.py:624
+#: recordtransfer/views/pre_submission.py:620
 msgid "Would you like to save your contact information to your profile?"
 msgstr ""
 
@@ -3652,7 +3651,7 @@ msgid "Next"
 msgstr ""
 
 #: recordtransfer/templates/recordtransfer/submission_form_base.html:112
-#: recordtransfer/views/pre_submission.py:269
+#: recordtransfer/views/pre_submission.py:265
 msgid "Review"
 msgstr ""
 
@@ -4009,7 +4008,7 @@ msgstr ""
 
 #: recordtransfer/tests/unit/views/test_profile.py:146
 #: recordtransfer/tests/unit/views/test_profile.py:241
-#: recordtransfer/views/pre_submission.py:532
+#: recordtransfer/views/pre_submission.py:528
 #: recordtransfer/views/profile.py:115
 msgid "Please correct the errors below."
 msgstr ""
@@ -4084,75 +4083,71 @@ msgstr ""
 msgid "File not found for this job"
 msgstr ""
 
-#: recordtransfer/views/post_submission.py:80
+#: recordtransfer/views/post_submission.py:79
 msgid "Submission not found"
 msgstr ""
 
-#: recordtransfer/views/post_submission.py:110
+#: recordtransfer/views/post_submission.py:109
 msgid "Submission group not found"
 msgstr ""
 
-#: recordtransfer/views/post_submission.py:132
+#: recordtransfer/views/post_submission.py:131
 msgid "This submission group has no submissions associated with it to export."
 msgstr ""
 
-#: recordtransfer/views/post_submission.py:199
+#: recordtransfer/views/post_submission.py:198
 msgid "Group updated"
 msgstr ""
 
-#: recordtransfer/views/post_submission.py:210
+#: recordtransfer/views/post_submission.py:209
 msgid "There was an error updating the group"
 msgstr ""
 
-#: recordtransfer/views/post_submission.py:219
-msgid "Direct access is not allowed."
-msgstr ""
-
-#: recordtransfer/views/pre_submission.py:99
+#: recordtransfer/views/pre_submission.py:95
 msgid "Date Last Changed"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:100
+#: recordtransfer/views/pre_submission.py:96
 msgid "Date Started"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:101
+#: recordtransfer/views/pre_submission.py:97
 msgid "Files Uploaded"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:176
+#: recordtransfer/views/pre_submission.py:172
 msgid "Legal Agreement"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:184
+#: recordtransfer/views/pre_submission.py:180
 msgid ""
 "Enter your contact information in case you need to be contacted by one of "
 "our archivists regarding your submission"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:190
+#: recordtransfer/views/pre_submission.py:186
 msgid "Record Source Information (Optional)"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:193
+#: recordtransfer/views/pre_submission.py:189
 msgid ""
 "Are you submitting records on behalf of another person or organization? "
 "Select Yes to enter information about them."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:198
+#: recordtransfer/views/pre_submission.py:194
 msgid "Record Description"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:202
+#: recordtransfer/views/pre_submission.py:198
 msgid "Provide a brief description of the records you're submitting"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:206
+#: recordtransfer/views/pre_submission.py:202
 msgid "Record Rights and Restrictions (Optional)"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:210
+#: recordtransfer/views/pre_submission.py:206
 #, python-format
 msgid ""
 "Depending on the records you are submitting, there may be specific rights "
@@ -4161,11 +4156,11 @@ msgid ""
 "explanations."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:225
+#: recordtransfer/views/pre_submission.py:221
 msgid "Identifiers (Optional)"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:232
+#: recordtransfer/views/pre_submission.py:228
 msgid ""
 "If you have any identifiers associated with these records, such as reference "
 "numbers, codes, or other unique IDs, you may enter them here. <b> This step "
@@ -4173,78 +4168,78 @@ msgid ""
 "records, you may proceed to the next step."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:238
+#: recordtransfer/views/pre_submission.py:234
 msgid "Assign Submission to Group (Optional)"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:241
+#: recordtransfer/views/pre_submission.py:237
 msgid ""
 "You may assign this submission to a group to keep your records organized. "
 "<b>This step is optional</b>. If you do not wish to assign a group, you can "
 "proceed to the next step."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:250
+#: recordtransfer/views/pre_submission.py:246
 msgid "Upload Files"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:253
+#: recordtransfer/views/pre_submission.py:249
 msgid "Add any final notes you would like to add, and upload your files"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:261
+#: recordtransfer/views/pre_submission.py:257
 msgid "Final Notes"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:263
+#: recordtransfer/views/pre_submission.py:259
 msgid "Add any final notes that may not have fit in previous steps"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:271
+#: recordtransfer/views/pre_submission.py:267
 msgid "Review the information you've entered before submitting"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:293
+#: recordtransfer/views/pre_submission.py:289
 msgid "Invalid step name"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:340
+#: recordtransfer/views/pre_submission.py:336
 msgid ""
 "Can't load this in-progress submission because it will put you over the "
 "maximum concurrent session limit."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:350
+#: recordtransfer/views/pre_submission.py:346
 msgid ""
 "Can't create a new submission because it will put you over the maximum "
 "concurrent session limit."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:401
-#: recordtransfer/views/pre_submission.py:595
+#: recordtransfer/views/pre_submission.py:397
+#: recordtransfer/views/pre_submission.py:591
 #, python-format
 msgid ""
 "Your submission was saved, but you have reached your session limit. Go to "
 "%(link_start)syour profile%(link_end)s to see your saved submissions."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:416
+#: recordtransfer/views/pre_submission.py:412
 msgid "Submission saved successfully."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:435
+#: recordtransfer/views/pre_submission.py:431
 #, python-format
 msgid ""
 "This submission will expire on %(date)s. Please be sure to complete your "
 "submission before then."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:447
-#: recordtransfer/views/pre_submission.py:611
+#: recordtransfer/views/pre_submission.py:443
+#: recordtransfer/views/pre_submission.py:607
 msgid "There was an error saving the submission."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:1022
+#: recordtransfer/views/pre_submission.py:1044
 msgid ""
 "There was an error creating your submission. Please try again later or "
 "contact us for assistance."
@@ -4379,7 +4374,7 @@ msgid ""
 "Please try again later. Contact us if you continue to experience issues."
 msgstr ""
 
-#: upload/admin.py:47 upload/admin.py:261
+#: upload/admin.py:47 upload/admin.py:262
 msgid "Upload Size"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 msgid "File was removed"
 msgstr ""
 
-#: upload/admin.py:271
+#: upload/admin.py:272
 msgid "Last upload at"
 msgstr ""
 
@@ -4569,47 +4564,47 @@ msgid ""
 "%(max_size_mb)sMB"
 msgstr ""
 
-#: upload/models.py:61
+#: upload/models.py:62
 msgid "Session Created"
 msgstr ""
 
-#: upload/models.py:62
+#: upload/models.py:63
 msgid "Session Expired"
 msgstr ""
 
-#: upload/models.py:63
+#: upload/models.py:64
 msgid "Uploading Files"
 msgstr ""
 
-#: upload/models.py:64
+#: upload/models.py:65
 msgid "File Copy in Progress"
 msgstr ""
 
-#: upload/models.py:65
+#: upload/models.py:66
 msgid "All Files in Permanent Storage"
 msgstr ""
 
-#: upload/models.py:66
+#: upload/models.py:67
 msgid "Copying Failed"
 msgstr ""
 
-#: upload/models.py:67
+#: upload/models.py:68
 msgid "File Removal in Progress"
 msgstr ""
 
-#: upload/models.py:553
+#: upload/models.py:554
 #, python-format
 msgid "%(file_count)s, totalling %(total_size)s"
 msgstr ""
 
-#: upload/models.py:566
+#: upload/models.py:567
 #, python-format
 msgid "Session %(token)s (%(count)s file, started: %(date)s)"
 msgid_plural "Session %(token)s (%(count)s files, started: %(date)s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: upload/models.py:577
+#: upload/models.py:578
 #, python-format
 msgid "%(token)s (started at %(date)s)"
 msgstr ""
@@ -4619,50 +4614,58 @@ msgstr ""
 msgid "%(name)s Removed! | %(session)s"
 msgstr ""
 
-#: upload/tests/unit/test_views.py:437 upload/views.py:225
-msgid "Invalid filename or upload session token"
+#: upload/views.py:91
+msgid "Invalid or expired upload session"
 msgstr ""
 
-#: upload/views.py:50
-msgid "Invalid upload session token"
-msgstr ""
-
-#: upload/views.py:64
+#: upload/views.py:104
 msgid "There was an internal server error. Please try again."
 msgstr ""
 
-#: upload/views.py:84
+#: upload/views.py:123
 msgid "No file was uploaded"
 msgstr ""
 
-#: upload/views.py:112
-#, python-format
-msgid "Malware was detected in the file \"%(name)s\""
+#: upload/views.py:131
+msgid "The file was not accepted"
 msgstr ""
 
-#: upload/views.py:124
-#, python-format
-msgid "File \"%(name)s\" is too large to scan for malware"
+#: upload/views.py:141
+msgid "The file was not accepted in session"
 msgstr ""
 
-#: upload/views.py:136
-msgid "Unable to scan file for malware due to scanner error"
+#: upload/views.py:153
+msgid "Malware was detected in the file"
 msgstr ""
 
-#: upload/views.py:150
-msgid "There was an error uploading the file"
+#: upload/views.py:161
+msgid "The file was too large to be scanned for malware"
 msgstr ""
 
-#: upload/views.py:233
-msgid "File not found in upload session"
+#: upload/views.py:169
+msgid "There was an error while scanning the file. Please try again later."
 msgstr ""
 
-#: upload/views.py:238
-msgid "Cannot remove file from upload session"
+#: upload/views.py:180
+msgid "There was an error processing the file. Please try again later."
 msgstr ""
 
-#: upload/views.py:246
+#: upload/views.py:191
+msgid "There was an error uploading the file. Please try again later."
+msgstr ""
+
+#: upload/views.py:224 upload/views.py:235 upload/views.py:245
+#: upload/views.py:292 upload/views.py:311 upload/views.py:322
+#: upload/views.py:330 upload/views.py:341
 msgid "The uploaded file could not be found"
+msgstr ""
+
+#: upload/views.py:278
+msgid "Invalid upload session"
+msgstr ""
+
+#: upload/views.py:303
+msgid "The uploaded file could not be deleted"
 msgstr ""
 
 #: utility/files.py:49 utility/files.py:68

--- a/app/locale/en/LC_MESSAGES/djangojs.po
+++ b/app/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-20 19:45-0600\n"
+"POT-Creation-Date: 2026-06-02 11:59-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,10 +27,10 @@ msgstr ""
 msgid "No description available"
 msgstr ""
 
-#: frontend/main/js/submission_form/uppyForm.js:157
+#: frontend/main/js/submission_form/uppyForm.js:160
 msgid "You must upload at least one file."
 msgstr ""
 
-#: frontend/main/js/submission_form/uppyForm.js:166
+#: frontend/main/js/submission_form/uppyForm.js:169
 msgid "Remove the files with issues to proceed."
 msgstr ""

--- a/app/locale/fr/LC_MESSAGES/django.po
+++ b/app/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 21:44-0500\n"
+"POT-Creation-Date: 2026-06-02 11:59-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Gabrielle Archambault <Gabrielle.Archambault@umanitoba.ca>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: app/settings/base.py:144
+#: app/settings/base.py:186
 msgid "English"
 msgstr "Anglais"
 
-#: app/settings/base.py:145
+#: app/settings/base.py:187
 msgid "French"
 msgstr "Français"
 
-#: app/settings/base.py:146
+#: app/settings/base.py:188
 msgid "Hindi"
 msgstr "Hindi"
 
@@ -94,32 +94,32 @@ msgstr ""
 "Enregistrez un identifiant pour identifier cette accession de manière unique"
 
 #: caais/forms.py:171 caais/forms.py:208
-#: recordtransfer/forms/submission_forms.py:365
-#: recordtransfer/forms/submission_forms.py:402
+#: recordtransfer/forms/submission_forms.py:374
+#: recordtransfer/forms/submission_forms.py:411
 msgid "Invalid date format"
 msgstr "Format de date invalide"
 
-#: caais/forms.py:190 recordtransfer/forms/submission_forms.py:384
+#: caais/forms.py:190 recordtransfer/forms/submission_forms.py:393
 msgid "Date cannot be in the future"
 msgstr "La date ne peut pas être dans le futur"
 
-#: caais/forms.py:192 recordtransfer/forms/submission_forms.py:386
+#: caais/forms.py:192 recordtransfer/forms/submission_forms.py:395
 msgid "End date cannot be in the future"
 msgstr "La date de fin ne peut pas être dans le futur"
 
-#: caais/forms.py:198 recordtransfer/forms/submission_forms.py:392
+#: caais/forms.py:198 recordtransfer/forms/submission_forms.py:401
 msgid "Date cannot be before 1800"
 msgstr "La date ne peut pas être avant 1800"
 
-#: caais/forms.py:200 recordtransfer/forms/submission_forms.py:394
+#: caais/forms.py:200 recordtransfer/forms/submission_forms.py:403
 msgid "End date cannot be before 1800"
 msgstr "La date de fin ne peut pas être avant 1800"
 
-#: caais/forms.py:210 recordtransfer/forms/submission_forms.py:404
+#: caais/forms.py:210 recordtransfer/forms/submission_forms.py:413
 msgid "Invalid date format for end date"
 msgstr "Format de date invalide pour la date de fin"
 
-#: caais/forms.py:220 recordtransfer/forms/submission_forms.py:414
+#: caais/forms.py:220 recordtransfer/forms/submission_forms.py:423
 msgid "End date must be later than start date"
 msgstr "La date de fin doit être postérieure à la date de début"
 
@@ -130,24 +130,24 @@ msgstr ""
 "'%(id)s' est un type d’identifiant réservé - veuillez utiliser un autre nom "
 "de type"
 
-#: caais/forms.py:365 recordtransfer/forms/mixins.py:17
-#: recordtransfer/forms/mixins.py:145
-#: recordtransfer/forms/submission_forms.py:186
-#: recordtransfer/forms/submission_forms.py:197
-#: recordtransfer/forms/submission_forms.py:212
-#: recordtransfer/forms/submission_forms.py:442
+#: caais/forms.py:365 recordtransfer/forms/mixins.py:35
+#: recordtransfer/forms/mixins.py:163
+#: recordtransfer/forms/submission_forms.py:195
+#: recordtransfer/forms/submission_forms.py:206
+#: recordtransfer/forms/submission_forms.py:221
+#: recordtransfer/forms/submission_forms.py:451
 msgid "This field is required."
 msgstr "Ce champ est obligatoire."
 
-#: caais/forms.py:366 recordtransfer/forms/mixins.py:18
+#: caais/forms.py:366 recordtransfer/forms/mixins.py:36
 msgid "Phone number must look like \"+1 (999) 999-9999\""
 msgstr "Le numéro de téléphone doit ressembler à \"+1 (999) 999-9999\""
 
-#: caais/forms.py:374 caais/models.py:950 recordtransfer/forms/mixins.py:25
+#: caais/forms.py:374 caais/models.py:950 recordtransfer/forms/mixins.py:43
 msgid "Phone number"
 msgstr "Numéro de téléphone"
 
-#: caais/forms.py:378 recordtransfer/forms/submission_forms.py:125
+#: caais/forms.py:378 recordtransfer/forms/submission_forms.py:134
 #: recordtransfer/forms/user_forms.py:36
 #: recordtransfer/templates/includes/account_info_form.html:12
 msgid "Email"
@@ -231,7 +231,7 @@ msgstr ""
 "Fournir une estimation préliminaire de dates échelonnées ou préciser en "
 "toutes lettres si elles n’ont pas encore été déterminées"
 
-#: caais/models.py:309 recordtransfer/forms/submission_forms.py:452
+#: caais/models.py:309 recordtransfer/forms/submission_forms.py:461
 msgid "Date of materials"
 msgstr "Date des matériaux"
 
@@ -340,7 +340,7 @@ msgid "Source types"
 msgstr "Types de sources"
 
 #: caais/models.py:759 caais/models.py:910
-#: recordtransfer/forms/submission_forms.py:260
+#: recordtransfer/forms/submission_forms.py:269
 msgid "Source type"
 msgstr "Type de source"
 
@@ -357,7 +357,7 @@ msgid "Source roles"
 msgstr "Rôles de la source"
 
 #: caais/models.py:784 caais/models.py:1002
-#: recordtransfer/forms/submission_forms.py:297
+#: recordtransfer/forms/submission_forms.py:306
 msgid "Source role"
 msgstr "Rôle de la source"
 
@@ -405,15 +405,15 @@ msgstr ""
 "utilisées\n"
 "pas l’établissement"
 
-#: caais/models.py:929 recordtransfer/forms/submission_forms.py:107
+#: caais/models.py:929 recordtransfer/forms/submission_forms.py:116
 msgid "Contact name"
 msgstr "Nom du contact"
 
-#: caais/models.py:936 recordtransfer/forms/submission_forms.py:114
+#: caais/models.py:936 recordtransfer/forms/submission_forms.py:123
 msgid "Job title"
 msgstr "Titre du poste"
 
-#: caais/models.py:943 recordtransfer/forms/submission_forms.py:121
+#: caais/models.py:943 recordtransfer/forms/submission_forms.py:130
 msgid "Organization"
 msgstr "Organisation"
 
@@ -421,15 +421,15 @@ msgstr "Organisation"
 msgid "Email address"
 msgstr "Courriel"
 
-#: caais/models.py:964 recordtransfer/forms/mixins.py:32
+#: caais/models.py:964 recordtransfer/forms/mixins.py:50
 msgid "Address line 1"
 msgstr "Adresse ligne 1"
 
-#: caais/models.py:971 recordtransfer/forms/mixins.py:39
+#: caais/models.py:971 recordtransfer/forms/mixins.py:57
 msgid "Address line 2"
 msgstr "Adresse ligne 2"
 
-#: caais/models.py:978 recordtransfer/forms/mixins.py:45
+#: caais/models.py:978 recordtransfer/forms/mixins.py:63
 #: recordtransfer/models.py:73
 msgid "City"
 msgstr "Ville"
@@ -442,7 +442,7 @@ msgstr ""
 msgid "Postal or zip code"
 msgstr ""
 
-#: caais/models.py:995 recordtransfer/forms/mixins.py:161
+#: caais/models.py:995 recordtransfer/forms/mixins.py:179
 msgid "Country"
 msgstr "Pays"
 
@@ -913,43 +913,43 @@ msgstr ""
 msgid "No other details listed"
 msgstr "Aucun autre détail indiqué"
 
-#: recordtransfer/admin.py:218
+#: recordtransfer/admin.py:220
 msgid ""
 "The selected submission group(s) do not contain any submissions to export."
 msgstr ""
 "Le(s) groupe(s) de soumission sélectionné(s) ne contiennent aucune "
 "soumission à exporter."
 
-#: recordtransfer/admin.py:229
+#: recordtransfer/admin.py:231
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export CAAIS 1.0 CSV for Submissions in Selected"
 msgstr "Exporter CSV NCIAA 1.0 pour Sélectionnés"
 
-#: recordtransfer/admin.py:239
+#: recordtransfer/admin.py:241
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export AtoM 2.6 Accession CSV for Submissions in Selected"
 msgstr "Exporter AtoM 2.6 Accession CSV pour Sélectionnés"
 
-#: recordtransfer/admin.py:249
+#: recordtransfer/admin.py:251
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export AtoM 2.3 Accession CSV for Submissions in Selected"
 msgstr "Exporter AtoM 2.3 Accession CSV pour Sélectionnés"
 
-#: recordtransfer/admin.py:259
+#: recordtransfer/admin.py:261
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export AtoM 2.2 Accession CSV for Submissions in Selected"
 msgstr "Exporter AtoM 2.2 Accession CSV pour Sélectionnés"
 
-#: recordtransfer/admin.py:269
+#: recordtransfer/admin.py:271
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export AtoM 2.1 Accession CSV for Submissions in Selected"
 msgstr "Exporter AtoM 2.1 Accession CSV pour Sélectionnés"
 
-#: recordtransfer/admin.py:388
+#: recordtransfer/admin.py:390
 msgid "Click link to view uploaded files"
 msgstr "Cliquez sur le lien pour voir les fichiers téléchargés"
 
-#: recordtransfer/admin.py:412
+#: recordtransfer/admin.py:414
 #, python-format
 msgid ""
 "A downloadable bag is being generated. Visit the %(link_start)sjobs "
@@ -960,7 +960,7 @@ msgstr ""
 "%(link_start)s page des emplois %(link_end)s pour le statut de génération du "
 "sac, ou consultez la page de Soumission pour un lien de téléchargement"
 
-#: recordtransfer/admin.py:428
+#: recordtransfer/admin.py:430
 msgid ""
 "There are no files associated with this submission, it is not possible to "
 "create a Bag"
@@ -968,117 +968,117 @@ msgstr ""
 "Il n'y a pas de fichiers associés à cette soumission, il n'est pas possible "
 "de créer un sac"
 
-#: recordtransfer/admin.py:437
+#: recordtransfer/admin.py:439
 #, python-format
 msgid "Submission with ID '%(id)s' doesn't exist. Perhaps it was deleted?"
 msgstr ""
 "Soumission avec l'identifiant '%(id)s' n'existe pas. Peut-être a-t-il été "
 "supprimé?"
 
-#: recordtransfer/admin.py:447
+#: recordtransfer/admin.py:449
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export CAAIS 1.0 CSV for Metadata in Selected"
 msgstr "Exporter CSV NCIAA 1.0 pour Sélectionnés"
 
-#: recordtransfer/admin.py:459
+#: recordtransfer/admin.py:461
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export AtoM 2.6 Accession CSV for Metadata in Selected"
 msgstr "Exporter AtoM 2.6 Accession CSV pour Sélectionnés"
 
-#: recordtransfer/admin.py:471
+#: recordtransfer/admin.py:473
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export AtoM 2.3 Accession CSV for Metadata in Selected"
 msgstr "Exporter AtoM 2.3 Accession CSV pour Sélectionnés"
 
-#: recordtransfer/admin.py:483
+#: recordtransfer/admin.py:485
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export AtoM 2.2 Accession CSV for Metadata in Selected"
 msgstr "Exporter AtoM 2.2 Accession CSV pour Sélectionnés"
 
-#: recordtransfer/admin.py:495
+#: recordtransfer/admin.py:497
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export AtoM 2.1 Accession CSV for Metadata in Selected"
 msgstr "Exporter AtoM 2.1 Accession CSV pour Sélectionnés"
 
-#: recordtransfer/admin.py:545 upload/admin.py:54
+#: recordtransfer/admin.py:547 upload/admin.py:54
 msgid "File Link"
 msgstr "Lien de fichier"
 
-#: recordtransfer/admin.py:551
+#: recordtransfer/admin.py:553
 msgid "No file attached"
 msgstr "Pas de fichier joint"
 
-#: recordtransfer/admin.py:578
+#: recordtransfer/admin.py:580
 #: recordtransfer/templates/includes/profile_forms.html:18
-#: recordtransfer/views/pre_submission.py:181
+#: recordtransfer/views/pre_submission.py:177
 msgid "Contact Information"
 msgstr "Coordonnées"
 
-#: recordtransfer/admin.py:593
+#: recordtransfer/admin.py:595
 msgid "Language Preferences"
 msgstr "Préférences de langues"
 
-#: recordtransfer/admin.py:599
+#: recordtransfer/admin.py:601
 msgid "Email Updates"
 msgstr "Mises à jour par courriel"
 
-#: recordtransfer/admin.py:653 recordtransfer/views/account.py:324
+#: recordtransfer/admin.py:655 recordtransfer/views/account.py:324
 msgid "Password updated"
 msgstr "Mot de passe mis à jour"
 
-#: recordtransfer/admin.py:654 recordtransfer/views/account.py:325
+#: recordtransfer/admin.py:656 recordtransfer/views/account.py:325
 #: recordtransfer/views/account.py:366
 msgid "password"
 msgstr "mot de passe"
 
-#: recordtransfer/admin.py:655 recordtransfer/admin.py:685
+#: recordtransfer/admin.py:657 recordtransfer/admin.py:687
 #: recordtransfer/management/commands/send_test_email.py:178
 #: recordtransfer/views/account.py:326
 msgid "updated"
 msgstr "mis à jour"
 
-#: recordtransfer/admin.py:666
+#: recordtransfer/admin.py:668
 msgid "Non-superusers cannot modify superuser accounts."
 msgstr ""
 "Les non-superutilisateurs ne peuvent pas modifier les comptes "
 "superutilisateurs."
 
-#: recordtransfer/admin.py:677
+#: recordtransfer/admin.py:679
 msgid "Account Deactivated"
 msgstr "Compte désactivé"
 
-#: recordtransfer/admin.py:678 recordtransfer/admin.py:684
+#: recordtransfer/admin.py:680 recordtransfer/admin.py:686
 #: recordtransfer/management/commands/send_test_email.py:177
 msgid "account"
 msgstr "compte"
 
-#: recordtransfer/admin.py:679
+#: recordtransfer/admin.py:681
 msgid "deactivated"
 msgstr "désactivé"
 
-#: recordtransfer/admin.py:683
+#: recordtransfer/admin.py:685
 #: recordtransfer/management/commands/send_test_email.py:176
 msgid "Account updated"
 msgstr "Compte mis à jour"
 
-#: recordtransfer/admin.py:696
+#: recordtransfer/admin.py:698
 msgid "Superuser privileges have been added to your account."
 msgstr "Les privilèges de superutilisateur ont été ajoutés à votre compte."
 
-#: recordtransfer/admin.py:698
+#: recordtransfer/admin.py:700
 msgid "Superuser privileges have been removed from your account."
 msgstr "Les privilèges de superutilisateur ont été retirés de votre compte."
 
-#: recordtransfer/admin.py:701
+#: recordtransfer/admin.py:703
 #: recordtransfer/management/commands/send_test_email.py:179
 msgid "Staff privileges have been added to your account."
 msgstr "Les privilèges du personnel ont été ajoutés à votre compte."
 
-#: recordtransfer/admin.py:703
+#: recordtransfer/admin.py:705
 msgid "Staff privileges have been removed from your account."
 msgstr "Les privilèges du personnel ont été retirés de votre compte."
 
-#: recordtransfer/admin.py:760
+#: recordtransfer/admin.py:762
 #, python-format
 msgid "Setting \"%(key)s\" has been reset to its default value of %(value)s."
 msgstr ""
@@ -1456,9 +1456,9 @@ msgid ""
 msgstr ""
 "Nom par défaut du type d'événement de soumission - relatif à la section "
 "5.1.1. de la NCIAA.\n"
-"Au moment de la réception d'une soumission, un événement de type « "
-"Soumission » est créé pour cette soumission. Vous pouvez contrôler le nom du "
-"Type d'événement pour cet événement ici."
+"Au moment de la réception d'une soumission, un événement de type "
+"« Soumission » est créé pour cette soumission. Vous pouvez contrôler le nom "
+"du Type d'événement pour cet événement ici."
 
 #: recordtransfer/enums.py:279
 msgid ""
@@ -1469,9 +1469,9 @@ msgid ""
 msgstr ""
 "Valeur par défaut de l'Agent de l'événement - relatif à la section 5.1.3. de "
 "la NCIAA.\n"
-"Au moment de la réception d'une soumission, un événement de type « "
-"Soumission » est créé pour cette soumission. Vous pouvez contrôler le nom de "
-"l'Agent d'événement pour cet événement ici."
+"Au moment de la réception d'une soumission, un événement de type "
+"« Soumission » est créé pour cette soumission. Vous pouvez contrôler le nom "
+"de l'Agent d'événement pour cet événement ici."
 
 #: recordtransfer/enums.py:287
 msgid ""
@@ -1482,8 +1482,8 @@ msgid ""
 msgstr ""
 "Valeur par défaut de la note sur l - relatif à la section 5.1.4. de la "
 "NCIAA.\n"
-"Au moment de la réception d'une soumission, un événement de type « "
-"Soumission » est créé pour cette soumission. Vous pouvez contrôler ici si "
+"Au moment de la réception d'une soumission, un événement de type "
+"« Soumission » est créé pour cette soumission. Vous pouvez contrôler ici si "
 "une note sur l'événement est ajoutée pour cet événement."
 
 #: recordtransfer/enums.py:296
@@ -1582,105 +1582,109 @@ msgstr "%(setting)s doit être un nombre entier positif."
 msgid "%(setting)s must be a valid email address."
 msgstr "%(setting)s doit être une adresse courriel valide."
 
-#: recordtransfer/forms/mixins.py:31
+#: recordtransfer/forms/mixins.py:11
+msgid "HTML is not allowed in this field."
+msgstr ""
+
+#: recordtransfer/forms/mixins.py:49
 msgid "Street, and street number"
 msgstr "Rue et numéro de rue"
 
-#: recordtransfer/forms/mixins.py:38
+#: recordtransfer/forms/mixins.py:56
 msgid "Unit Number, RPO, PO BOX... (optional)"
 msgstr "Numéro d'unité, RPO, boîte postale... (facultatif)"
 
-#: recordtransfer/forms/mixins.py:56
+#: recordtransfer/forms/mixins.py:74
 msgid "Select your province"
 msgstr "Sélectionnez votre province"
 
-#: recordtransfer/forms/mixins.py:127 recordtransfer/models.py:79
+#: recordtransfer/forms/mixins.py:145 recordtransfer/models.py:79
 msgid "Province or state"
 msgstr "Province ou état"
 
-#: recordtransfer/forms/mixins.py:139
+#: recordtransfer/forms/mixins.py:157
 msgid "Other province or state"
 msgstr "Autre province ou état"
 
-#: recordtransfer/forms/mixins.py:147
+#: recordtransfer/forms/mixins.py:165
 msgid ""
 "Postal code must look like \"Z0Z 0Z0\", zip code must look like \"12345\" or "
 "\"12345-1234\""
 msgstr ""
 "Le code postal doit ressembler à « Z0Z 0Z0 », « 12345 » ou « 12345-1234 »."
 
-#: recordtransfer/forms/mixins.py:156
+#: recordtransfer/forms/mixins.py:174
 msgid "Postal / Zip code"
 msgstr "Code postal"
 
-#: recordtransfer/forms/mixins.py:159
+#: recordtransfer/forms/mixins.py:177
 msgid "Select your Country"
 msgstr "Sélectionnez votre pays"
 
-#: recordtransfer/forms/mixins.py:175
+#: recordtransfer/forms/mixins.py:193
 msgid "Address line 1 is required if address line 2 is provided."
 msgstr ""
 "La ligne d'adresse 1 est obligatoire si la ligne d'adresse 2 est fournie."
 
-#: recordtransfer/forms/mixins.py:181
+#: recordtransfer/forms/mixins.py:199
 msgid ""
 "You must select a province or state, use \"Other\" to enter a custom location"
 msgstr ""
 "Vous devez sélectionner une province ou un état, utilisez « Autre » pour "
 "saisir un emplacement personnalisé"
 
-#: recordtransfer/forms/mixins.py:187
+#: recordtransfer/forms/mixins.py:205
 msgid ""
 "This field must be filled out if \"Other\" province or state is selected"
 msgstr ""
 "Ce champ doit être rempli si « Autre » province ou état est sélectionné"
 
-#: recordtransfer/forms/mixins.py:205
+#: recordtransfer/forms/mixins.py:223
 msgid "Please verify you are human"
 msgstr "Veuillez vérifier que vous êtes bien un être humain"
 
-#: recordtransfer/forms/submission_forms.py:71
+#: recordtransfer/forms/submission_forms.py:80
 msgid "I accept these terms"
 msgstr "J'accepte ces conditions"
 
-#: recordtransfer/forms/submission_forms.py:201
+#: recordtransfer/forms/submission_forms.py:210
 msgid "If \"Source type\" is Other, enter your own source type"
 msgstr "Si « Type de source » est Autre, entrez votre propre type de source"
 
-#: recordtransfer/forms/submission_forms.py:216
+#: recordtransfer/forms/submission_forms.py:225
 msgid "If \"Source role\" is Other, enter your own source role"
 msgstr "Si « rôle de source » est Autre, entrez votre propre rôle de source"
 
-#: recordtransfer/forms/submission_forms.py:225
+#: recordtransfer/forms/submission_forms.py:234
 #: recordtransfer/templates/includes/delete_in_progress_submission_modal.html:21
 #: recordtransfer/templates/includes/delete_submission_group_modal.html:19
 #: recordtransfer/templates/recordtransfer/submission_form_review.html:64
 msgid "Yes"
 msgstr "Oui"
 
-#: recordtransfer/forms/submission_forms.py:226
+#: recordtransfer/forms/submission_forms.py:235
 #: recordtransfer/templates/recordtransfer/submission_form_review.html:66
 msgid "No"
 msgstr "Non"
 
-#: recordtransfer/forms/submission_forms.py:231
+#: recordtransfer/forms/submission_forms.py:240
 msgid "Fill out this section?"
 msgstr "Remplir cette section?"
 
-#: recordtransfer/forms/submission_forms.py:244
+#: recordtransfer/forms/submission_forms.py:253
 msgid "Name of source"
 msgstr "Nom de la source"
 
-#: recordtransfer/forms/submission_forms.py:245
+#: recordtransfer/forms/submission_forms.py:254
 msgid "The organization or entity submitting the records"
 msgstr "L'organisation ou l'entité qui soumet les documents"
 
-#: recordtransfer/forms/submission_forms.py:259
-#: recordtransfer/forms/submission_forms.py:296
+#: recordtransfer/forms/submission_forms.py:268
+#: recordtransfer/forms/submission_forms.py:305
 msgid "Please select one"
 msgstr "Veuillez sélectionner une option"
 
-#: recordtransfer/forms/submission_forms.py:262
+#: recordtransfer/forms/submission_forms.py:271
 msgid ""
 "How would you describe <b>what</b> the source entity is? i.e., The source is "
 "a(n) ______"
@@ -1688,27 +1692,27 @@ msgstr ""
 "Comment décririez-vous <b>ce qu'est</b> l'entité source ? Autrement dit, la "
 "source est un(e)"
 
-#: recordtransfer/forms/submission_forms.py:277
+#: recordtransfer/forms/submission_forms.py:286
 msgid "A source type not covered by the other choices"
 msgstr "Un type de source non couvert par les autres choix"
 
-#: recordtransfer/forms/submission_forms.py:282
+#: recordtransfer/forms/submission_forms.py:291
 msgid "Other source type"
 msgstr "Autre type de source"
 
-#: recordtransfer/forms/submission_forms.py:298
+#: recordtransfer/forms/submission_forms.py:307
 msgid "How does the source relate to the records? "
 msgstr "Quel est le lien entre la source et les dossiers? "
 
-#: recordtransfer/forms/submission_forms.py:311
+#: recordtransfer/forms/submission_forms.py:320
 msgid "A source role not covered by the other choices"
 msgstr "Un rôle de source non couvert par les autres choix"
 
-#: recordtransfer/forms/submission_forms.py:316
+#: recordtransfer/forms/submission_forms.py:325
 msgid "Other source role"
 msgstr "Autre rôle de source"
 
-#: recordtransfer/forms/submission_forms.py:326
+#: recordtransfer/forms/submission_forms.py:335
 msgid ""
 "Enter any notes you think may be useful for the archives to have about this "
 "entity (optional)"
@@ -1716,43 +1720,43 @@ msgstr ""
 "Entrez toute note qui pourrait être utile aux archives concernant cette "
 "entité (facultatif)."
 
-#: recordtransfer/forms/submission_forms.py:331
+#: recordtransfer/forms/submission_forms.py:340
 msgid "Source notes"
 msgstr "Notes de la source"
 
-#: recordtransfer/forms/submission_forms.py:332
+#: recordtransfer/forms/submission_forms.py:341
 msgid "e.g., The donor wishes to remain anonymous"
 msgstr "par exemple, le donateur souhaite rester anonyme"
 
-#: recordtransfer/forms/submission_forms.py:423
+#: recordtransfer/forms/submission_forms.py:432
 msgid "e.g., Committee Meeting Minutes"
 msgstr "par exemple, Procès-verbal de la réunion du comité"
 
-#: recordtransfer/forms/submission_forms.py:424
+#: recordtransfer/forms/submission_forms.py:433
 msgid "Title"
 msgstr "Titre"
 
-#: recordtransfer/forms/submission_forms.py:431
+#: recordtransfer/forms/submission_forms.py:440
 msgid "English, French"
 msgstr "Anglais, Français"
 
-#: recordtransfer/forms/submission_forms.py:432
+#: recordtransfer/forms/submission_forms.py:441
 msgid "Enter all relevant languages here"
 msgstr "Entrez toutes les langues pertinentes ici"
 
-#: recordtransfer/forms/submission_forms.py:433
+#: recordtransfer/forms/submission_forms.py:442
 msgid "Language(s)"
 msgstr "Langue(s)"
 
-#: recordtransfer/forms/submission_forms.py:443
+#: recordtransfer/forms/submission_forms.py:452
 msgid "Date must be in the format YYYY-MM-DD or YYYY-MM-DD - YYYY-MM-DD"
 msgstr "La date doit être dans le format AAAA-MM-JJ ou AAAA-MM-JJ - AAAA-MM-JJ"
 
-#: recordtransfer/forms/submission_forms.py:447
+#: recordtransfer/forms/submission_forms.py:456
 msgid "2000-03-14 - 2001-05-06"
 msgstr "2000-03-14 - 2001-05-06"
 
-#: recordtransfer/forms/submission_forms.py:454
+#: recordtransfer/forms/submission_forms.py:463
 msgid ""
 "Enter the range of dates that the materials cover, or a single date if there "
 "is no range."
@@ -1760,26 +1764,26 @@ msgstr ""
 "Entrez l'intervalle de dates couverte par les documents, ou une seule date "
 "s'il n'y a pas d'intervalle."
 
-#: recordtransfer/forms/submission_forms.py:462
+#: recordtransfer/forms/submission_forms.py:471
 msgid "Date is approximated"
 msgstr "La date est approximative"
 
-#: recordtransfer/forms/submission_forms.py:464
+#: recordtransfer/forms/submission_forms.py:473
 msgid ""
 "Check this box if the date is approximate, or if you are unsure of the date."
 msgstr ""
 "Cochez cette case si la date est approximative ou si vous n'êtes pas sûr de "
 "la date."
 
-#: recordtransfer/forms/submission_forms.py:473
+#: recordtransfer/forms/submission_forms.py:482
 msgid "e.g., These files contain images from ..."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:475
+#: recordtransfer/forms/submission_forms.py:484
 msgid "Description of contents"
 msgstr "Description du contenu"
 
-#: recordtransfer/forms/submission_forms.py:477
+#: recordtransfer/forms/submission_forms.py:486
 msgid ""
 "Briefly describe the content of the files you are submitting. What do the "
 "files contain?"
@@ -1787,7 +1791,7 @@ msgstr ""
 "Décrivez brièvement le contenu des fichiers que vous soumettez. Que "
 "contiennent ces fichiers?"
 
-#: recordtransfer/forms/submission_forms.py:489
+#: recordtransfer/forms/submission_forms.py:498
 msgid ""
 "Enter any information you have on the history of who has had custody of the "
 "records or who has kept the records in the past (optional)"
@@ -1796,16 +1800,16 @@ msgstr ""
 "personnes qui ont eu la garde des documents ou qui les ont conservés dans le "
 "passé (facultatif)."
 
-#: recordtransfer/forms/submission_forms.py:495
+#: recordtransfer/forms/submission_forms.py:504
 msgid "Custodial history"
 msgstr "Historique de conservation"
 
-#: recordtransfer/forms/submission_forms.py:496
+#: recordtransfer/forms/submission_forms.py:505
 msgid "e.g., John Doe held these records before donating them in 1960"
 msgstr ""
 "par exemple, John Doe détenait ces documents avant de les donner en 1960"
 
-#: recordtransfer/forms/submission_forms.py:512
+#: recordtransfer/forms/submission_forms.py:521
 msgid ""
 "Record how many files and of what type they are that you are planning on "
 "submitting (optional)"
@@ -1813,15 +1817,15 @@ msgstr ""
 "Indiquez le nombre et le type de fichiers que vous prévoyez de soumettre "
 "(facultatif)."
 
-#: recordtransfer/forms/submission_forms.py:517
+#: recordtransfer/forms/submission_forms.py:526
 msgid "For example, &quot;200 PDF documents, totalling 2.0GB&quot;"
 msgstr "Par exemple, « 200 documents PDF, pour un total de 2,0 Go »"
 
-#: recordtransfer/forms/submission_forms.py:518
+#: recordtransfer/forms/submission_forms.py:527
 msgid "Quantity and type of files"
 msgstr "Quantité et type de fichiers"
 
-#: recordtransfer/forms/submission_forms.py:554
+#: recordtransfer/forms/submission_forms.py:563
 msgid ""
 "If \"Other type of rights\" is empty, you must choose one of the Rights "
 "types here"
@@ -1829,38 +1833,38 @@ msgstr ""
 "Si le champ « Autre type de droits » est vide, vous devez choisir ici l'un "
 "des types de droits"
 
-#: recordtransfer/forms/submission_forms.py:560
+#: recordtransfer/forms/submission_forms.py:569
 msgid "If \"Type of rights\" is empty, you must enter a different type here"
 msgstr ""
 "Si le champ « Type de droits » est vide, vous devez saisir un autre type ici"
 
-#: recordtransfer/forms/submission_forms.py:578
+#: recordtransfer/forms/submission_forms.py:587
 msgid "Type of rights"
 msgstr "Type de droits"
 
-#: recordtransfer/forms/submission_forms.py:579
+#: recordtransfer/forms/submission_forms.py:588
 msgid "Select a rights type (optional)"
 msgstr "Sélectionnez un type de droits (facultatif)"
 
-#: recordtransfer/forms/submission_forms.py:587
+#: recordtransfer/forms/submission_forms.py:596
 msgid "Other type of rights not covered by other choices"
 msgstr "Autres types de droits non couverts par les autres choix"
 
-#: recordtransfer/forms/submission_forms.py:591
+#: recordtransfer/forms/submission_forms.py:600
 msgid "For example: &quot;UK Human Rights Act 1998&quot;"
 msgstr "Par exemple: &quot;UK Human Rights Act 1998&quot;"
 
-#: recordtransfer/forms/submission_forms.py:592
+#: recordtransfer/forms/submission_forms.py:601
 msgid "Other type of rights"
 msgstr "Autres types de droits"
 
-#: recordtransfer/forms/submission_forms.py:601
+#: recordtransfer/forms/submission_forms.py:610
 msgid "Any notes on these rights or which files they may apply to (optional)"
 msgstr ""
 "Notes concernant ces droits ou les fichiers auxquels ils s'appliquent "
 "(facultatif)"
 
-#: recordtransfer/forms/submission_forms.py:606
+#: recordtransfer/forms/submission_forms.py:615
 msgid ""
 "For example: &quot;Copyright until 2050&quot;, &quot;Only applies to "
 "images&quot;, etc."
@@ -1868,73 +1872,73 @@ msgstr ""
 "Par exemple : « droits d'auteur jusqu'en 2050 », « S'applique uniquement aux "
 "images », etc."
 
-#: recordtransfer/forms/submission_forms.py:608
+#: recordtransfer/forms/submission_forms.py:617
 msgid "Notes for rights"
 msgstr "Notes relatives aux droits"
 
-#: recordtransfer/forms/submission_forms.py:637
+#: recordtransfer/forms/submission_forms.py:646
 msgid "This identifier type is reserved and cannot be used"
 msgstr "Ce type d'identifiant est réservé et ne peut pas être utilisé"
 
-#: recordtransfer/forms/submission_forms.py:641
-#: recordtransfer/forms/submission_forms.py:646
+#: recordtransfer/forms/submission_forms.py:650
+#: recordtransfer/forms/submission_forms.py:655
 msgid "Must enter a value for this identifier"
 msgstr "Vous devez saisir une valeur pour cet identifiant"
 
-#: recordtransfer/forms/submission_forms.py:643
-#: recordtransfer/forms/submission_forms.py:645
+#: recordtransfer/forms/submission_forms.py:652
+#: recordtransfer/forms/submission_forms.py:654
 msgid "Must enter a type for this identifier"
 msgstr "Il faut entrer un type pour cet identifiant"
 
-#: recordtransfer/forms/submission_forms.py:648
+#: recordtransfer/forms/submission_forms.py:657
 msgid "Cannot enter a note without entering a value and type"
 msgstr "Impossible de saisir une note sans entrer une valeur et un type"
 
-#: recordtransfer/forms/submission_forms.py:656
+#: recordtransfer/forms/submission_forms.py:665
 msgid "The type of the identifier"
 msgstr "Le type de l'identifiant"
 
-#: recordtransfer/forms/submission_forms.py:659
+#: recordtransfer/forms/submission_forms.py:668
 msgid ""
 "For example: &quot;Receipt number&quot;, &quot;LAC Record ID&quot;, etc."
 msgstr "Par exemple : « Numéro de reçu », « Identifiant BAC », etc."
 
-#: recordtransfer/forms/submission_forms.py:660
+#: recordtransfer/forms/submission_forms.py:669
 msgid "Type of identifier"
 msgstr "Type d'identifiant"
 
-#: recordtransfer/forms/submission_forms.py:667
-#: recordtransfer/forms/submission_forms.py:670
+#: recordtransfer/forms/submission_forms.py:676
+#: recordtransfer/forms/submission_forms.py:679
 msgid "Identifier value"
 msgstr "Valeur de l'identifiant"
 
-#: recordtransfer/forms/submission_forms.py:679
+#: recordtransfer/forms/submission_forms.py:688
 msgid "Any notes on this identifier or which files it may apply to (optional)."
 msgstr ""
 "Notes concernant cet identifiant ou les fichiers auxquels il peut "
 "s'appliquer (facultatif)."
 
-#: recordtransfer/forms/submission_forms.py:683
+#: recordtransfer/forms/submission_forms.py:692
 msgid "Notes for identifier"
 msgstr "Notes pour l'identifiant"
 
-#: recordtransfer/forms/submission_forms.py:708
+#: recordtransfer/forms/submission_forms.py:717
 msgid "Select a group"
 msgstr "Sélectionnez un groupe"
 
-#: recordtransfer/forms/submission_forms.py:735
+#: recordtransfer/forms/submission_forms.py:744
 msgid "Assigned group"
 msgstr "Groupe assigné"
 
-#: recordtransfer/forms/submission_forms.py:759
-#: recordtransfer/forms/submission_forms.py:824
+#: recordtransfer/forms/submission_forms.py:774
+#: recordtransfer/forms/submission_forms.py:822
 msgid "Record any general notes you have about the records here (optional)"
 msgstr ""
 "Notez ici toutes les notes générales que vous avez concernant les dossiers "
 "(facultatif)."
 
-#: recordtransfer/forms/submission_forms.py:764
-#: recordtransfer/forms/submission_forms.py:829
+#: recordtransfer/forms/submission_forms.py:779
+#: recordtransfer/forms/submission_forms.py:827
 msgid ""
 "These should be notes that did not fit in any of the previous steps of this "
 "form"
@@ -1942,63 +1946,58 @@ msgstr ""
 "Il devrait s'agir de notes qui ne trouvaient pas leur place dans les étapes "
 "précédentes de ce formulaire"
 
-#: recordtransfer/forms/submission_forms.py:766
-#: recordtransfer/forms/submission_forms.py:831
+#: recordtransfer/forms/submission_forms.py:781
+#: recordtransfer/forms/submission_forms.py:829
 msgid "Other notes"
 msgstr "Autres notes"
 
-#: recordtransfer/forms/submission_forms.py:773
-msgid "Upload session token is required"
-msgstr "L'identifiant de session de téléchargement est requis"
-
-#: recordtransfer/forms/submission_forms.py:784
-#: recordtransfer/forms/submission_forms.py:793
+#: recordtransfer/forms/submission_forms.py:791
 msgid "Invalid upload session state. Please try again."
 msgstr "État de session de téléchargement non valide. Veuillez réessayer."
 
-#: recordtransfer/forms/submission_forms.py:797
+#: recordtransfer/forms/submission_forms.py:795
 msgid "You must upload at least one file"
 msgstr "Vous devez télécharger au moins un fichier"
 
-#: recordtransfer/forms/submission_forms.py:914
+#: recordtransfer/forms/submission_forms.py:908
 msgid "No identifiers were provided."
 msgstr "Aucun identifiant n'a été fourni."
 
-#: recordtransfer/forms/submission_forms.py:916
+#: recordtransfer/forms/submission_forms.py:910
 msgid "No record rights or restrictions were provided."
 msgstr ""
 "Aucun droit ni restriction n'ont été accordés en matière d'enregistrement."
 
-#: recordtransfer/forms/submission_group_form.py:19
+#: recordtransfer/forms/submission_group_form.py:20
 #: recordtransfer/templates/includes/submission_group_table.html:4
 #: recordtransfer/views/profile.py:173
 msgid "Group Name"
 msgstr "Nom du groupe"
 
-#: recordtransfer/forms/submission_group_form.py:26
+#: recordtransfer/forms/submission_group_form.py:27
 msgid "Enter group description"
 msgstr "Entrez la description du groupe"
 
-#: recordtransfer/forms/submission_group_form.py:31
+#: recordtransfer/forms/submission_group_form.py:32
 #: recordtransfer/templates/includes/submission_group_table.html:5
 #: recordtransfer/templates/recordtransfer/submission_form_groupsubmission.html:31
 #: recordtransfer/views/profile.py:174
 msgid "Group Description"
 msgstr "Description du groupe"
 
-#: recordtransfer/forms/submission_group_form.py:49
+#: recordtransfer/forms/submission_group_form.py:50
 msgid "Form is empty."
 msgstr "Le formulaire est vide."
 
-#: recordtransfer/forms/submission_group_form.py:58
+#: recordtransfer/forms/submission_group_form.py:60
 msgid "Required"
 msgstr "Requis"
 
-#: recordtransfer/forms/submission_group_form.py:72
+#: recordtransfer/forms/submission_group_form.py:74
 msgid "You have already created a group with this name."
 msgstr "Vous avez déjà créé un groupe avec ce nom."
 
-#: recordtransfer/forms/submission_group_form.py:78
+#: recordtransfer/forms/submission_group_form.py:80
 msgid "No changes detected."
 msgstr "Aucun changement détecté."
 
@@ -2436,7 +2435,7 @@ msgstr "Expire bientôt"
 
 #: recordtransfer/templates/includes/open_session_table.html:30
 #: recordtransfer/templates/includes/submission_table.html:24
-#: upload/admin.py:51 upload/admin.py:258 upload/admin.py:268
+#: upload/admin.py:51 upload/admin.py:259 upload/admin.py:269
 msgid "N/A"
 msgstr "Sans objet"
 
@@ -2508,7 +2507,7 @@ msgid "Language"
 msgstr "Langue"
 
 #: recordtransfer/templates/includes/save_contact_info_modal.html:9
-#: recordtransfer/views/pre_submission.py:624
+#: recordtransfer/views/pre_submission.py:620
 msgid "Would you like to save your contact information to your profile?"
 msgstr "Souhaitez-vous enregistrer vos coordonnées dans votre profil ?"
 
@@ -3734,8 +3733,8 @@ msgstr ""
 "\n"
 "                Ce qui suit est un rapport généré automatiquement pour la "
 "soumission effectuée par\n"
-"                %(username)s (%(email)s) le %(date)s, intitulée « %(title)s "
-"».\n"
+"                %(username)s (%(email)s) le %(date)s, intitulée "
+"« %(title)s ».\n"
 "          "
 
 #: recordtransfer/templates/recordtransfer/submission_detail.html:34
@@ -4308,7 +4307,7 @@ msgid "Next"
 msgstr "Suivant"
 
 #: recordtransfer/templates/recordtransfer/submission_form_base.html:112
-#: recordtransfer/views/pre_submission.py:269
+#: recordtransfer/views/pre_submission.py:265
 msgid "Review"
 msgstr "Révision"
 
@@ -4736,7 +4735,7 @@ msgstr "Retour à la connexion"
 
 #: recordtransfer/tests/unit/views/test_profile.py:146
 #: recordtransfer/tests/unit/views/test_profile.py:241
-#: recordtransfer/views/pre_submission.py:532
+#: recordtransfer/views/pre_submission.py:528
 #: recordtransfer/views/profile.py:115
 msgid "Please correct the errors below."
 msgstr "Veuillez corriger les erreurs ci-dessous."
@@ -4819,48 +4818,44 @@ msgstr "La ressource demandée est introuvable"
 msgid "File not found for this job"
 msgstr "Fichier introuvable pour cette tâche"
 
-#: recordtransfer/views/post_submission.py:80
+#: recordtransfer/views/post_submission.py:79
 msgid "Submission not found"
 msgstr "Soumission introuvable"
 
-#: recordtransfer/views/post_submission.py:110
+#: recordtransfer/views/post_submission.py:109
 msgid "Submission group not found"
 msgstr "Groupe de soumission introuvable"
 
-#: recordtransfer/views/post_submission.py:132
+#: recordtransfer/views/post_submission.py:131
 msgid "This submission group has no submissions associated with it to export."
 msgstr ""
 "Ce groupe de soumissions ne comporte aucune soumission associée à exporter."
 
-#: recordtransfer/views/post_submission.py:199
+#: recordtransfer/views/post_submission.py:198
 msgid "Group updated"
 msgstr "Groupe mis à jour"
 
-#: recordtransfer/views/post_submission.py:210
+#: recordtransfer/views/post_submission.py:209
 msgid "There was an error updating the group"
 msgstr "Une erreur s'est produite lors de la mise à jour du groupe"
 
-#: recordtransfer/views/post_submission.py:219
-msgid "Direct access is not allowed."
-msgstr "L'accès direct n'est pas autorisé."
-
-#: recordtransfer/views/pre_submission.py:99
+#: recordtransfer/views/pre_submission.py:95
 msgid "Date Last Changed"
 msgstr "Date de la dernière modification"
 
-#: recordtransfer/views/pre_submission.py:100
+#: recordtransfer/views/pre_submission.py:96
 msgid "Date Started"
 msgstr "Date de début"
 
-#: recordtransfer/views/pre_submission.py:101
+#: recordtransfer/views/pre_submission.py:97
 msgid "Files Uploaded"
 msgstr "Fichiers téléchargés"
 
-#: recordtransfer/views/pre_submission.py:176
+#: recordtransfer/views/pre_submission.py:172
 msgid "Legal Agreement"
 msgstr "Accord juridique"
 
-#: recordtransfer/views/pre_submission.py:184
+#: recordtransfer/views/pre_submission.py:180
 msgid ""
 "Enter your contact information in case you need to be contacted by one of "
 "our archivists regarding your submission"
@@ -4868,11 +4863,11 @@ msgstr ""
 "Veuillez saisir vos coordonnées au cas où l'un de nos archivistes aurait "
 "besoin de vous contacter au sujet de votre soumission"
 
-#: recordtransfer/views/pre_submission.py:190
+#: recordtransfer/views/pre_submission.py:186
 msgid "Record Source Information (Optional)"
 msgstr "Informations sur la source de l'enregistrement (facultatif)"
 
-#: recordtransfer/views/pre_submission.py:193
+#: recordtransfer/views/pre_submission.py:189
 msgid ""
 "Are you submitting records on behalf of another person or organization? "
 "Select Yes to enter information about them."
@@ -4880,20 +4875,20 @@ msgstr ""
 "Souhaitez-vous soumettre des documents au nom d'une autre personne ou "
 "organisation? Sélectionnez Oui pour saisir les informations à leur sujet."
 
-#: recordtransfer/views/pre_submission.py:198
+#: recordtransfer/views/pre_submission.py:194
 msgid "Record Description"
 msgstr "Description des documents d'archives"
 
-#: recordtransfer/views/pre_submission.py:202
+#: recordtransfer/views/pre_submission.py:198
 msgid "Provide a brief description of the records you're submitting"
 msgstr ""
 "Fournissez une brève description des documents d'archives que vous soumettez"
 
-#: recordtransfer/views/pre_submission.py:206
+#: recordtransfer/views/pre_submission.py:202
 msgid "Record Rights and Restrictions (Optional)"
 msgstr "Droits et restrictions relatifs aux documents d'archives (facultatif)"
 
-#: recordtransfer/views/pre_submission.py:210
+#: recordtransfer/views/pre_submission.py:206
 #, python-format
 msgid ""
 "Depending on the records you are submitting, there may be specific rights "
@@ -4906,11 +4901,11 @@ msgstr ""
 "comprendre les différents types de droits ? %(link_start)sConsultez notre "
 "guide%(link_end)s pour obtenir des explications détaillées."
 
-#: recordtransfer/views/pre_submission.py:225
+#: recordtransfer/views/pre_submission.py:221
 msgid "Identifiers (Optional)"
 msgstr "Identifiants (facultatif)"
 
-#: recordtransfer/views/pre_submission.py:232
+#: recordtransfer/views/pre_submission.py:228
 msgid ""
 "If you have any identifiers associated with these records, such as reference "
 "numbers, codes, or other unique IDs, you may enter them here. <b> This step "
@@ -4923,11 +4918,11 @@ msgstr ""
 "disposez d'aucun identifiant associé aux documents d'archives, vous pouvez "
 "passer à l'étape suivante."
 
-#: recordtransfer/views/pre_submission.py:238
+#: recordtransfer/views/pre_submission.py:234
 msgid "Assign Submission to Group (Optional)"
 msgstr "Attribuer la soumission à un groupe (facultatif)"
 
-#: recordtransfer/views/pre_submission.py:241
+#: recordtransfer/views/pre_submission.py:237
 msgid ""
 "You may assign this submission to a group to keep your records organized. "
 "<b>This step is optional</b>. If you do not wish to assign a group, you can "
@@ -4937,35 +4932,35 @@ msgstr ""
 "documents d'archives. <b>Cette étape est facultative</b>. Si vous ne "
 "souhaitez pas attribuer de groupe, vous pouvez passer à l'étape suivante."
 
-#: recordtransfer/views/pre_submission.py:250
+#: recordtransfer/views/pre_submission.py:246
 msgid "Upload Files"
 msgstr "Télécharger des fichiers"
 
-#: recordtransfer/views/pre_submission.py:253
+#: recordtransfer/views/pre_submission.py:249
 msgid "Add any final notes you would like to add, and upload your files"
 msgstr ""
 "Ajoutez les dernières notes que vous souhaitez ajouter, puis téléchargez vos "
 "fichiers"
 
-#: recordtransfer/views/pre_submission.py:261
+#: recordtransfer/views/pre_submission.py:257
 msgid "Final Notes"
 msgstr "Notes finales"
 
-#: recordtransfer/views/pre_submission.py:263
+#: recordtransfer/views/pre_submission.py:259
 msgid "Add any final notes that may not have fit in previous steps"
 msgstr ""
 "Ajoutez toute note finale qui n'aurait pas pu être intégrée aux étapes "
 "précédentes"
 
-#: recordtransfer/views/pre_submission.py:271
+#: recordtransfer/views/pre_submission.py:267
 msgid "Review the information you've entered before submitting"
 msgstr "Vérifiez les informations que vous avez saisies avant de les envoyer"
 
-#: recordtransfer/views/pre_submission.py:293
+#: recordtransfer/views/pre_submission.py:289
 msgid "Invalid step name"
 msgstr "Nom de l'étape invalide"
 
-#: recordtransfer/views/pre_submission.py:340
+#: recordtransfer/views/pre_submission.py:336
 msgid ""
 "Can't load this in-progress submission because it will put you over the "
 "maximum concurrent session limit."
@@ -4973,7 +4968,7 @@ msgstr ""
 "Impossible de charger cette soumission en cours, car cela dépasserait la "
 "limite maximale de sessions simultanées."
 
-#: recordtransfer/views/pre_submission.py:350
+#: recordtransfer/views/pre_submission.py:346
 msgid ""
 "Can't create a new submission because it will put you over the maximum "
 "concurrent session limit."
@@ -4981,8 +4976,8 @@ msgstr ""
 "Impossible de créer une nouvelle soumission car cela dépasserait la limite "
 "maximale de sessions simultanées."
 
-#: recordtransfer/views/pre_submission.py:401
-#: recordtransfer/views/pre_submission.py:595
+#: recordtransfer/views/pre_submission.py:397
+#: recordtransfer/views/pre_submission.py:591
 #, python-format
 msgid ""
 "Your submission was saved, but you have reached your session limit. Go to "
@@ -4992,11 +4987,11 @@ msgstr ""
 "votre session. Allez à %(link_start)svotre profil%(link_end)s pour voir vos "
 "soumissions enregistrées."
 
-#: recordtransfer/views/pre_submission.py:416
+#: recordtransfer/views/pre_submission.py:412
 msgid "Submission saved successfully."
 msgstr "Soumission enregistrée avec succès."
 
-#: recordtransfer/views/pre_submission.py:435
+#: recordtransfer/views/pre_submission.py:431
 #, python-format
 msgid ""
 "This submission will expire on %(date)s. Please be sure to complete your "
@@ -5005,12 +5000,12 @@ msgstr ""
 "Cette soumission expirera le %(date)s. Veuillez vous assurer de terminer "
 "votre soumission avant cette date."
 
-#: recordtransfer/views/pre_submission.py:447
-#: recordtransfer/views/pre_submission.py:611
+#: recordtransfer/views/pre_submission.py:443
+#: recordtransfer/views/pre_submission.py:607
 msgid "There was an error saving the submission."
 msgstr "Une erreur s'est produite lors de l'enregistrement de la soumission."
 
-#: recordtransfer/views/pre_submission.py:1022
+#: recordtransfer/views/pre_submission.py:1044
 msgid ""
 "There was an error creating your submission. Please try again later or "
 "contact us for assistance."
@@ -5149,7 +5144,7 @@ msgid ""
 msgstr ""
 "Veuillez réessayer plus tard. Contactez-nous si les difficultés persistent."
 
-#: upload/admin.py:47 upload/admin.py:261
+#: upload/admin.py:47 upload/admin.py:262
 msgid "Upload Size"
 msgstr "Taille du téléchargement"
 
@@ -5157,7 +5152,7 @@ msgstr "Taille du téléchargement"
 msgid "File was removed"
 msgstr "Le fichier a été supprimé"
 
-#: upload/admin.py:271
+#: upload/admin.py:272
 msgid "Last upload at"
 msgstr "Dernier téléchargement à"
 
@@ -5356,47 +5351,47 @@ msgstr ""
 "Le fichier \"%(filename)s\" est trop volumineux (%(size_mb).2fMo). Taille "
 "maximale des fichiers: %(max_size_mb)sMo"
 
-#: upload/models.py:61
+#: upload/models.py:62
 msgid "Session Created"
 msgstr "Session créée"
 
-#: upload/models.py:62
+#: upload/models.py:63
 msgid "Session Expired"
 msgstr "Session expirée"
 
-#: upload/models.py:63
+#: upload/models.py:64
 msgid "Uploading Files"
 msgstr "Téléchargement de fichiers"
 
-#: upload/models.py:64
+#: upload/models.py:65
 msgid "File Copy in Progress"
 msgstr "Copie du fichier en cours"
 
-#: upload/models.py:65
+#: upload/models.py:66
 msgid "All Files in Permanent Storage"
 msgstr "Tous les fichiers dans l'entreposage permanent"
 
-#: upload/models.py:66
+#: upload/models.py:67
 msgid "Copying Failed"
 msgstr "Échec de la copie"
 
-#: upload/models.py:67
+#: upload/models.py:68
 msgid "File Removal in Progress"
 msgstr "Suppression de fichier en cours"
 
-#: upload/models.py:553
+#: upload/models.py:554
 #, python-format
 msgid "%(file_count)s, totalling %(total_size)s"
 msgstr "%(file_count)s, totalisant %(total_size)s"
 
-#: upload/models.py:566
+#: upload/models.py:567
 #, python-format
 msgid "Session %(token)s (%(count)s file, started: %(date)s)"
 msgid_plural "Session %(token)s (%(count)s files, started: %(date)s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: upload/models.py:577
+#: upload/models.py:578
 #, python-format
 msgid "%(token)s (started at %(date)s)"
 msgstr "%(token)s (commencé à %(date)s)"
@@ -5406,54 +5401,78 @@ msgstr "%(token)s (commencé à %(date)s)"
 msgid "%(name)s Removed! | %(session)s"
 msgstr "%(name)s Supprimé! | %(session)s"
 
-#: upload/tests/unit/test_views.py:437 upload/views.py:225
-msgid "Invalid filename or upload session token"
-msgstr "Nom de fichier ou identifiant de session de téléchargement invalide"
-
-#: upload/views.py:50
-msgid "Invalid upload session token"
+#: upload/views.py:91
+#, fuzzy
+#| msgid "Invalid upload session token"
+msgid "Invalid or expired upload session"
 msgstr "Identifiant de session de téléchargement invalide"
 
-#: upload/views.py:64
+#: upload/views.py:104
 msgid "There was an internal server error. Please try again."
 msgstr "Une erreur interne du serveur s'est produite. Veuillez réessayer."
 
-#: upload/views.py:84
+#: upload/views.py:123
 msgid "No file was uploaded"
 msgstr "Aucun fichier n'a été téléchargé"
 
-#: upload/views.py:112
-#, python-format
-msgid "Malware was detected in the file \"%(name)s\""
+#: upload/views.py:131
+#, fuzzy
+#| msgid "The form was not valid."
+msgid "The file was not accepted"
+msgstr "Le formulaire n'était pas valide."
+
+#: upload/views.py:141
+msgid "The file was not accepted in session"
+msgstr ""
+
+#: upload/views.py:153
+#, fuzzy
+#| msgid "Malware was detected in the file \"%(name)s\""
+msgid "Malware was detected in the file"
 msgstr "Un logiciel malveillant a été détecté dans le fichier «%(name)s»"
 
-#: upload/views.py:124
-#, python-format
-msgid "File \"%(name)s\" is too large to scan for malware"
+#: upload/views.py:161
+#, fuzzy
+#| msgid "File \"%(name)s\" is too large to scan for malware"
+msgid "The file was too large to be scanned for malware"
 msgstr ""
 "Fichier \"%(name)s\" est trop volumineux pour être analysé à la recherche de "
 "logiciels malveillants"
 
-#: upload/views.py:136
-msgid "Unable to scan file for malware due to scanner error"
-msgstr ""
-"Impossible d'analyser le fichier à la recherche de logiciels malveillants en "
-"raison d'une erreur de lecture"
+#: upload/views.py:169
+#, fuzzy
+#| msgid "There was an internal server error. Please try again."
+msgid "There was an error while scanning the file. Please try again later."
+msgstr "Une erreur interne du serveur s'est produite. Veuillez réessayer."
 
-#: upload/views.py:150
-msgid "There was an error uploading the file"
+#: upload/views.py:180
+#, fuzzy
+#| msgid "There was an internal server error. Please try again."
+msgid "There was an error processing the file. Please try again later."
+msgstr "Une erreur interne du serveur s'est produite. Veuillez réessayer."
+
+#: upload/views.py:191
+#, fuzzy
+#| msgid "There was an error uploading the file"
+msgid "There was an error uploading the file. Please try again later."
 msgstr "Une erreur s'est produite lors du téléchargement du fichier"
 
-#: upload/views.py:233
-msgid "File not found in upload session"
-msgstr "Fichier introuvable dans la session de téléchargement"
-
-#: upload/views.py:238
-msgid "Cannot remove file from upload session"
-msgstr "Impossible de supprimer le fichier de la session de téléchargement"
-
-#: upload/views.py:246
+#: upload/views.py:224 upload/views.py:235 upload/views.py:245
+#: upload/views.py:292 upload/views.py:311 upload/views.py:322
+#: upload/views.py:330 upload/views.py:341
 msgid "The uploaded file could not be found"
+msgstr "Le fichier téléchargé est introuvable"
+
+#: upload/views.py:278
+#, fuzzy
+#| msgid "Invalid upload session token"
+msgid "Invalid upload session"
+msgstr "Identifiant de session de téléchargement invalide"
+
+#: upload/views.py:303
+#, fuzzy
+#| msgid "The uploaded file could not be found"
+msgid "The uploaded file could not be deleted"
 msgstr "Le fichier téléchargé est introuvable"
 
 #: utility/files.py:49 utility/files.py:68
@@ -5480,6 +5499,26 @@ msgctxt ""
 "a count like: '5 Video files'"
 msgid "%(file_count_1)s, and %(file_count_2)s"
 msgstr "%(file_count_1)s, et %(file_count_2)s"
+
+#~ msgid "Upload session token is required"
+#~ msgstr "L'identifiant de session de téléchargement est requis"
+
+#~ msgid "Direct access is not allowed."
+#~ msgstr "L'accès direct n'est pas autorisé."
+
+#~ msgid "Invalid filename or upload session token"
+#~ msgstr "Nom de fichier ou identifiant de session de téléchargement invalide"
+
+#~ msgid "Unable to scan file for malware due to scanner error"
+#~ msgstr ""
+#~ "Impossible d'analyser le fichier à la recherche de logiciels malveillants "
+#~ "en raison d'une erreur de lecture"
+
+#~ msgid "File not found in upload session"
+#~ msgstr "Fichier introuvable dans la session de téléchargement"
+
+#~ msgid "Cannot remove file from upload session"
+#~ msgstr "Impossible de supprimer le fichier de la session de téléchargement"
 
 #, python-format
 #~ msgid "[CAAIS %(section)s]"

--- a/app/locale/fr/LC_MESSAGES/djangojs.po
+++ b/app/locale/fr/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-20 19:45-0600\n"
+"POT-Creation-Date: 2026-06-02 11:59-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: French Team <fr@example.com>\n"
@@ -27,10 +27,10 @@ msgstr "Impossible d’ajouter le fichier en double '%s', il existe déjà"
 msgid "No description available"
 msgstr "Aucune description disponible"
 
-#: frontend/main/js/submission_form/uppyForm.js:157
+#: frontend/main/js/submission_form/uppyForm.js:160
 msgid "You must upload at least one file."
 msgstr "Vous devez télécharger au moins un fichier."
 
-#: frontend/main/js/submission_form/uppyForm.js:166
+#: frontend/main/js/submission_form/uppyForm.js:169
 msgid "Remove the files with issues to proceed."
 msgstr "Supprimez les fichiers présentant des problèmes pour continuer."

--- a/app/locale/hi/LC_MESSAGES/django.po
+++ b/app/locale/hi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 21:44-0500\n"
+"POT-Creation-Date: 2026-06-02 11:59-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: app/settings/base.py:144
+#: app/settings/base.py:186
 msgid "English"
 msgstr ""
 
-#: app/settings/base.py:145
+#: app/settings/base.py:187
 msgid "French"
 msgstr ""
 
-#: app/settings/base.py:146
+#: app/settings/base.py:188
 msgid "Hindi"
 msgstr ""
 
@@ -91,32 +91,32 @@ msgid "Record an identifier to uniquely identify this accession"
 msgstr ""
 
 #: caais/forms.py:171 caais/forms.py:208
-#: recordtransfer/forms/submission_forms.py:365
-#: recordtransfer/forms/submission_forms.py:402
+#: recordtransfer/forms/submission_forms.py:374
+#: recordtransfer/forms/submission_forms.py:411
 msgid "Invalid date format"
 msgstr ""
 
-#: caais/forms.py:190 recordtransfer/forms/submission_forms.py:384
+#: caais/forms.py:190 recordtransfer/forms/submission_forms.py:393
 msgid "Date cannot be in the future"
 msgstr ""
 
-#: caais/forms.py:192 recordtransfer/forms/submission_forms.py:386
+#: caais/forms.py:192 recordtransfer/forms/submission_forms.py:395
 msgid "End date cannot be in the future"
 msgstr ""
 
-#: caais/forms.py:198 recordtransfer/forms/submission_forms.py:392
+#: caais/forms.py:198 recordtransfer/forms/submission_forms.py:401
 msgid "Date cannot be before 1800"
 msgstr ""
 
-#: caais/forms.py:200 recordtransfer/forms/submission_forms.py:394
+#: caais/forms.py:200 recordtransfer/forms/submission_forms.py:403
 msgid "End date cannot be before 1800"
 msgstr ""
 
-#: caais/forms.py:210 recordtransfer/forms/submission_forms.py:404
+#: caais/forms.py:210 recordtransfer/forms/submission_forms.py:413
 msgid "Invalid date format for end date"
 msgstr ""
 
-#: caais/forms.py:220 recordtransfer/forms/submission_forms.py:414
+#: caais/forms.py:220 recordtransfer/forms/submission_forms.py:423
 msgid "End date must be later than start date"
 msgstr ""
 
@@ -125,24 +125,24 @@ msgstr ""
 msgid "'%(id)s' is a reserved Identifier type - please use another type name"
 msgstr ""
 
-#: caais/forms.py:365 recordtransfer/forms/mixins.py:17
-#: recordtransfer/forms/mixins.py:145
-#: recordtransfer/forms/submission_forms.py:186
-#: recordtransfer/forms/submission_forms.py:197
-#: recordtransfer/forms/submission_forms.py:212
-#: recordtransfer/forms/submission_forms.py:442
+#: caais/forms.py:365 recordtransfer/forms/mixins.py:35
+#: recordtransfer/forms/mixins.py:163
+#: recordtransfer/forms/submission_forms.py:195
+#: recordtransfer/forms/submission_forms.py:206
+#: recordtransfer/forms/submission_forms.py:221
+#: recordtransfer/forms/submission_forms.py:451
 msgid "This field is required."
 msgstr "यह फ़ील्ड आवश्यक है."
 
-#: caais/forms.py:366 recordtransfer/forms/mixins.py:18
+#: caais/forms.py:366 recordtransfer/forms/mixins.py:36
 msgid "Phone number must look like \"+1 (999) 999-9999\""
 msgstr ""
 
-#: caais/forms.py:374 caais/models.py:950 recordtransfer/forms/mixins.py:25
+#: caais/forms.py:374 caais/models.py:950 recordtransfer/forms/mixins.py:43
 msgid "Phone number"
 msgstr "फ़ोन नंबर"
 
-#: caais/forms.py:378 recordtransfer/forms/submission_forms.py:125
+#: caais/forms.py:378 recordtransfer/forms/submission_forms.py:134
 #: recordtransfer/forms/user_forms.py:36
 #: recordtransfer/templates/includes/account_info_form.html:12
 msgid "Email"
@@ -216,7 +216,7 @@ msgid ""
 "not it has yet been determined"
 msgstr ""
 
-#: caais/models.py:309 recordtransfer/forms/submission_forms.py:452
+#: caais/models.py:309 recordtransfer/forms/submission_forms.py:461
 msgid "Date of materials"
 msgstr "सामग्री की तिथि"
 
@@ -310,7 +310,7 @@ msgid "Source types"
 msgstr "स्रोत प्रकार"
 
 #: caais/models.py:759 caais/models.py:910
-#: recordtransfer/forms/submission_forms.py:260
+#: recordtransfer/forms/submission_forms.py:269
 msgid "Source type"
 msgstr "स्रोत प्रकार"
 
@@ -325,7 +325,7 @@ msgid "Source roles"
 msgstr "स्रोत भूमिकाएँ"
 
 #: caais/models.py:784 caais/models.py:1002
-#: recordtransfer/forms/submission_forms.py:297
+#: recordtransfer/forms/submission_forms.py:306
 msgid "Source role"
 msgstr "स्रोत भूमिका"
 
@@ -364,15 +364,15 @@ msgid ""
 "standard"
 msgstr ""
 
-#: caais/models.py:929 recordtransfer/forms/submission_forms.py:107
+#: caais/models.py:929 recordtransfer/forms/submission_forms.py:116
 msgid "Contact name"
 msgstr "संपर्क नाम"
 
-#: caais/models.py:936 recordtransfer/forms/submission_forms.py:114
+#: caais/models.py:936 recordtransfer/forms/submission_forms.py:123
 msgid "Job title"
 msgstr "पद का नाम"
 
-#: caais/models.py:943 recordtransfer/forms/submission_forms.py:121
+#: caais/models.py:943 recordtransfer/forms/submission_forms.py:130
 msgid "Organization"
 msgstr "संगठन"
 
@@ -380,15 +380,15 @@ msgstr "संगठन"
 msgid "Email address"
 msgstr ""
 
-#: caais/models.py:964 recordtransfer/forms/mixins.py:32
+#: caais/models.py:964 recordtransfer/forms/mixins.py:50
 msgid "Address line 1"
 msgstr "पता पंक्ति 1"
 
-#: caais/models.py:971 recordtransfer/forms/mixins.py:39
+#: caais/models.py:971 recordtransfer/forms/mixins.py:57
 msgid "Address line 2"
 msgstr "पता पंक्ति 2"
 
-#: caais/models.py:978 recordtransfer/forms/mixins.py:45
+#: caais/models.py:978 recordtransfer/forms/mixins.py:63
 #: recordtransfer/models.py:73
 msgid "City"
 msgstr "शहर"
@@ -401,7 +401,7 @@ msgstr ""
 msgid "Postal or zip code"
 msgstr ""
 
-#: caais/models.py:995 recordtransfer/forms/mixins.py:161
+#: caais/models.py:995 recordtransfer/forms/mixins.py:179
 msgid "Country"
 msgstr "देश"
 
@@ -793,41 +793,41 @@ msgstr ""
 msgid "No other details listed"
 msgstr ""
 
-#: recordtransfer/admin.py:218
+#: recordtransfer/admin.py:220
 msgid ""
 "The selected submission group(s) do not contain any submissions to export."
 msgstr ""
 
-#: recordtransfer/admin.py:229
+#: recordtransfer/admin.py:231
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export CAAIS 1.0 CSV for Submissions in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:239
+#: recordtransfer/admin.py:241
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export AtoM 2.6 Accession CSV for Submissions in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:249
+#: recordtransfer/admin.py:251
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export AtoM 2.3 Accession CSV for Submissions in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:259
+#: recordtransfer/admin.py:261
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export AtoM 2.2 Accession CSV for Submissions in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:269
+#: recordtransfer/admin.py:271
 msgctxt "\"Selected\" refers to one or more Submission Group objects."
 msgid "Export AtoM 2.1 Accession CSV for Submissions in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:388
+#: recordtransfer/admin.py:390
 msgid "Click link to view uploaded files"
 msgstr ""
 
-#: recordtransfer/admin.py:412
+#: recordtransfer/admin.py:414
 #, python-format
 msgid ""
 "A downloadable bag is being generated. Visit the %(link_start)sjobs "
@@ -835,119 +835,119 @@ msgid ""
 "Submission page for a download link"
 msgstr ""
 
-#: recordtransfer/admin.py:428
+#: recordtransfer/admin.py:430
 msgid ""
 "There are no files associated with this submission, it is not possible to "
 "create a Bag"
 msgstr ""
 
-#: recordtransfer/admin.py:437
+#: recordtransfer/admin.py:439
 #, python-format
 msgid "Submission with ID '%(id)s' doesn't exist. Perhaps it was deleted?"
 msgstr ""
 
-#: recordtransfer/admin.py:447
+#: recordtransfer/admin.py:449
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export CAAIS 1.0 CSV for Metadata in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:459
+#: recordtransfer/admin.py:461
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export AtoM 2.6 Accession CSV for Metadata in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:471
+#: recordtransfer/admin.py:473
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export AtoM 2.3 Accession CSV for Metadata in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:483
+#: recordtransfer/admin.py:485
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export AtoM 2.2 Accession CSV for Metadata in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:495
+#: recordtransfer/admin.py:497
 msgctxt "\"Selected\" refers to one or more Submission objects."
 msgid "Export AtoM 2.1 Accession CSV for Metadata in Selected"
 msgstr ""
 
-#: recordtransfer/admin.py:545 upload/admin.py:54
+#: recordtransfer/admin.py:547 upload/admin.py:54
 msgid "File Link"
 msgstr "फ़ाइल लिंक"
 
-#: recordtransfer/admin.py:551
+#: recordtransfer/admin.py:553
 msgid "No file attached"
 msgstr "कोई फ़ाइल अटैच नहीं है"
 
-#: recordtransfer/admin.py:578
+#: recordtransfer/admin.py:580
 #: recordtransfer/templates/includes/profile_forms.html:18
-#: recordtransfer/views/pre_submission.py:181
+#: recordtransfer/views/pre_submission.py:177
 msgid "Contact Information"
 msgstr ""
 
-#: recordtransfer/admin.py:593
+#: recordtransfer/admin.py:595
 msgid "Language Preferences"
 msgstr ""
 
-#: recordtransfer/admin.py:599
+#: recordtransfer/admin.py:601
 msgid "Email Updates"
 msgstr ""
 
-#: recordtransfer/admin.py:653 recordtransfer/views/account.py:324
+#: recordtransfer/admin.py:655 recordtransfer/views/account.py:324
 msgid "Password updated"
 msgstr "पासवर्ड अपडेट हो गया है"
 
-#: recordtransfer/admin.py:654 recordtransfer/views/account.py:325
+#: recordtransfer/admin.py:656 recordtransfer/views/account.py:325
 #: recordtransfer/views/account.py:366
 msgid "password"
 msgstr "कूटशब्द"
 
-#: recordtransfer/admin.py:655 recordtransfer/admin.py:685
+#: recordtransfer/admin.py:657 recordtransfer/admin.py:687
 #: recordtransfer/management/commands/send_test_email.py:178
 #: recordtransfer/views/account.py:326
 msgid "updated"
 msgstr ""
 
-#: recordtransfer/admin.py:666
+#: recordtransfer/admin.py:668
 msgid "Non-superusers cannot modify superuser accounts."
 msgstr ""
 
-#: recordtransfer/admin.py:677
+#: recordtransfer/admin.py:679
 msgid "Account Deactivated"
 msgstr ""
 
-#: recordtransfer/admin.py:678 recordtransfer/admin.py:684
+#: recordtransfer/admin.py:680 recordtransfer/admin.py:686
 #: recordtransfer/management/commands/send_test_email.py:177
 msgid "account"
 msgstr ""
 
-#: recordtransfer/admin.py:679
+#: recordtransfer/admin.py:681
 msgid "deactivated"
 msgstr ""
 
-#: recordtransfer/admin.py:683
+#: recordtransfer/admin.py:685
 #: recordtransfer/management/commands/send_test_email.py:176
 msgid "Account updated"
 msgstr "खाता अपडेट हो गया है"
 
-#: recordtransfer/admin.py:696
+#: recordtransfer/admin.py:698
 msgid "Superuser privileges have been added to your account."
 msgstr ""
 
-#: recordtransfer/admin.py:698
+#: recordtransfer/admin.py:700
 msgid "Superuser privileges have been removed from your account."
 msgstr ""
 
-#: recordtransfer/admin.py:701
+#: recordtransfer/admin.py:703
 #: recordtransfer/management/commands/send_test_email.py:179
 msgid "Staff privileges have been added to your account."
 msgstr ""
 
-#: recordtransfer/admin.py:703
+#: recordtransfer/admin.py:705
 msgid "Staff privileges have been removed from your account."
 msgstr ""
 
-#: recordtransfer/admin.py:760
+#: recordtransfer/admin.py:762
 #, python-format
 msgid "Setting \"%(key)s\" has been reset to its default value of %(value)s."
 msgstr ""
@@ -1308,388 +1308,387 @@ msgstr ""
 msgid "%(setting)s must be a valid email address."
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:31
+#: recordtransfer/forms/mixins.py:11
+msgid "HTML is not allowed in this field."
+msgstr ""
+
+#: recordtransfer/forms/mixins.py:49
 msgid "Street, and street number"
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:38
+#: recordtransfer/forms/mixins.py:56
 msgid "Unit Number, RPO, PO BOX... (optional)"
 msgstr "यूनिट संख्या, आरपीओ, पीओ बॉक्स... (वैकल्पिक)"
 
-#: recordtransfer/forms/mixins.py:56
+#: recordtransfer/forms/mixins.py:74
 msgid "Select your province"
 msgstr "अपना प्रांत चुनें"
 
-#: recordtransfer/forms/mixins.py:127 recordtransfer/models.py:79
+#: recordtransfer/forms/mixins.py:145 recordtransfer/models.py:79
 msgid "Province or state"
 msgstr "प्रांत या राज्य"
 
-#: recordtransfer/forms/mixins.py:139
+#: recordtransfer/forms/mixins.py:157
 msgid "Other province or state"
 msgstr "अन्य प्रांत या राज्य"
 
-#: recordtransfer/forms/mixins.py:147
+#: recordtransfer/forms/mixins.py:165
 msgid ""
 "Postal code must look like \"Z0Z 0Z0\", zip code must look like \"12345\" or "
 "\"12345-1234\""
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:156
+#: recordtransfer/forms/mixins.py:174
 msgid "Postal / Zip code"
 msgstr "डाक का / ज़िप कोड"
 
-#: recordtransfer/forms/mixins.py:159
+#: recordtransfer/forms/mixins.py:177
 msgid "Select your Country"
 msgstr "अपने देश का चयन करॊ"
 
-#: recordtransfer/forms/mixins.py:175
+#: recordtransfer/forms/mixins.py:193
 msgid "Address line 1 is required if address line 2 is provided."
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:181
+#: recordtransfer/forms/mixins.py:199
 msgid ""
 "You must select a province or state, use \"Other\" to enter a custom location"
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:187
+#: recordtransfer/forms/mixins.py:205
 msgid ""
 "This field must be filled out if \"Other\" province or state is selected"
 msgstr ""
 
-#: recordtransfer/forms/mixins.py:205
+#: recordtransfer/forms/mixins.py:223
 msgid "Please verify you are human"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:71
+#: recordtransfer/forms/submission_forms.py:80
 msgid "I accept these terms"
 msgstr "मैं इन शर्तों को स्वीकार करता/करती हूँ"
 
-#: recordtransfer/forms/submission_forms.py:201
+#: recordtransfer/forms/submission_forms.py:210
 msgid "If \"Source type\" is Other, enter your own source type"
 msgstr "यदि \"स्रोत प्रकार\" अन्य है, तो अपना स्वयं का स्रोत प्रकार दर्ज करें"
 
-#: recordtransfer/forms/submission_forms.py:216
+#: recordtransfer/forms/submission_forms.py:225
 msgid "If \"Source role\" is Other, enter your own source role"
 msgstr "यदि \"स्रोत भूमिका\" अन्य है, तो अपनी स्वयं की स्रोत भूमिका दर्ज करें"
 
-#: recordtransfer/forms/submission_forms.py:225
+#: recordtransfer/forms/submission_forms.py:234
 #: recordtransfer/templates/includes/delete_in_progress_submission_modal.html:21
 #: recordtransfer/templates/includes/delete_submission_group_modal.html:19
 #: recordtransfer/templates/recordtransfer/submission_form_review.html:64
 msgid "Yes"
 msgstr "हाँ"
 
-#: recordtransfer/forms/submission_forms.py:226
+#: recordtransfer/forms/submission_forms.py:235
 #: recordtransfer/templates/recordtransfer/submission_form_review.html:66
 msgid "No"
 msgstr "नहीं"
 
-#: recordtransfer/forms/submission_forms.py:231
+#: recordtransfer/forms/submission_forms.py:240
 msgid "Fill out this section?"
 msgstr "इस अनुभाग को भरें?"
 
-#: recordtransfer/forms/submission_forms.py:244
+#: recordtransfer/forms/submission_forms.py:253
 msgid "Name of source"
 msgstr "स्रोत का नाम"
 
-#: recordtransfer/forms/submission_forms.py:245
+#: recordtransfer/forms/submission_forms.py:254
 msgid "The organization or entity submitting the records"
 msgstr "रिकॉर्ड प्रस्तुत करने वाला संगठन या संस्था"
 
-#: recordtransfer/forms/submission_forms.py:259
-#: recordtransfer/forms/submission_forms.py:296
+#: recordtransfer/forms/submission_forms.py:268
+#: recordtransfer/forms/submission_forms.py:305
 msgid "Please select one"
 msgstr "कृपया एक का चयन करें"
 
-#: recordtransfer/forms/submission_forms.py:262
+#: recordtransfer/forms/submission_forms.py:271
 msgid ""
 "How would you describe <b>what</b> the source entity is? i.e., The source is "
 "a(n) ______"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:277
+#: recordtransfer/forms/submission_forms.py:286
 msgid "A source type not covered by the other choices"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:282
+#: recordtransfer/forms/submission_forms.py:291
 msgid "Other source type"
 msgstr "अन्य स्रोत प्रकार"
 
-#: recordtransfer/forms/submission_forms.py:298
+#: recordtransfer/forms/submission_forms.py:307
 msgid "How does the source relate to the records? "
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:311
+#: recordtransfer/forms/submission_forms.py:320
 msgid "A source role not covered by the other choices"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:316
+#: recordtransfer/forms/submission_forms.py:325
 msgid "Other source role"
 msgstr "अन्य स्रोत भूमिका"
 
-#: recordtransfer/forms/submission_forms.py:326
+#: recordtransfer/forms/submission_forms.py:335
 msgid ""
 "Enter any notes you think may be useful for the archives to have about this "
 "entity (optional)"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:331
+#: recordtransfer/forms/submission_forms.py:340
 msgid "Source notes"
 msgstr "स्रोत नोट्स"
 
-#: recordtransfer/forms/submission_forms.py:332
+#: recordtransfer/forms/submission_forms.py:341
 msgid "e.g., The donor wishes to remain anonymous"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:423
+#: recordtransfer/forms/submission_forms.py:432
 msgid "e.g., Committee Meeting Minutes"
 msgstr "उदाहरण: समिति की बैठक के कार्यवृत्त"
 
-#: recordtransfer/forms/submission_forms.py:424
+#: recordtransfer/forms/submission_forms.py:433
 msgid "Title"
 msgstr "शीर्षक"
 
-#: recordtransfer/forms/submission_forms.py:431
+#: recordtransfer/forms/submission_forms.py:440
 msgid "English, French"
 msgstr "अंग्रेज़ी, फ्रेंच"
 
-#: recordtransfer/forms/submission_forms.py:432
+#: recordtransfer/forms/submission_forms.py:441
 msgid "Enter all relevant languages here"
 msgstr "सभी प्रासंगिक भाषाएँ यहाँ दर्ज करें"
 
-#: recordtransfer/forms/submission_forms.py:433
+#: recordtransfer/forms/submission_forms.py:442
 msgid "Language(s)"
 msgstr "भाषा(एँ)"
 
-#: recordtransfer/forms/submission_forms.py:443
+#: recordtransfer/forms/submission_forms.py:452
 msgid "Date must be in the format YYYY-MM-DD or YYYY-MM-DD - YYYY-MM-DD"
 msgstr "दिनांक YYYY-MM-DD या YYYY-MM-DD - YYYY-MM-DD प्रारूप में होना चाहिए"
 
-#: recordtransfer/forms/submission_forms.py:447
+#: recordtransfer/forms/submission_forms.py:456
 msgid "2000-03-14 - 2001-05-06"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:454
+#: recordtransfer/forms/submission_forms.py:463
 msgid ""
 "Enter the range of dates that the materials cover, or a single date if there "
 "is no range."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:462
+#: recordtransfer/forms/submission_forms.py:471
 msgid "Date is approximated"
 msgstr "तिथि अनुमानित है"
 
-#: recordtransfer/forms/submission_forms.py:464
+#: recordtransfer/forms/submission_forms.py:473
 msgid ""
 "Check this box if the date is approximate, or if you are unsure of the date."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:473
+#: recordtransfer/forms/submission_forms.py:482
 msgid "e.g., These files contain images from ..."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:475
+#: recordtransfer/forms/submission_forms.py:484
 msgid "Description of contents"
 msgstr "विषय की व्याख्या"
 
-#: recordtransfer/forms/submission_forms.py:477
+#: recordtransfer/forms/submission_forms.py:486
 msgid ""
 "Briefly describe the content of the files you are submitting. What do the "
 "files contain?"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:489
+#: recordtransfer/forms/submission_forms.py:498
 msgid ""
 "Enter any information you have on the history of who has had custody of the "
 "records or who has kept the records in the past (optional)"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:495
+#: recordtransfer/forms/submission_forms.py:504
 msgid "Custodial history"
 msgstr "हिरासत का इतिहास"
 
-#: recordtransfer/forms/submission_forms.py:496
+#: recordtransfer/forms/submission_forms.py:505
 msgid "e.g., John Doe held these records before donating them in 1960"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:512
+#: recordtransfer/forms/submission_forms.py:521
 msgid ""
 "Record how many files and of what type they are that you are planning on "
 "submitting (optional)"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:517
+#: recordtransfer/forms/submission_forms.py:526
 msgid "For example, &quot;200 PDF documents, totalling 2.0GB&quot;"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:518
+#: recordtransfer/forms/submission_forms.py:527
 msgid "Quantity and type of files"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:554
+#: recordtransfer/forms/submission_forms.py:563
 msgid ""
 "If \"Other type of rights\" is empty, you must choose one of the Rights "
 "types here"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:560
+#: recordtransfer/forms/submission_forms.py:569
 msgid "If \"Type of rights\" is empty, you must enter a different type here"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:578
+#: recordtransfer/forms/submission_forms.py:587
 msgid "Type of rights"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:579
+#: recordtransfer/forms/submission_forms.py:588
 msgid "Select a rights type (optional)"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:587
+#: recordtransfer/forms/submission_forms.py:596
 msgid "Other type of rights not covered by other choices"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:591
+#: recordtransfer/forms/submission_forms.py:600
 msgid "For example: &quot;UK Human Rights Act 1998&quot;"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:592
+#: recordtransfer/forms/submission_forms.py:601
 msgid "Other type of rights"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:601
+#: recordtransfer/forms/submission_forms.py:610
 msgid "Any notes on these rights or which files they may apply to (optional)"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:606
+#: recordtransfer/forms/submission_forms.py:615
 msgid ""
 "For example: &quot;Copyright until 2050&quot;, &quot;Only applies to "
 "images&quot;, etc."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:608
+#: recordtransfer/forms/submission_forms.py:617
 msgid "Notes for rights"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:637
+#: recordtransfer/forms/submission_forms.py:646
 msgid "This identifier type is reserved and cannot be used"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:641
-#: recordtransfer/forms/submission_forms.py:646
+#: recordtransfer/forms/submission_forms.py:650
+#: recordtransfer/forms/submission_forms.py:655
 msgid "Must enter a value for this identifier"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:643
-#: recordtransfer/forms/submission_forms.py:645
+#: recordtransfer/forms/submission_forms.py:652
+#: recordtransfer/forms/submission_forms.py:654
 msgid "Must enter a type for this identifier"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:648
+#: recordtransfer/forms/submission_forms.py:657
 msgid "Cannot enter a note without entering a value and type"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:656
+#: recordtransfer/forms/submission_forms.py:665
 msgid "The type of the identifier"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:659
+#: recordtransfer/forms/submission_forms.py:668
 msgid ""
 "For example: &quot;Receipt number&quot;, &quot;LAC Record ID&quot;, etc."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:660
+#: recordtransfer/forms/submission_forms.py:669
 msgid "Type of identifier"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:667
-#: recordtransfer/forms/submission_forms.py:670
+#: recordtransfer/forms/submission_forms.py:676
+#: recordtransfer/forms/submission_forms.py:679
 msgid "Identifier value"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:679
+#: recordtransfer/forms/submission_forms.py:688
 msgid "Any notes on this identifier or which files it may apply to (optional)."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:683
+#: recordtransfer/forms/submission_forms.py:692
 msgid "Notes for identifier"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:708
+#: recordtransfer/forms/submission_forms.py:717
 msgid "Select a group"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:735
+#: recordtransfer/forms/submission_forms.py:744
 msgid "Assigned group"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:759
-#: recordtransfer/forms/submission_forms.py:824
+#: recordtransfer/forms/submission_forms.py:774
+#: recordtransfer/forms/submission_forms.py:822
 msgid "Record any general notes you have about the records here (optional)"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:764
-#: recordtransfer/forms/submission_forms.py:829
+#: recordtransfer/forms/submission_forms.py:779
+#: recordtransfer/forms/submission_forms.py:827
 msgid ""
 "These should be notes that did not fit in any of the previous steps of this "
 "form"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:766
-#: recordtransfer/forms/submission_forms.py:831
+#: recordtransfer/forms/submission_forms.py:781
+#: recordtransfer/forms/submission_forms.py:829
 msgid "Other notes"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:773
-msgid "Upload session token is required"
-msgstr ""
-
-#: recordtransfer/forms/submission_forms.py:784
-#: recordtransfer/forms/submission_forms.py:793
+#: recordtransfer/forms/submission_forms.py:791
 msgid "Invalid upload session state. Please try again."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:797
+#: recordtransfer/forms/submission_forms.py:795
 msgid "You must upload at least one file"
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:914
+#: recordtransfer/forms/submission_forms.py:908
 msgid "No identifiers were provided."
 msgstr ""
 
-#: recordtransfer/forms/submission_forms.py:916
+#: recordtransfer/forms/submission_forms.py:910
 msgid "No record rights or restrictions were provided."
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:19
+#: recordtransfer/forms/submission_group_form.py:20
 #: recordtransfer/templates/includes/submission_group_table.html:4
 #: recordtransfer/views/profile.py:173
 msgid "Group Name"
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:26
+#: recordtransfer/forms/submission_group_form.py:27
 msgid "Enter group description"
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:31
+#: recordtransfer/forms/submission_group_form.py:32
 #: recordtransfer/templates/includes/submission_group_table.html:5
 #: recordtransfer/templates/recordtransfer/submission_form_groupsubmission.html:31
 #: recordtransfer/views/profile.py:174
 msgid "Group Description"
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:49
+#: recordtransfer/forms/submission_group_form.py:50
 msgid "Form is empty."
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:58
+#: recordtransfer/forms/submission_group_form.py:60
 msgid "Required"
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:72
+#: recordtransfer/forms/submission_group_form.py:74
 msgid "You have already created a group with this name."
 msgstr ""
 
-#: recordtransfer/forms/submission_group_form.py:78
+#: recordtransfer/forms/submission_group_form.py:80
 msgid "No changes detected."
 msgstr ""
 
@@ -2099,7 +2098,7 @@ msgstr ""
 
 #: recordtransfer/templates/includes/open_session_table.html:30
 #: recordtransfer/templates/includes/submission_table.html:24
-#: upload/admin.py:51 upload/admin.py:258 upload/admin.py:268
+#: upload/admin.py:51 upload/admin.py:259 upload/admin.py:269
 msgid "N/A"
 msgstr ""
 
@@ -2163,7 +2162,7 @@ msgid "Language"
 msgstr ""
 
 #: recordtransfer/templates/includes/save_contact_info_modal.html:9
-#: recordtransfer/views/pre_submission.py:624
+#: recordtransfer/views/pre_submission.py:620
 msgid "Would you like to save your contact information to your profile?"
 msgstr ""
 
@@ -3660,7 +3659,7 @@ msgid "Next"
 msgstr ""
 
 #: recordtransfer/templates/recordtransfer/submission_form_base.html:112
-#: recordtransfer/views/pre_submission.py:269
+#: recordtransfer/views/pre_submission.py:265
 msgid "Review"
 msgstr ""
 
@@ -4017,7 +4016,7 @@ msgstr ""
 
 #: recordtransfer/tests/unit/views/test_profile.py:146
 #: recordtransfer/tests/unit/views/test_profile.py:241
-#: recordtransfer/views/pre_submission.py:532
+#: recordtransfer/views/pre_submission.py:528
 #: recordtransfer/views/profile.py:115
 msgid "Please correct the errors below."
 msgstr ""
@@ -4092,75 +4091,71 @@ msgstr ""
 msgid "File not found for this job"
 msgstr ""
 
-#: recordtransfer/views/post_submission.py:80
+#: recordtransfer/views/post_submission.py:79
 msgid "Submission not found"
 msgstr ""
 
-#: recordtransfer/views/post_submission.py:110
+#: recordtransfer/views/post_submission.py:109
 msgid "Submission group not found"
 msgstr ""
 
-#: recordtransfer/views/post_submission.py:132
+#: recordtransfer/views/post_submission.py:131
 msgid "This submission group has no submissions associated with it to export."
 msgstr ""
 
-#: recordtransfer/views/post_submission.py:199
+#: recordtransfer/views/post_submission.py:198
 msgid "Group updated"
 msgstr ""
 
-#: recordtransfer/views/post_submission.py:210
+#: recordtransfer/views/post_submission.py:209
 msgid "There was an error updating the group"
 msgstr ""
 
-#: recordtransfer/views/post_submission.py:219
-msgid "Direct access is not allowed."
-msgstr ""
-
-#: recordtransfer/views/pre_submission.py:99
+#: recordtransfer/views/pre_submission.py:95
 msgid "Date Last Changed"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:100
+#: recordtransfer/views/pre_submission.py:96
 msgid "Date Started"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:101
+#: recordtransfer/views/pre_submission.py:97
 msgid "Files Uploaded"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:176
+#: recordtransfer/views/pre_submission.py:172
 msgid "Legal Agreement"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:184
+#: recordtransfer/views/pre_submission.py:180
 msgid ""
 "Enter your contact information in case you need to be contacted by one of "
 "our archivists regarding your submission"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:190
+#: recordtransfer/views/pre_submission.py:186
 msgid "Record Source Information (Optional)"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:193
+#: recordtransfer/views/pre_submission.py:189
 msgid ""
 "Are you submitting records on behalf of another person or organization? "
 "Select Yes to enter information about them."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:198
+#: recordtransfer/views/pre_submission.py:194
 msgid "Record Description"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:202
+#: recordtransfer/views/pre_submission.py:198
 msgid "Provide a brief description of the records you're submitting"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:206
+#: recordtransfer/views/pre_submission.py:202
 msgid "Record Rights and Restrictions (Optional)"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:210
+#: recordtransfer/views/pre_submission.py:206
 #, python-format
 msgid ""
 "Depending on the records you are submitting, there may be specific rights "
@@ -4169,11 +4164,11 @@ msgid ""
 "explanations."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:225
+#: recordtransfer/views/pre_submission.py:221
 msgid "Identifiers (Optional)"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:232
+#: recordtransfer/views/pre_submission.py:228
 msgid ""
 "If you have any identifiers associated with these records, such as reference "
 "numbers, codes, or other unique IDs, you may enter them here. <b> This step "
@@ -4181,78 +4176,78 @@ msgid ""
 "records, you may proceed to the next step."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:238
+#: recordtransfer/views/pre_submission.py:234
 msgid "Assign Submission to Group (Optional)"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:241
+#: recordtransfer/views/pre_submission.py:237
 msgid ""
 "You may assign this submission to a group to keep your records organized. "
 "<b>This step is optional</b>. If you do not wish to assign a group, you can "
 "proceed to the next step."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:250
+#: recordtransfer/views/pre_submission.py:246
 msgid "Upload Files"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:253
+#: recordtransfer/views/pre_submission.py:249
 msgid "Add any final notes you would like to add, and upload your files"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:261
+#: recordtransfer/views/pre_submission.py:257
 msgid "Final Notes"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:263
+#: recordtransfer/views/pre_submission.py:259
 msgid "Add any final notes that may not have fit in previous steps"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:271
+#: recordtransfer/views/pre_submission.py:267
 msgid "Review the information you've entered before submitting"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:293
+#: recordtransfer/views/pre_submission.py:289
 msgid "Invalid step name"
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:340
+#: recordtransfer/views/pre_submission.py:336
 msgid ""
 "Can't load this in-progress submission because it will put you over the "
 "maximum concurrent session limit."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:350
+#: recordtransfer/views/pre_submission.py:346
 msgid ""
 "Can't create a new submission because it will put you over the maximum "
 "concurrent session limit."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:401
-#: recordtransfer/views/pre_submission.py:595
+#: recordtransfer/views/pre_submission.py:397
+#: recordtransfer/views/pre_submission.py:591
 #, python-format
 msgid ""
 "Your submission was saved, but you have reached your session limit. Go to "
 "%(link_start)syour profile%(link_end)s to see your saved submissions."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:416
+#: recordtransfer/views/pre_submission.py:412
 msgid "Submission saved successfully."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:435
+#: recordtransfer/views/pre_submission.py:431
 #, python-format
 msgid ""
 "This submission will expire on %(date)s. Please be sure to complete your "
 "submission before then."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:447
-#: recordtransfer/views/pre_submission.py:611
+#: recordtransfer/views/pre_submission.py:443
+#: recordtransfer/views/pre_submission.py:607
 msgid "There was an error saving the submission."
 msgstr ""
 
-#: recordtransfer/views/pre_submission.py:1022
+#: recordtransfer/views/pre_submission.py:1044
 msgid ""
 "There was an error creating your submission. Please try again later or "
 "contact us for assistance."
@@ -4387,7 +4382,7 @@ msgid ""
 "Please try again later. Contact us if you continue to experience issues."
 msgstr ""
 
-#: upload/admin.py:47 upload/admin.py:261
+#: upload/admin.py:47 upload/admin.py:262
 msgid "Upload Size"
 msgstr "अपलोड आकार"
 
@@ -4395,7 +4390,7 @@ msgstr "अपलोड आकार"
 msgid "File was removed"
 msgstr "फाइल हटा दी गई थी"
 
-#: upload/admin.py:271
+#: upload/admin.py:272
 msgid "Last upload at"
 msgstr ""
 
@@ -4577,47 +4572,47 @@ msgid ""
 "%(max_size_mb)sMB"
 msgstr ""
 
-#: upload/models.py:61
+#: upload/models.py:62
 msgid "Session Created"
 msgstr ""
 
-#: upload/models.py:62
+#: upload/models.py:63
 msgid "Session Expired"
 msgstr ""
 
-#: upload/models.py:63
+#: upload/models.py:64
 msgid "Uploading Files"
 msgstr ""
 
-#: upload/models.py:64
+#: upload/models.py:65
 msgid "File Copy in Progress"
 msgstr ""
 
-#: upload/models.py:65
+#: upload/models.py:66
 msgid "All Files in Permanent Storage"
 msgstr ""
 
-#: upload/models.py:66
+#: upload/models.py:67
 msgid "Copying Failed"
 msgstr ""
 
-#: upload/models.py:67
+#: upload/models.py:68
 msgid "File Removal in Progress"
 msgstr ""
 
-#: upload/models.py:553
+#: upload/models.py:554
 #, python-format
 msgid "%(file_count)s, totalling %(total_size)s"
 msgstr ""
 
-#: upload/models.py:566
+#: upload/models.py:567
 #, python-format
 msgid "Session %(token)s (%(count)s file, started: %(date)s)"
 msgid_plural "Session %(token)s (%(count)s files, started: %(date)s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: upload/models.py:577
+#: upload/models.py:578
 #, python-format
 msgid "%(token)s (started at %(date)s)"
 msgstr ""
@@ -4627,50 +4622,58 @@ msgstr ""
 msgid "%(name)s Removed! | %(session)s"
 msgstr ""
 
-#: upload/tests/unit/test_views.py:437 upload/views.py:225
-msgid "Invalid filename or upload session token"
+#: upload/views.py:91
+msgid "Invalid or expired upload session"
 msgstr ""
 
-#: upload/views.py:50
-msgid "Invalid upload session token"
-msgstr ""
-
-#: upload/views.py:64
+#: upload/views.py:104
 msgid "There was an internal server error. Please try again."
 msgstr ""
 
-#: upload/views.py:84
+#: upload/views.py:123
 msgid "No file was uploaded"
 msgstr ""
 
-#: upload/views.py:112
-#, python-format
-msgid "Malware was detected in the file \"%(name)s\""
+#: upload/views.py:131
+msgid "The file was not accepted"
 msgstr ""
 
-#: upload/views.py:124
-#, python-format
-msgid "File \"%(name)s\" is too large to scan for malware"
+#: upload/views.py:141
+msgid "The file was not accepted in session"
 msgstr ""
 
-#: upload/views.py:136
-msgid "Unable to scan file for malware due to scanner error"
+#: upload/views.py:153
+msgid "Malware was detected in the file"
 msgstr ""
 
-#: upload/views.py:150
-msgid "There was an error uploading the file"
+#: upload/views.py:161
+msgid "The file was too large to be scanned for malware"
 msgstr ""
 
-#: upload/views.py:233
-msgid "File not found in upload session"
+#: upload/views.py:169
+msgid "There was an error while scanning the file. Please try again later."
 msgstr ""
 
-#: upload/views.py:238
-msgid "Cannot remove file from upload session"
+#: upload/views.py:180
+msgid "There was an error processing the file. Please try again later."
 msgstr ""
 
-#: upload/views.py:246
+#: upload/views.py:191
+msgid "There was an error uploading the file. Please try again later."
+msgstr ""
+
+#: upload/views.py:224 upload/views.py:235 upload/views.py:245
+#: upload/views.py:292 upload/views.py:311 upload/views.py:322
+#: upload/views.py:330 upload/views.py:341
 msgid "The uploaded file could not be found"
+msgstr ""
+
+#: upload/views.py:278
+msgid "Invalid upload session"
+msgstr ""
+
+#: upload/views.py:303
+msgid "The uploaded file could not be deleted"
 msgstr ""
 
 #: utility/files.py:49 utility/files.py:68

--- a/app/locale/hi/LC_MESSAGES/djangojs.po
+++ b/app/locale/hi/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-20 19:45-0600\n"
+"POT-Creation-Date: 2026-06-02 11:59-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,10 +27,10 @@ msgstr "डुप्लिकेट फ़ाइल '%s' को नहीं ज
 msgid "No description available"
 msgstr "कोई विवरण उपलब्ध नहीं है"
 
-#: frontend/main/js/submission_form/uppyForm.js:157
+#: frontend/main/js/submission_form/uppyForm.js:160
 msgid "You must upload at least one file."
 msgstr "आपको कम से कम एक फ़ाइल अपलोड करनी होगी"
 
-#: frontend/main/js/submission_form/uppyForm.js:166
+#: frontend/main/js/submission_form/uppyForm.js:169
 msgid "Remove the files with issues to proceed."
 msgstr "आगे बढ़ने के लिए समस्या वाली फ़ाइलें हटाएँ."

--- a/app/recordtransfer/forms/submission_forms.py
+++ b/app/recordtransfer/forms/submission_forms.py
@@ -15,7 +15,6 @@ from django.conf import settings
 from django.db.models import Case, CharField, Value, When
 from django.forms import BaseForm, BaseFormSet
 from django.utils.translation import gettext_lazy as _
-from upload.models import UploadSession
 
 from recordtransfer.constants import (
     HtmlIds,
@@ -747,7 +746,10 @@ class GroupSubmissionForm(SubmissionForm):
 
 
 class UploadFilesForm(SubmissionForm):
-    """The form where users upload their files and write any final notes."""
+    """The form where users upload their files and write any final notes.
+
+    The upload session is supplied by the view.
+    """
 
     class Meta:
         """Meta information for the form."""
@@ -756,7 +758,10 @@ class UploadFilesForm(SubmissionForm):
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user", None)
-        self.correct_session_token = kwargs.pop("correct_session_token", None)
+        # The view is responsible for resolving the active UploadSession and
+        # passing it in. May be None during construction; clean() will surface
+        # an error in that case.
+        self.upload_session = kwargs.pop("upload_session", None)
         super().__init__(*args, **kwargs)
 
     general_note = forms.CharField(
@@ -776,39 +781,22 @@ class UploadFilesForm(SubmissionForm):
         label=_("Other notes"),
     )
 
-    session_token = forms.CharField(
-        required=True,
-        widget=forms.HiddenInput(),
-        label="hidden",
-        error_messages={"required": _("Upload session token is required")},
-    )
-
     def clean(self) -> dict:
-        """Check that the session token is valid and that at least one file has been uploaded."""
+        """Check that the upload session is valid and that at least one file was uploaded."""
         cleaned_data = super().clean()
-        token = cleaned_data.get("session_token")
 
-        upload_session = UploadSession.objects.filter(token=token, user=self.user).first()
-
-        if not upload_session:
-            self.add_error("session_token", _("Invalid upload session state. Please try again."))
+        if not self.upload_session or self.upload_session.user_id != getattr(
+            self.user, "id", None
+        ):
+            self.add_error(None, _("Invalid upload session state. Please try again."))
             return cleaned_data
 
-        if upload_session.token != self.correct_session_token:
-            LOGGER.warning(
-                "**SUSPICIOUS OPERATION**: hidden session_token input was changed by %s in the "
-                "upload files form",
-                self.user.username if self.user else "unknown user",
-            )
-            self.add_error("session_token", _("Invalid upload session state. Please try again."))
-            return cleaned_data
-
-        if upload_session.file_count == 0:
-            self.add_error("session_token", _("You must upload at least one file"))
+        if self.upload_session.file_count == 0:
+            self.add_error(None, _("You must upload at least one file"))
             return cleaned_data
 
         cleaned_data["quantity_and_unit_of_measure"] = (
-            upload_session.get_quantity_and_unit_of_measure()
+            self.upload_session.get_quantity_and_unit_of_measure()
         )
 
         return cleaned_data
@@ -865,13 +853,9 @@ class ReviewForm(SubmissionForm):
     def _get_file_upload_fields_data(form: UploadFilesForm, user: User) -> dict[str, Any]:
         """Handle file upload specific field processing."""
         fields_data = ReviewForm._get_base_fields_data(form)
-        session_token = form.cleaned_data.get("session_token")
+        session = form.upload_session
 
-        if not (session_token and user):
-            return fields_data
-
-        session = UploadSession.objects.filter(token=session_token, user=user).first()
-        if not session:
+        if not session or not user or session.user_id != user.id:
             return fields_data
 
         # Adds on links to access uploaded files

--- a/app/recordtransfer/tests/unit/test_forms.py
+++ b/app/recordtransfer/tests/unit/test_forms.py
@@ -1004,12 +1004,11 @@ class UploadFilesFormTest(TestCase):
 
     def test_form_valid(self) -> None:
         """Case where the form is valid."""
-        form_data = {
-            "session_token": self.upload_session.token,
-            "general_note": "Some general note",
-        }
+        form_data = {"general_note": "Some general note"}
         form = UploadFilesForm(
-            data=form_data, user=self.user, correct_session_token=self.upload_session.token
+            data=form_data,
+            user=self.user,
+            upload_session=self.upload_session,
         )
         self.assertTrue(form.is_valid())
         self.assertEqual(
@@ -1017,72 +1016,52 @@ class UploadFilesFormTest(TestCase):
             self.upload_session.get_quantity_and_unit_of_measure(),
         )
 
-    def test_form_missing_session_token(self) -> None:
-        """Case where the session token is missing."""
-        form_data = {
-            "general_note": "Some general note",
-        }
+    def test_form_valid_no_note(self) -> None:
+        """Case where the form is valid and no general note is given."""
         form = UploadFilesForm(
-            data=form_data, user=self.user, correct_session_token=self.upload_session.token
+            data={},
+            user=self.user,
+            upload_session=self.upload_session,
         )
-        self.assertFalse(form.is_valid())
-        self.assertIn("session_token", form.errors)
+        self.assertTrue(form.is_valid())
 
-    def test_form_invalid_session_token(self) -> None:
-        """Case where the session token is invalid."""
-        form_data = {
-            "session_token": "invalidtoken",
-            "general_note": "Some general note",
-        }
+    def test_form_missing_session(self) -> None:
+        """Case where the session is missing."""
+        form_data = {"general_note": "Some general note"}
         form = UploadFilesForm(
-            data=form_data, user=self.user, correct_session_token=self.upload_session.token
+            data=form_data,
+            user=self.user,
+            upload_session=None,
         )
         self.assertFalse(form.is_valid())
-        self.assertIn("session_token", form.errors)
+
+    def test_form_incorrect_session(self) -> None:
+        """Case where the session is for the wrong user."""
+        other_user = User.objects.create_user(
+            username="otheruser",
+            password="seW5I$ttW#",
+        )
+
+        other_session = UploadSession.new_session(user=other_user)
+
+        form_data = {"general_note": "Some general note"}
+        form = UploadFilesForm(
+            data=form_data,
+            user=self.user,
+            upload_session=other_session,
+        )
+        self.assertFalse(form.is_valid())
 
     def test_form_no_files_uploaded(self) -> None:
         """Case where no files have been uploaded."""
         self.upload_session.remove_temp_file_by_name("test_file.txt")
-
-        form_data = {
-            "session_token": self.upload_session.token,
-            "general_note": "Some general note",
-        }
+        form_data = {"general_note": "Some general note"}
         form = UploadFilesForm(
-            data=form_data, user=self.user, correct_session_token=self.upload_session.token
+            data=form_data,
+            user=self.user,
+            upload_session=self.upload_session,
         )
         self.assertFalse(form.is_valid())
-        self.assertIn("session_token", form.errors)
-
-    def test_form_tampered_session_token_different_user(self) -> None:
-        """Test case where another user's session token is sent in the form data."""
-        # Create another session by a different user
-        other_user = User.objects.create_user(username="altuser", password="#SP@4JEzf#")
-        other_session = UploadSession.new_session(user=other_user)
-        other_session.add_temp_file(SimpleUploadedFile("test.jpg", bytearray([1] * 64)))
-
-        form_data = {"session_token": other_session.token}
-        form = UploadFilesForm(
-            data=form_data, user=self.user, correct_session_token=self.upload_session.token
-        )
-
-        self.assertFalse(form.is_valid())
-        self.assertIn("session_token", form.errors)
-
-    def test_form_tampered_session_token_same_user(self) -> None:
-        """Test case where a different session token of the same user is sent in the form data."""
-        # Create another session by the same user
-        other_session = UploadSession.new_session(user=self.user)
-        other_session.add_temp_file(SimpleUploadedFile("test.jpg", bytearray([1] * 64)))
-
-        form_data = {"session_token": other_session.token}
-
-        form = UploadFilesForm(
-            data=form_data, user=self.user, correct_session_token=self.upload_session.token
-        )
-
-        self.assertFalse(form.is_valid())
-        self.assertIn("session_token", form.errors)
 
 
 class SubmissionGroupFormTest(TestCase):

--- a/app/recordtransfer/tests/unit/views/test_pre_submission.py
+++ b/app/recordtransfer/tests/unit/views/test_pre_submission.py
@@ -1,17 +1,33 @@
+import time
 from typing import cast
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from caais.models import RightsType, SourceRole, SourceType
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import HttpResponse
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import Client, RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
+from upload.handles import SESSION_KEY
 from upload.models import UploadSession
 
 from recordtransfer.constants import QueryParameters
 from recordtransfer.enums import SubmissionStep
 from recordtransfer.models import InProgressSubmission, SubmissionGroup, User
+
+
+def _set_handle(
+    client: Client,
+    handle: str,
+    upload_session: UploadSession,
+    ts: float | None = None,
+) -> None:
+    """Inject a handle -> upload_session mapping into the test client's session."""
+    session = client.session
+    handles = session.get(SESSION_KEY, {})
+    handles[handle] = {"sid": upload_session.pk, "ts": ts if ts is not None else time.time()}
+    session[SESSION_KEY] = handles
+    session.save()
 
 
 class OpenSessionsTests(TestCase):
@@ -256,6 +272,8 @@ class SubmissionFormWizardTests(TestCase):
             started_at=timezone.now(),
             user=self.user,
         )
+        self.handle = "abcdabcd" * 4
+        _set_handle(self.client, self.handle, self.session)
 
         self.test_data = [
             (SubmissionStep.ACCEPT_LEGAL.value, {"agreement_accepted": "on"}),
@@ -342,10 +360,11 @@ class SubmissionFormWizardTests(TestCase):
         return super().tearDown()
 
     def _upload_test_file(self) -> None:
-        """Upload a test file to the server using the provided session token."""
+        """Upload a test file to the server using the provided upload handle."""
         response = self.client.post(
-            reverse("upload:upload_files", kwargs={"session_token": "1234567890abcdef"}),
+            reverse("upload:upload_files"),
             {"file": SimpleUploadedFile("test_file.txt", b"contents", content_type="text/plain")},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
         )
         self.assertEqual(200, response.status_code)
 

--- a/app/recordtransfer/views/pre_submission.py
+++ b/app/recordtransfer/views/pre_submission.py
@@ -35,6 +35,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 from django_htmx.http import HttpResponseClientRedirect, trigger_client_event
 from formtools.wizard.views import SessionWizardView
+from upload.handles import register_handle
 from utility import is_deployed_environment
 
 from recordtransfer import forms
@@ -744,9 +745,6 @@ class SubmissionFormWizard(SessionWizardView):
             initial["postal_or_zip_code"] = user.postal_or_zip_code or ""
             initial["country"] = user.country or ""
 
-        if SubmissionStep(step) == SubmissionStep.UPLOAD_FILES:
-            initial["session_token"] = self.storage.extra_data.get("session_token", "")
-
         return initial
 
     def get_form_kwargs(self, step: Optional[str] = None) -> dict:
@@ -758,7 +756,13 @@ class SubmissionFormWizard(SessionWizardView):
 
         elif step == SubmissionStep.UPLOAD_FILES.value:
             kwargs["user"] = self.request.user
-            kwargs["correct_session_token"] = self.storage.extra_data["session_token"]
+            # The active upload session is resolved server-side from the
+            # wizard's stored token; the form itself sees only the resolved
+            # UploadSession instance, not a client-supplied identifier.
+            kwargs["upload_session"] = UploadSession.objects.filter(
+                token=self.storage.extra_data.get("session_token"),
+                user=self.request.user,
+            ).first()
 
         elif step == SubmissionStep.SOURCE_INFO.value:
             source_type, _ = SourceType.objects.get_or_create(name="Individual")
@@ -946,9 +950,22 @@ class SubmissionFormWizard(SessionWizardView):
                 },
             )
         elif step == SubmissionStep.UPLOAD_FILES:
+            session_token = self.storage.extra_data.get("session_token", "")
+            upload_handle = ""
+
+            # Create a fresh upload handle for this session to send to the user
+            if session_token:
+                upload_session = UploadSession.objects.filter(
+                    token=session_token, user=self.request.user
+                ).first()
+                if upload_session:
+                    upload_handle = register_handle(self.request, upload_session)
+
             js_context.update(
                 {
-                    "SESSION_TOKEN": self.storage.extra_data.get("session_token", ""),
+                    # UPLOAD_HANDLE is the opaque per-wizard identifier the frontend sends in the
+                    # X-Upload-Handle header.
+                    "UPLOAD_HANDLE": upload_handle,
                     "MAX_TOTAL_UPLOAD_SIZE_MB": settings.MAX_TOTAL_UPLOAD_SIZE_MB,
                     "MAX_SINGLE_UPLOAD_SIZE_MB": settings.MAX_SINGLE_UPLOAD_SIZE_MB,
                     "MAX_TOTAL_UPLOAD_COUNT": settings.MAX_TOTAL_UPLOAD_COUNT,

--- a/app/recordtransfer/views/pre_submission.py
+++ b/app/recordtransfer/views/pre_submission.py
@@ -796,6 +796,28 @@ class SubmissionFormWizard(SessionWizardView):
             )
         return final_forms
 
+    def get_upload_handle(self) -> str | None:
+        """Get a handle to enable uploading files.
+
+        The front-end should send the X-Upload-Handle header to this handle to be able to upload
+        files.
+        """
+        session_token = self.storage.extra_data.get("session_token", "")
+
+        # Create a fresh upload handle for this session to send to the user
+        if not session_token:
+            return None
+
+        upload_session = UploadSession.objects.filter(
+            token=session_token,
+            user=self.request.user,
+        ).first()
+
+        if not upload_session:
+            return None
+
+        return register_handle(self.request, upload_session)
+
     @property
     def review_step_reached(self) -> bool:
         """Check if the user has reached the review step at some point throughout this form. This
@@ -950,22 +972,11 @@ class SubmissionFormWizard(SessionWizardView):
                 },
             )
         elif step == SubmissionStep.UPLOAD_FILES:
-            session_token = self.storage.extra_data.get("session_token", "")
-            upload_handle = ""
-
-            # Create a fresh upload handle for this session to send to the user
-            if session_token:
-                upload_session = UploadSession.objects.filter(
-                    token=session_token, user=self.request.user
-                ).first()
-                if upload_session:
-                    upload_handle = register_handle(self.request, upload_session)
-
             js_context.update(
                 {
                     # UPLOAD_HANDLE is the opaque per-wizard identifier the frontend sends in the
                     # X-Upload-Handle header.
-                    "UPLOAD_HANDLE": upload_handle,
+                    "UPLOAD_HANDLE": self.get_upload_handle() or "",
                     "MAX_TOTAL_UPLOAD_SIZE_MB": settings.MAX_TOTAL_UPLOAD_SIZE_MB,
                     "MAX_SINGLE_UPLOAD_SIZE_MB": settings.MAX_SINGLE_UPLOAD_SIZE_MB,
                     "MAX_TOTAL_UPLOAD_COUNT": settings.MAX_TOTAL_UPLOAD_COUNT,

--- a/app/upload/admin.py
+++ b/app/upload/admin.py
@@ -105,6 +105,7 @@ class UploadedFileAdmin(BaseUploadedFileAdmin):
 
     fields: Sequence[str | Sequence[str]] = [
         "id",
+        "uuid",
         "name",
         "formatted_upload_size",
         "exists",

--- a/app/upload/handles.py
+++ b/app/upload/handles.py
@@ -1,0 +1,113 @@
+"""Opaque per-wizard upload handles.
+
+This module provides a small server-side mapping between opaque handles and :class:`UploadSession`
+instances. The mapping is stored in the authenticated user's Django session.
+
+This allows the frontend to refer to an active upload session by an opaque handle without ever
+seeing the underlying :attr:`UploadSession.token`. The security model is analogous to Django's CSRF
+token: an opaque value the client echoes back, validated against per-session server state.
+"""
+
+import time
+from typing import Optional
+from uuid import uuid4
+
+from django.http import HttpRequest
+
+from .models import UploadSession
+
+SESSION_KEY = "upload_handles"
+
+#: How long a handle remains valid without being re-registered or resolved.
+#: One hour by default — long enough for normal upload flows, short enough that
+#: a leaked handle becomes useless quickly.
+HANDLE_TTL_SECONDS = 60 * 60
+
+
+def _get_handles_for_session(request: HttpRequest) -> dict[str, dict]:
+    """Return the available handles for the given request's session."""
+    return request.session.get(SESSION_KEY, {})
+
+
+def _prune_expired(handles: dict[str, dict], now: float) -> dict[str, dict]:
+    """Drop any entries whose timestamp is older than the TTL."""
+    return {h: entry for h, entry in handles.items() if now - entry["ts"] <= HANDLE_TTL_SECONDS}
+
+
+def _save_handles_for_session(request: HttpRequest, handles: dict[str, dict]) -> None:
+    """Save the given handles to the request's session."""
+    request.session[SESSION_KEY] = handles
+    request.session.modified = True
+
+
+def register_handle(request: HttpRequest, upload_session: UploadSession) -> str:
+    """Register an upload session against an opaque handle in the user's session.
+
+    If a (non-expired) handle already exists for this upload session, that handle is returned and
+    its timestamp is refreshed. Otherwise, a fresh handle is generated.
+
+    Expired entries are pruned opportunistically.
+
+    Args:
+        request: The incoming HTTP request whose ``request.session`` will store the handle mapping.
+        upload_session: The upload session to register.
+
+    Returns:
+        The opaque handle string that should be sent to the client.
+    """
+    now = time.time()
+    handles = _prune_expired(_get_handles_for_session(request), now)
+
+    for existing_handle, entry in handles.items():
+        if entry["sid"] == upload_session.pk:
+            entry["ts"] = now
+            _save_handles_for_session(request, handles)
+            return existing_handle
+
+    handle = uuid4().hex
+    handles[handle] = {"sid": upload_session.pk, "ts": now}
+    _save_handles_for_session(request, handles)
+    return handle
+
+
+def resolve_handle(request: HttpRequest, handle: str) -> Optional[UploadSession]:
+    """Resolve a handle back to an :class:`UploadSession`.
+
+    The lookup is constrained to upload sessions owned by the authenticated user, so even if a
+    handle is leaked across users it cannot be used to access another user's session. The handle's
+    timestamp is refreshed on every successful resolution so active uploads keep it alive.
+
+    Args:
+        request: The incoming HTTP request.
+        handle: The opaque handle previously returned by :func:`register_handle`.
+
+    Returns:
+        The matching :class:`UploadSession`, or ``None`` if the handle is unknown, expired, or its
+        session does not belong to the user.
+    """
+    if not handle:
+        return None
+
+    now = time.time()
+    handles = _get_handles_for_session(request)
+
+    # If the handle doesn't exist, return None
+    entry = handles.get(handle)
+    if entry is None:
+        return None
+
+    # If the handle expired, delete it and return None
+    if now - entry["ts"] > HANDLE_TTL_SECONDS:
+        handles.pop(handle, None)
+        _save_handles_for_session(request, handles)
+        return None
+
+    # If the handle does not correspond to an upload session, return None
+    session = UploadSession.objects.filter(pk=entry["sid"], user=request.user).first()
+    if session is None:
+        return None
+
+    # Refresh last interaction time on entry
+    entry["ts"] = now
+    _save_handles_for_session(request, handles)
+    return session

--- a/app/upload/migrations/0003_uploadedfile_uuid.py
+++ b/app/upload/migrations/0003_uploadedfile_uuid.py
@@ -1,0 +1,60 @@
+"""Add an opaque ``uuid`` field to TempUploadedFile and PermUploadedFile.
+
+The UUID is used in user-facing file access URLs so the underlying
+``UploadSession.token`` no longer needs to be embedded in those URLs.
+
+Because the field is ``unique=True`` with a callable default, the migration is
+applied in three steps per model:
+
+1. Add the column as nullable (no unique constraint, no default).
+2. Populate UUIDs for every existing row.
+3. Apply the default + unique + not-null constraints.
+"""
+
+import uuid
+
+from django.db import migrations, models
+
+
+def populate_uuids(apps, schema_editor) -> None:  # noqa: ANN001
+    """Assign a fresh UUID to every existing TempUploadedFile and PermUploadedFile."""
+    for model_name in ("TempUploadedFile", "PermUploadedFile"):
+        Model = apps.get_model("upload", model_name)
+        for instance in Model.objects.all():
+            instance.uuid = uuid.uuid4()
+            instance.save(update_fields=["uuid"])
+
+
+class Migration(migrations.Migration):
+    """Add the uuid field to uploaded-file models for token-less access URLs."""
+
+    dependencies = [
+        ("upload", "0002_add_archivist_permissions"),
+    ]
+
+    operations = [
+        # Step 1: add the column as nullable so existing rows are not rejected.
+        migrations.AddField(
+            model_name="tempuploadedfile",
+            name="uuid",
+            field=models.UUIDField(null=True, editable=False),
+        ),
+        migrations.AddField(
+            model_name="permuploadedfile",
+            name="uuid",
+            field=models.UUIDField(null=True, editable=False),
+        ),
+        # Step 2: populate UUIDs for every existing row.
+        migrations.RunPython(populate_uuids, reverse_code=migrations.RunPython.noop),
+        # Step 3: apply the default + unique + not-null constraints.
+        migrations.AlterField(
+            model_name="tempuploadedfile",
+            name="uuid",
+            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        ),
+        migrations.AlterField(
+            model_name="permuploadedfile",
+            name="uuid",
+            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        ),
+    ]

--- a/app/upload/models.py
+++ b/app/upload/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+import uuid
 from itertools import chain
 from pathlib import Path
 from typing import Optional
@@ -590,6 +591,7 @@ def session_upload_location(instance: TempUploadedFile, filename: str) -> str:
 class BaseUploadedFile(models.Model):
     """Base class for uploaded files with shared methods."""
 
+    uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
     name = models.CharField(max_length=256, null=True, default="-")
     session = models.ForeignKey(UploadSession, on_delete=models.CASCADE, null=False)
     file_upload = models.FileField(null=True)
@@ -633,14 +635,12 @@ class BaseUploadedFile(models.Model):
         raise FileNotFoundError(f"{self.name} does not exist in session {self.session.token}")
 
     def get_file_access_url(self) -> str:
-        """Generate URL to request access for this file."""
-        return reverse(
-            "upload:uploaded_file",
-            kwargs={
-                "session_token": self.session.token,
-                "file_name": self.name,
-            },
-        )
+        """Generate URL to request access for this file.
+
+        The URL is keyed by the file's opaque :attr:`uuid` so the underlying upload session token
+        never appears in URLs exposed to the client.
+        """
+        return reverse("upload:uploaded_file_by_uuid", kwargs={"file_uuid": self.uuid})
 
     def __str__(self):
         """Return a string representation of this object."""

--- a/app/upload/tests/unit/test_views.py
+++ b/app/upload/tests/unit/test_views.py
@@ -1,23 +1,146 @@
 import logging
+import time
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
 from django.forms import ValidationError
-from django.test import TestCase, override_settings
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils.translation import gettext
+from upload.handles import HANDLE_TTL_SECONDS, SESSION_KEY
 from upload.models import TempUploadedFile, UploadSession
+from upload.views import UPLOAD_HANDLE_HEADER
+
+
+def _set_handle(
+    client: Client,
+    handle: str,
+    upload_session: UploadSession,
+    ts: float | None = None,
+) -> None:
+    """Inject a handle -> upload_session mapping into the test client's session."""
+    session = client.session
+    handles = session.get(SESSION_KEY, {})
+    handles[handle] = {"sid": upload_session.pk, "ts": ts if ts is not None else time.time()}
+    session[SESSION_KEY] = handles
+    session.save()
+
+
+def _del_handle(
+    client: Client,
+    handle: str,
+) -> None:
+    """Delete a handle previously set in _set_handle()."""
+    session = client.session
+    handles = session.get(SESSION_KEY, {})
+    if handle in handles:
+        del handles[handle]
+    session[SESSION_KEY] = handles
+    session.save()
+
+
+@override_settings(
+    FILE_UPLOAD_ENABLED=True,
+)
+class TestListFilesView(TestCase):
+    """Tests for listing uploaded files view."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        """Set up test data."""
+        cls.one_kib = bytearray([1] * 1024)
+        cls.test_user_1 = get_user_model().objects.create_user(
+            username="testuser1", password="1X<ISRUkw+tuK"
+        )
+
+    def setUp(self) -> None:
+        """Set up test environment."""
+        self.client.login(username="testuser1", password="1X<ISRUkw+tuK")
+        self.session = UploadSession.new_session(self.test_user_1)
+        self.handle = "deadbeef" * 4  # 32-char opaque handle for tests
+        _set_handle(self.client, self.handle, self.session)
+
+    def test_list_files_with_valid_handle(self) -> None:
+        """List endpoint returns the session's files when handle is valid."""
+        self.session.add_temp_file(SimpleUploadedFile("a.pdf", self.one_kib))
+        response = self.client.get(
+            reverse("upload:upload_files"),
+            HTTP_X_UPLOAD_HANDLE=self.handle,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()["files"]), 1)
+
+    def test_list_files_missing_handle(self) -> None:
+        """Endpoint returns 400 if no handle is sent."""
+        response = self.client.get(reverse("upload:upload_files"))
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+        self.assertNotIn("uploadSessionToken", response.json())
+
+    def test_list_files_unknown_handle(self) -> None:
+        """Endpoint returns 400 if the handle is not registered."""
+        response = self.client.get(
+            reverse("upload:upload_files"),
+            HTTP_X_UPLOAD_HANDLE="00000000" * 4,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_other_users_files(self) -> None:
+        """Test that a user cannot list another user's files."""
+        self.client.logout()
+
+        # Create a second user, log them in, register a handle in their session,
+        # then attempt to use that same handle while logged in as user 1.
+        other_user = get_user_model().objects.create_user(
+            username="testuser2", password="1X<ISRUkw+tuK"
+        )
+        other_session = UploadSession.new_session(user=other_user)
+        other_handle = "11112222" * 4
+        self.client.login(username="testuser2", password="1X<ISRUkw+tuK")
+        _set_handle(self.client, other_handle, other_session)
+        self.client.logout()
+
+        # Log back in as the original user, but now try to use testuser2's handle
+        self.client.login(username="testuser1", password="1X<ISRUkw+tuK")
+
+        response = self.client.get(
+            reverse("upload:upload_files"),
+            HTTP_X_UPLOAD_HANDLE=other_handle,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_expired_handle_is_rejected(self) -> None:
+        """Test that a handle with a timestamp older than the TTL is not resolvable."""
+        stale_handle = "aaaabbbb" * 4
+        _set_handle(
+            self.client,
+            stale_handle,
+            self.session,
+            ts=time.time() - (HANDLE_TTL_SECONDS + 5),
+        )
+        response = self.client.get(
+            reverse("upload:upload_files"),
+            HTTP_X_UPLOAD_HANDLE=stale_handle,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def tearDown(self) -> None:
+        """Tear down test environment."""
+        TempUploadedFile.objects.all().delete()
+        UploadSession.objects.all().delete()
+        self.client.logout()
 
 
 @override_settings(
     ACCEPTED_FILE_FORMATS={"Document": ["docx", "pdf"], "Spreadsheet": ["xlsx"]},
+    FILE_UPLOAD_ENABLED=True,
     MAX_TOTAL_UPLOAD_SIZE_MB=3,
     MAX_SINGLE_UPLOAD_SIZE_MB=1,
     MAX_TOTAL_UPLOAD_COUNT=4,
 )
 class TestUploadFilesView(TestCase):
-    """Tests for upload:upload_files view."""
+    """Test uploading files."""
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -42,101 +165,105 @@ class TestUploadFilesView(TestCase):
         self.patch__accept_file.return_value = {"accepted": True}
         self.patch__accept_session.return_value = {"accepted": True}
 
-        # Create a new upload session token
         self.session = UploadSession.new_session(user=self.test_user_1)
-        self.token = self.session.token
-        self.url = reverse("upload:upload_files", args=[self.token])
+        self.handle = "deadbeef" * 4  # 32-char opaque handle for tests
+        _set_handle(self.client, self.handle, self.session)
 
-    def tearDown(self) -> None:
-        """Tear down test environment."""
-        TempUploadedFile.objects.all().delete()
-        UploadSession.objects.all().delete()
-        self.client.logout()
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        """Tear down test class."""
-        super().tearDownClass()
-        logging.disable(logging.NOTSET)
-        patch.stopall()
-
-    ## --- GET Request Tests --- ##
-    def test_list_uploaded_files_invalid_session_token(self) -> None:
-        """Invalid session token."""
-        response = self.client.get(reverse("upload:upload_files", args=["invalid_token"]))
-        self.assertEqual(response.status_code, 400)
-        response_json = response.json()
-        self.assertIn("error", response_json)
-
-    def test_list_uploaded_files_invalid_user(self) -> None:
-        """Invalid user for the session."""
-        # Create a new session with a different user
-        other_session = UploadSession.new_session(
-            user=get_user_model().objects.create_user(
-                username="testuser2", password="1X<ISRUkw+tuK"
-            )
+    def test_upload_file_with_valid_handle(self) -> None:
+        """POST uploads a file when the handle is valid."""
+        response = self.client.post(
+            reverse("upload:upload_files"),
+            {"file": SimpleUploadedFile("File.pdf", self.one_kib)},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
         )
-        # Try to access other user's session's files
-        response = self.client.get(reverse("upload:upload_files", args=[other_session.token]))
-        self.assertEqual(response.status_code, 400)
-        response_json = response.json()
-        self.assertIn("error", response_json)
-
-    def test_list_uploaded_files_empty_session(self) -> None:
-        """Session has no files."""
-        response = self.client.get(self.url)
+        self.session.refresh_from_db()
         self.assertEqual(response.status_code, 200)
-        response_json = response.json()
-        self.assertEqual(response_json.get("files"), [])
+        self.assertEqual(self.session.file_count, 1)
 
-    def test_list_uploaded_files_with_files(self) -> None:
-        """Session has one file."""
-        file_to_upload = SimpleUploadedFile("testfile.txt", self.one_kib)
-        temp_file = self.session.add_temp_file(file_to_upload)
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-        response_json = response.json()
-        response_files = response_json.get("files")
-        self.assertEqual(len(response_files), 1)
-        self.assertEqual(response_files[0]["name"], "testfile.txt")
-        self.assertEqual(response_files[0]["size"], file_to_upload.size)
-        self.assertEqual(response_files[0]["url"], temp_file.get_file_access_url())
-
-    ## --- POST Request Tests --- ##
-
-    def test_logged_out_error(self) -> None:
-        """Test that a 302 is returned if the user is not logged in."""
+    def test_cant_upload_if_not_logged_in(self) -> None:
+        """Files should not be uploaded if the user is not logged in."""
         self.client.logout()
-        response = self.client.post(self.url, {})
+        response = self.client.post(
+            reverse("upload:upload_files"),
+            {"file": SimpleUploadedFile("File.pdf", self.one_kib)},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
+        )
         self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.session.file_count, 0)
+
+    def test_cant_upload_without_handle(self) -> None:
+        """Test that an error is received if there is no session handle."""
+        response = self.client.post(
+            reverse("upload:upload_files"),
+            {"file": SimpleUploadedFile("File.pdf", self.one_kib)},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(self.session.file_count, 0)
+
+    def test_cant_upload_with_invalid_handle(self) -> None:
+        """Test that an error is received if there is no session handle."""
+        _del_handle(self.client, self.handle)
+        response = self.client.post(
+            reverse("upload:upload_files"),
+            {"file": SimpleUploadedFile("File.pdf", self.one_kib)},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(self.session.file_count, 0)
 
     def test_500_error_caught(self) -> None:
         """Test that a 500 is returned if an error is raised."""
         self.patch__accept_file.side_effect = ValueError("err")
         response = self.client.post(
-            self.url,
+            reverse("upload:upload_files"),
             {"file": SimpleUploadedFile("File.PDF", self.one_kib)},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
         )
         self.assertEqual(response.status_code, 500)
+        self.assertIn("error", response.json())
 
     def test_no_files_uploaded(self) -> None:
         """Test that a 400 is returned if no files are uploaded."""
-        response = self.client.post(self.url, {})
+        response = self.client.post(
+            reverse("upload:upload_files"),
+            {},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
+        )
         self.assertEqual(response.status_code, 400)
 
-    def test_same_session_used(self) -> None:
-        """Test that the same session is used if the token is provided."""
+    def test_cant_upload_with_other_user_handle(self) -> None:
+        """Test that an error is received when a user tries to upload with another's token."""
+        self.client.logout()
+
+        # Start a new session as a different user
+        other_user = get_user_model().objects.create_user(
+            username="testuser2", password="1X<ISRUkw+tuK"
+        )
+        self.client.login(username="testuser2", password="1X<ISRUkw+tuK")
+
+        # First try before making our own session for the new user
         response = self.client.post(
-            self.url,
-            {"file": SimpleUploadedFile("File.pdf", self.one_kib)},
+            reverse("upload:upload_files"),
+            {"file": SimpleUploadedFile("File.PDF", self.one_kib)},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
         )
 
-        self.session.refresh_from_db()
+        self.assertEqual(response.status_code, 400)
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.session.file_count, 1)
-        # Check that no error is raised if the uploaded file is looked up within the session
-        self.session.get_file_by_name("File.pdf")
+        # Try again after making our own session
+        other_user_session = UploadSession.new_session(user=other_user)
+        other_handle = "00001111" * 4
+        _set_handle(self.client, other_handle, other_user_session)
+
+        response = self.client.post(
+            reverse("upload:upload_files"),
+            {"file": SimpleUploadedFile("File.PDF", self.one_kib)},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+        self.assertEqual(self.session.file_count, 0)
 
     def test_html_file_is_sanitized_after_malware_scan(self) -> None:
         """Test that HTML files are sanitized after malware scanning and before saving."""
@@ -150,11 +277,12 @@ class TestUploadFilesView(TestCase):
 
         self.patch_check_for_malware.side_effect = assert_unsanitized_during_malware_scan
         response = self.client.post(
-            self.url,
+            reverse("upload:upload_files"),
             {"file": SimpleUploadedFile("File.html", html_content, content_type="text/html")},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
         )
 
-        self.session.refresh_from_db()
+        self.session.refresh_from_db()  # type: ignore
         uploaded_file = self.session.get_file_by_name("File.html")
         uploaded_file.file_upload.open()
         saved_content = uploaded_file.file_upload.read()
@@ -165,39 +293,14 @@ class TestUploadFilesView(TestCase):
         self.assertNotIn(b"alert", saved_content)
         self.assertIn(b"<p>Safe</p>", saved_content)
 
-    def test_error_from_invalid_token(self) -> None:
-        """Test that a 400 error is received if the token is invalid."""
-        response = self.client.post(
-            reverse("upload:upload_files", args=["invalid_token"]),
-            {"file": SimpleUploadedFile("File.PDF", self.one_kib)},
-        )
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(self.session.file_count, 0)
-
-    def test_new_session_made_token_mismatch_user(self) -> None:
-        """Test that a 400 error is received if the token does not match the user."""
-        other_user = get_user_model().objects.create_user(
-            username="testuser2", password="1X<ISRUkw+tuK"
-        )
-        other_user_session = UploadSession.new_session(user=other_user)
-
-        response = self.client.post(
-            reverse("upload:upload_files", args=[other_user_session.token]),
-            {"file": SimpleUploadedFile("File.PDF", self.one_kib)},
-        )
-        other_user_session.refresh_from_db()
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(other_user_session.file_count, 0)
-
     def test_file_issue_flagged(self) -> None:
         """Test that an issue is flagged if the file is not accepted."""
         self.patch__accept_file.return_value = {"accepted": False, "error": "ISSUE"}
 
         response = self.client.post(
-            self.url,
+            reverse("upload:upload_files"),
             {"file": SimpleUploadedFile("File.PDF", self.one_kib)},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
         )
 
         response_json = response.json()
@@ -213,8 +316,9 @@ class TestUploadFilesView(TestCase):
         self.patch__accept_session.return_value = {"accepted": False, "error": "ISSUE"}
 
         response = self.client.post(
-            self.url,
+            reverse("upload:upload_files"),
             {"file": SimpleUploadedFile("File.PDF", self.one_kib)},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
         )
 
         response_json = response.json()
@@ -229,15 +333,16 @@ class TestUploadFilesView(TestCase):
         """Test that malware is flagged if the file contains malware."""
         self.patch_check_for_malware.side_effect = ValidationError("Malware found")
         response = self.client.post(
-            self.url,
+            reverse("upload:upload_files"),
             {"file": SimpleUploadedFile("File.PDF", self.one_kib)},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
         )
 
         response_json = response.json()
         self.session.refresh_from_db()
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response_json.get("error"), 'Malware was detected in the file "File.PDF"')
+        self.assertEqual(response_json.get("error"), "Malware was detected in the file")
         self.assertEqual(response_json.get("accepted"), False)
         self.assertEqual(self.session.file_count, 0)
 
@@ -247,8 +352,9 @@ class TestUploadFilesView(TestCase):
             "File is too large to scan for malware"
         )
         response = self.client.post(
-            self.url,
+            reverse("upload:upload_files"),
             {"file": SimpleUploadedFile("File.PDF", self.one_kib)},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
         )
 
         response_json = response.json()
@@ -256,7 +362,7 @@ class TestUploadFilesView(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            response_json.get("error"), 'File "File.PDF" is too large to scan for malware'
+            response_json.get("error"), "The file was too large to be scanned for malware"
         )
         self.assertEqual(response_json.get("accepted"), False)
         self.assertEqual(self.session.file_count, 0)
@@ -269,8 +375,9 @@ class TestUploadFilesView(TestCase):
             "Unable to scan file for malware due to scanner error"
         )
         response = self.client.post(
-            self.url,
+            reverse("upload:upload_files"),
             {"file": SimpleUploadedFile("File.PDF", self.one_kib)},
+            HTTP_X_UPLOAD_HANDLE=self.handle,
         )
 
         response_json = response.json()
@@ -278,22 +385,141 @@ class TestUploadFilesView(TestCase):
 
         self.assertEqual(response.status_code, 500)
         self.assertEqual(
-            response_json.get("error"), "Unable to scan file for malware due to scanner error"
+            response_json.get("error"),
+            "There was an error while scanning the file. Please try again later.",
         )
         self.assertEqual(response_json.get("accepted"), False)
         self.assertEqual(self.session.file_count, 0)
 
+    def tearDown(self) -> None:
+        """Tear down test environment."""
+        self.client.logout()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Tear down test class."""
+        super().tearDownClass()
+        logging.disable(logging.NOTSET)
+        patch.stopall()
+
 
 @override_settings(
     DEBUG=True,
-    FILE_UPLOAD_ENABLED=False,
-    ROOT_URLCONF="upload.urls_readonly",
+    FILE_UPLOAD_ENABLED=True,
 )
-class TestReadOnlyUploadedFileView(TestCase):
-    """Tests for uploaded_file view.
+class TestGetUploadedFileByUUID(TestCase):
+    """Test accessing files by UUID."""
 
-    Since the default GET + DELETE uploaded_file view is included when testing, we override the URL
-    config in this class to include the read-only view.
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Disable logging."""
+        super().setUpClass()
+        logging.disable(logging.CRITICAL)
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        """Set up test data."""
+        cls.one_kib = bytearray([1] * 1024)
+        User = get_user_model()
+        cls.test_user_1 = User.objects.create_user(
+            username="testuser1",
+            password="1X<ISRUkw+tuK",
+        )
+        cls.admin_user = User.objects.create_user(
+            username="admin",
+            password="3&SAjfTYZQ",
+            is_staff=True,
+        )
+
+    def setUp(self) -> None:
+        """Set up test environment."""
+        _ = self.client.login(username="testuser1", password="1X<ISRUkw+tuK")
+        self.session = UploadSession.new_session(user=self.test_user_1)
+        file_to_upload = SimpleUploadedFile("testfile.txt", self.one_kib)
+        self.temp_file = self.session.add_temp_file(file_to_upload)
+
+    def test_temp_file_access_ok(self) -> None:
+        """Test a successful temp file access request."""
+        response = self.client.get(
+            reverse("upload:uploaded_file_by_uuid", args=[self.temp_file.uuid])
+        )
+        url = self.temp_file.get_file_media_url()
+        self.assertEqual(response.url, url)
+
+    @override_settings(DEBUG=False)
+    def test_temp_file_access_prod_ok(self) -> None:
+        """Test a successful temp file access request in production."""
+        response = self.client.get(
+            reverse("upload:uploaded_file_by_uuid", args=[self.temp_file.uuid])
+        )
+        self.assertEqual(response["X-Accel-Redirect"], self.temp_file.get_file_media_url())
+
+    def test_perm_file_access_ok(self) -> None:
+        """Test a succesful file access request for a perm file."""
+        self.session.make_uploads_permanent()
+        perm_file = self.session.permuploadedfile_set.first()
+        response = self.client.get(
+            reverse(
+                "upload:uploaded_file_by_uuid",
+                args=[perm_file.uuid],
+            )
+        )
+        self.assertEqual(response.url, perm_file.get_file_media_url())
+
+    @override_settings(DEBUG=False)
+    def test_perm_file_access_prod_ok(self) -> None:
+        """Test a succesful file access request for a perm file in production."""
+        self.session.make_uploads_permanent()
+        perm_file = self.session.permuploadedfile_set.first()
+        response = self.client.get(
+            reverse(
+                "upload:uploaded_file_by_uuid",
+                args=[perm_file.uuid],
+            )
+        )
+        self.assertEqual(response["X-Accel-Redirect"], perm_file.get_file_media_url())
+
+    def test_regular_user_cant_access_other_files(self) -> None:
+        """Test that a regular non-staff user cannotget access another user's files."""
+        self.client.logout()
+
+        # Log in as a different user, and try to get the original user's file
+        _ = get_user_model().objects.create_user(username="testuser2", password="8ASbruPeZma8$")
+
+        self.client.login(username="testuser2", password="8ASbruPeZma8$")
+
+        response = self.client.get(
+            reverse(
+                "upload:uploaded_file_by_uuid",
+                args=[self.temp_file.uuid],
+            )
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_admin_user_can_access_other_files(self) -> None:
+        """Test that a staff user can access other users' files."""
+        self.client.logout()
+
+        self.client.login(username="admin", password="3&SAjfTYZQ")
+
+        response = self.client.get(
+            reverse(
+                "upload:uploaded_file_by_uuid",
+                args=[self.temp_file.uuid],
+            ),
+        )
+        self.assertEqual(response.url, self.temp_file.get_file_media_url())
+
+
+@override_settings(
+    DEBUG=True,
+    FILE_UPLOAD_ENABLED=True,
+)
+class TestGetAndDeleteUploadedFileByName(TestCase):
+    """Tests accessing and deleting files by name.
+
+    This file access method works using upload session handles.
     """
 
     @classmethod
@@ -307,9 +533,13 @@ class TestReadOnlyUploadedFileView(TestCase):
         """Set up test data."""
         cls.one_kib = bytearray([1] * 1024)
         User = get_user_model()
-        cls.test_user_1 = User.objects.create_user(username="testuser1", password="1X<ISRUkw+tuK")
+        cls.test_user_1 = User.objects.create_user(
+            username="testuser1",
+            password="1X<ISRUkw+tuK",
+        )
         cls.admin_user = User.objects.create_user(
-            username="admin", password="3&SAjfTYZQ", is_staff=True
+            username="admin",
+            password="3&SAjfTYZQ",
         )
 
     def setUp(self) -> None:
@@ -317,186 +547,188 @@ class TestReadOnlyUploadedFileView(TestCase):
         _ = self.client.login(username="testuser1", password="1X<ISRUkw+tuK")
         self.session = UploadSession.new_session(user=self.test_user_1)
 
-        file_to_upload = SimpleUploadedFile("testfile.txt", self.one_kib)
-        self.temp_file = self.session.add_temp_file(file_to_upload)
-        self.url = reverse("uploaded_file", args=[self.session.token, file_to_upload.name])
+        self.handle = "deadbeef" * 4  # 32-char opaque handle for tests
+        _set_handle(self.client, self.handle, self.session)
 
-    def test_readonly_uploaded_file_session_not_found(self) -> None:
-        """Invalid session token returns 404."""
-        response = self.client.get(
-            reverse("uploaded_file", args=["invalid_token", "testfile.txt"])
-        )
-        self.assertEqual(response.status_code, 404)
-
-    def test_readonly_uploaded_file_not_found(self) -> None:
-        """Invalid file name in a valid session."""
-        response = self.client.get(
-            reverse(
-                "uploaded_file",
-                args=[self.session.token, "invalid_file.txt"],
-            )
-        )
-        self.assertEqual(response.status_code, 404)
-
-    def test_readonly_uploaded_file_invalid_user(self) -> None:
-        """Invalid user for the session."""
-        self.session.user = get_user_model().objects.create_user(
-            username="testuser2", password="1X<ISRUkw+tuK"
-        )
-        self.session.save()
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 404)
-
-    @override_settings(DEBUG=True)
-    def test_get_readonly_uploaded_file_in_debug(self) -> None:
-        """Test getting the file in DEBUG mode."""
-        response = self.client.get(self.url)
-        self.assertEqual(response.url, self.temp_file.get_file_media_url())
-
-    @override_settings(DEBUG=False)
-    def test_get_readonly_uploaded_file_in_production(self) -> None:
-        """Test getting the file in production mode."""
-        response = self.client.get(self.url)
-        self.assertIn("X-Accel-Redirect", response.headers)
-        self.assertEqual(response.headers["X-Accel-Redirect"], self.temp_file.get_file_media_url())
-
-    def test_admin_can_get_any_readonly_uploaded_file(self) -> None:
-        """Test that admin users can get uploaded files from any session."""
-        # Login as admin
-        self.client.logout()
-        self.client.login(username="admin", password="3&SAjfTYZQ")
-
-        # Try to access the file from another user's session
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 302)
-
-    def test_delete_not_allowed_for_uploader(self) -> None:
-        """Test that the user who uploaded the file cannot DELETE it."""
-        response = self.client.delete(self.url)
-        self.assertEqual(response.status_code, 405)
-
-    def test_delete_not_allowed_for_admin(self) -> None:
-        """Test that the admins cannot DELETE uploaded files."""
-        # Login as admin
-        self.client.logout()
-        self.client.login(username="admin", password="3&SAjfTYZQ")
-
-        response = self.client.delete(self.url)
-        self.assertEqual(response.status_code, 405)
-
-    def tearDown(self) -> None:
-        """Tear down test environment."""
-        TempUploadedFile.objects.all().delete()
-        UploadSession.objects.all().delete()
-
-
-class TestUploadedFileView(TestCase):
-    """Tests for upload:uploaded_file view."""
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        """Set logging level."""
-        super().setUpClass()
-        logging.disable(logging.CRITICAL)
-
-    @classmethod
-    def setUpTestData(cls) -> None:
-        """Set up test data."""
-        cls.one_kib = bytearray([1] * 1024)
-        User = get_user_model()
-        cls.test_user_1 = User.objects.create_user(username="testuser1", password="1X<ISRUkw+tuK")
-        cls.admin_user = User.objects.create_user(
-            username="admin", password="3&SAjfTYZQ", is_staff=True
-        )
-
-    def setUp(self) -> None:
-        """Set up test environment."""
-        _ = self.client.login(username="testuser1", password="1X<ISRUkw+tuK")
-        self.session = UploadSession.new_session(user=self.test_user_1)
-
-        file_to_upload = SimpleUploadedFile("testfile.txt", self.one_kib)
         self.temp_file = self.session.add_temp_file(
             SimpleUploadedFile("testfile.txt", self.one_kib)
         )
-        self.url = reverse("upload:uploaded_file", args=[self.session.token, file_to_upload.name])
 
-    def test_uploaded_file_session_not_found(self) -> None:
-        """Invalid session token returns default 404 page (not JSON)."""
+    def test_get_invalid_handle(self) -> None:
+        """Test that getting from a non-existent session handle returns a 404.
+
+        This can happen if a session handle expires, for example.
+        """
+        _del_handle(self.client, self.handle)
         response = self.client.get(
-            reverse("upload:uploaded_file", args=["invalid_token", "testfile.txt"])
+            reverse(
+                "upload:uploaded_file_by_name",
+                args=["testfile.txt"],
+            ),
+            HTTP_X_UPLOAD_HANDLE=self.handle,
         )
         self.assertEqual(response.status_code, 404)
 
-    def test_uploaded_file_not_found(self) -> None:
-        """Invalid file name in a valid session."""
+    def test_delete_invalid_handle(self) -> None:
+        """Test that deleting from a non-existent session handle returns a 404."""
+        _del_handle(self.client, self.handle)
+        response = self.client.delete(
+            reverse(
+                "upload:uploaded_file_by_name",
+                args=["testfile.txt"],
+            ),
+            HTTP_X_UPLOAD_HANDLE=self.handle,
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_file_not_found(self) -> None:
+        """Test that getting a non-existent file returns a 404."""
         response = self.client.get(
-            reverse("upload:uploaded_file", args=[self.session.token, "invalid_file.txt"])
+            reverse(
+                "upload:uploaded_file_by_name",
+                args=["invalid_file.mp3"],
+            ),
+            HTTP_X_UPLOAD_HANDLE=self.handle,
         )
         self.assertEqual(response.status_code, 404)
 
-    def test_uploaded_file_invalid_user(self) -> None:
-        """Invalid user for the session."""
-        self.session.user = get_user_model().objects.create_user(
-            username="testuser2", password="1X<ISRUkw+tuK"
+    def test_delete_file_not_found(self) -> None:
+        """Test that deleting a non-existent file returns a 404."""
+        response = self.client.delete(
+            reverse(
+                "upload:uploaded_file_by_name",
+                args=["invalid_file.mp3"],
+            ),
+            HTTP_X_UPLOAD_HANDLE=self.handle,
         )
-        self.session.save()
-        response = self.client.get(self.url)
         self.assertEqual(response.status_code, 404)
 
-    def test_delete_uploaded_file(self) -> None:
-        """Delete an uploaded file."""
-        response = self.client.delete(self.url)
-        self.assertEqual(response.status_code, 204)
-        self.assertFalse(TempUploadedFile.objects.filter(name="testfile.txt").exists())
+    def test_cant_get_other_users_file(self) -> None:
+        """Test that a user cannot access another user's files."""
+        self.client.logout()
 
-    def test_delete_uploaded_file_invalid_user(self) -> None:
-        """Test delete with an invalid user for the session."""
-        self.session.user = get_user_model().objects.create_user(
-            username="testuser2", password="1X<ISRUkw+tuK"
+        # Log in as a different user, and upload a different file
+        other_user = get_user_model().objects.create_user(
+            username="testuser2", password="8ASbruPeZma8$"
         )
-        self.session.save()
-        response = self.client.delete(self.url)
+        self.client.login(username="testuser2", password="8ASbruPeZma8$")
+        other_session = UploadSession.new_session(other_user)
+        other_handle = "abababab" * 4
+        _set_handle(self.client, other_handle, other_session)
+        other_session.add_temp_file(SimpleUploadedFile("otheruserfile.pdf", self.one_kib))
+        self.client.logout()
+
+        # Log back in as the original user, try to access the other file
+        self.client.login(username="testuser1", password="1X<ISRUkw+tuK")
+        response = self.client.get(
+            reverse(
+                "upload:uploaded_file_by_name",
+                args=["otheruserfile.txt"],
+            ),
+            HTTP_X_UPLOAD_HANDLE=other_handle,
+        )
         self.assertEqual(response.status_code, 404)
-        self.assertTrue(TempUploadedFile.objects.filter(name="testfile.txt").exists())
-        response_json = response.json()
-        self.assertIn("error", response_json)
-        self.assertEqual(
-            response_json["error"], gettext("Invalid filename or upload session token")
+
+    def test_cant_delete_other_users_file(self) -> None:
+        """Test that a user cannot delete another user's files."""
+        self.client.logout()
+
+        # Log in as a different user, and upload a different file
+        other_user = get_user_model().objects.create_user(
+            username="testuser2", password="8ASbruPeZma8$"
         )
+        self.client.login(username="testuser2", password="8ASbruPeZma8$")
+        other_session = UploadSession.new_session(other_user)
+        other_handle = "abababab" * 4
+        _set_handle(self.client, other_handle, other_session)
+        other_session.add_temp_file(SimpleUploadedFile("otheruserfile.pdf", self.one_kib))
+        self.client.logout()
+
+        # Log back in as the original user, try to delete the other file
+        self.client.login(username="testuser1", password="1X<ISRUkw+tuK")
+        response = self.client.delete(
+            reverse(
+                "upload:uploaded_file_by_name",
+                args=["otheruserfile.txt"],
+            ),
+            HTTP_X_UPLOAD_HANDLE=other_handle,
+        )
+        self.assertEqual(response.status_code, 404)
 
     @override_settings(DEBUG=True)
-    def test_get_uploaded_file_in_debug(self) -> None:
+    def test_get_temp_file_ok(self) -> None:
         """Test getting the file in DEBUG mode."""
-        response = self.client.get(self.url)
+        response = self.client.get(
+            reverse(
+                "upload:uploaded_file_by_name",
+                args=["testfile.txt"],
+            ),
+            HTTP_X_UPLOAD_HANDLE=self.handle,
+        )
         self.assertEqual(response.url, self.temp_file.get_file_media_url())
 
     @override_settings(DEBUG=False)
-    def test_get_uploaded_file_in_production(self) -> None:
+    def test_get_temp_file_ok_in_prod(self) -> None:
         """Test getting the file in production mode."""
-        response = self.client.get(self.url)
-        self.assertIn("X-Accel-Redirect", response.headers)
-        self.assertEqual(response.headers["X-Accel-Redirect"], self.temp_file.get_file_media_url())
+        response = self.client.get(
+            reverse(
+                "upload:uploaded_file_by_name",
+                args=["testfile.txt"],
+            ),
+            HTTP_X_UPLOAD_HANDLE=self.handle,
+        )
+        self.assertIn("X-Accel-Redirect", response)
+        self.assertEqual(response["X-Accel-Redirect"], self.temp_file.get_file_media_url())
 
-    def test_admin_can_get_any_uploaded_file(self) -> None:
-        """Test that admin users can get uploaded files from any session."""
-        # Login as admin
-        self.client.logout()
-        self.client.login(username="admin", password="3&SAjfTYZQ")
-
-        # Try to access the file from another user's session
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-
-    def test_admin_can_delete_any_uploaded_file(self) -> None:
-        """Test that admin users can delete uploaded files from any session."""
-        # Login as admin
-        self.client.logout()
-        self.client.login(username="admin", password="3&SAjfTYZQ")
-
-        # Try to delete the file from another user's session
-        response = self.client.delete(self.url)
+    @override_settings(DEBUG=True)
+    def test_delete_temp_file_ok(self) -> None:
+        """Test that temp files can be deleted while uploading files."""
+        response = self.client.delete(
+            reverse(
+                "upload:uploaded_file_by_name",
+                args=["testfile.txt"],
+            ),
+            HTTP_X_UPLOAD_HANDLE=self.handle,
+        )
         self.assertEqual(response.status_code, 204)
-        self.assertFalse(TempUploadedFile.objects.filter(name="testfile.txt").exists())
+
+    @override_settings(DEBUG=False)
+    def test_delete_temp_file_ok_in_prod(self) -> None:
+        """Test getting the file in production mode."""
+        response = self.client.delete(
+            reverse(
+                "upload:uploaded_file_by_name",
+                args=["testfile.txt"],
+            ),
+            HTTP_X_UPLOAD_HANDLE=self.handle,
+        )
+        self.assertEqual(response.status_code, 204)
+
+    def test_admin_cannot_tamper_with_files(self) -> None:
+        """Test that the admins cannot GET or DELETE uploaded files other users are uploading."""
+        # Login as admin
+        self.client.logout()
+        self.client.login(username="admin", password="3&SAjfTYZQ")
+
+        # Try to delete it
+        response = self.client.delete(
+            reverse(
+                "upload:uploaded_file_by_name",
+                args=["testfile.txt"],
+            ),
+            HTTP_X_UPLOAD_HANDLE=self.handle,
+        )
+        self.assertEqual(response.status_code, 404)
+
+        # Try to get it
+        response = self.client.get(
+            reverse(
+                "upload:uploaded_file_by_name",
+                args=["testfile.txt"],
+            ),
+            HTTP_X_UPLOAD_HANDLE=self.handle,
+        )
+        self.assertEqual(response.status_code, 404)
 
     def tearDown(self) -> None:
         """Tear down test environment."""

--- a/app/upload/tests/unit/test_views.py
+++ b/app/upload/tests/unit/test_views.py
@@ -7,10 +7,8 @@ from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
 from django.forms import ValidationError
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
-from django.utils.translation import gettext
 from upload.handles import HANDLE_TTL_SECONDS, SESSION_KEY
 from upload.models import TempUploadedFile, UploadSession
-from upload.views import UPLOAD_HANDLE_HEADER
 
 
 def _set_handle(

--- a/app/upload/urls.py
+++ b/app/upload/urls.py
@@ -6,14 +6,23 @@ from . import views
 
 app_name = "upload"
 urlpatterns = [
+    # Session-token-less endpoints. The upload session is resolved on the server from the opaque
+    # per-wizard handle sent in the X-Upload-Handle request header.
     path(
-        "upload-session/<session_token>/files/",
+        "upload-session/files/",
         never_cache(login_required(views.upload_or_list_files)),
         name="upload_files",
     ),
     path(
-        "upload-session/<session_token>/files/<file_name>/",
-        never_cache(login_required(views.uploaded_file)),
-        name="uploaded_file",
+        "upload-session/files/<file_name>/",
+        never_cache(login_required(views.uploaded_file_by_name)),
+        name="uploaded_file_by_name",
+    ),
+    # Per-file access by opaque UUID. Used for browser-clickable file links (where custom request
+    # headers aren't possible) so the upload session token does not need to be embedded in the URL.
+    path(
+        "uploaded-files/<uuid:file_uuid>/",
+        login_required(views.uploaded_file_by_uuid),
+        name="uploaded_file_by_uuid",
     ),
 ]

--- a/app/upload/urls_readonly.py
+++ b/app/upload/urls_readonly.py
@@ -5,8 +5,8 @@ from . import views
 
 urlpatterns = [
     path(
-        "upload-session/<session_token>/files/<file_name>/",
-        login_required(views.readonly_uploaded_file),
-        name="uploaded_file",
+        "uploaded-files/<uuid:file_uuid>/",
+        login_required(views.uploaded_file_by_uuid),
+        name="uploaded_file_by_uuid",
     ),
 ]

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Optional, cast
+from typing import Optional
+from uuid import UUID
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -15,22 +16,29 @@ from nginx.serve import serve_media_file
 
 from .check import accept_file, accept_session
 from .clam import check_for_malware
+from .handles import resolve_handle
 from .html import sanitize_html_file
-from .models import UploadSession
+from .models import PermUploadedFile, TempUploadedFile, UploadSession
 
 User = settings.AUTH_USER_MODEL
 
 LOGGER = logging.getLogger(__name__)
 
+#: HTTP header used to convey the opaque per-wizard upload handle for the
+#: session-token-less upload endpoints.
+UPLOAD_HANDLE_HEADER = "X-Upload-Handle"
+
 
 @require_http_methods(["GET", "POST"])
-def upload_or_list_files(request: HttpRequest, session_token: str) -> JsonResponse:
-    """Upload a single file to the server list the files uploaded in a given upload session. The
-    file is added to the upload session using the session token passed as a parameter in the
-    request. If a session token is invalid, an error message is returned.
+def upload_or_list_files(request: HttpRequest) -> JsonResponse:
+    """Upload a single file to the server list the files uploaded in a given upload session.
 
-    The file type is checked against this application's :ref:`ACCEPTED_FILE_FORMATS` setting, if
-    the file is not an accepted type, an error message is returned.
+    The proper upload session is retrieved by way of accessing the request's session data. This
+    must contain a valid upload handle to list or upload files. This ID is set by the form wizard.
+
+    When uploading, the file type is checked against this application's
+    :ref:`ACCEPTED_FILE_FORMATS` setting, if the file is not an accepted type, an error message is
+    returned.
 
     Args:
         request: The HTTP GET or POST request
@@ -42,14 +50,11 @@ def upload_or_list_files(request: HttpRequest, session_token: str) -> JsonRespon
         `error` is included.
     """
     try:
-        user: User = cast(User, request.user)
-        session = UploadSession.objects.filter(token=session_token, user=user).first()
+        session = resolve_handle(request, request.headers.get(UPLOAD_HANDLE_HEADER, ""))
+
         if not session:
             return JsonResponse(
-                {
-                    "uploadSessionToken": session_token,
-                    "error": gettext("Invalid upload session token"),
-                },
+                {"error": gettext("Invalid or expired upload session")},
                 status=400,
             )
 
@@ -181,76 +186,124 @@ def _handle_upload_file(request: HttpRequest, session: UploadSession) -> JsonRes
 
 
 @require_http_methods(["GET"])
-def readonly_uploaded_file(
-    request: HttpRequest, session_token: str, file_name: str
-) -> HttpResponse:
+def uploaded_file_by_uuid(request: HttpRequest, file_uuid: UUID) -> HttpResponse:
+    """Serve an uploaded file looked up by its opaque per-file UUID.
+
+    Args:
+        request: The HTTP request.
+        file_uuid: The per-file UUID generated when the file was uploaded.
+
+    Returns:
+        HttpResponse: Redirects to the file's media path in development, or returns an
+        X-Accel-Redirect in production. 404 if the file does not exist or is not accessible to the
+        requester.
+    """
+    uploaded_file = (
+        TempUploadedFile.objects.filter(uuid=file_uuid).first()
+        or PermUploadedFile.objects.filter(uuid=file_uuid).first()
+    )
+    if uploaded_file is None:
+        raise Http404(gettext("The uploaded file could not be found"))
+
+    # Owners may access their own files; staff may access any file.
+    if not request.user.is_staff and uploaded_file.session.user_id != request.user.id:
+        LOGGER.error(
+            "A non-staff user tried to access a file they do not have ownership over! User %s "
+            "(id: %d) requested the file '%s' that they do not own.",
+            request.user.username,
+            request.user.pk,
+            file_uuid,
+        )
+        raise Http404(gettext("The uploaded file could not be found"))
+
+    try:
+        file_url = uploaded_file.get_file_media_url()
+    except FileNotFoundError as exc:
+        LOGGER.error(
+            "Tried to get a non-existent file '%s'",
+            file_uuid,
+            exc_info=exc,
+        )
+        raise Http404(gettext("The uploaded file could not be found")) from exc
+
+    return serve_media_file(file_url)
+
+
+@require_http_methods(["DELETE", "GET"])
+def uploaded_file_by_name(request: HttpRequest, file_name: str) -> HttpResponse:
+    """Get or delete a previously-uploaded file identified by the name and the upload handle.
+
+    The upload session is resolved from the X-Upload-Handle header.
+
+    Args:
+        request: The HTTP DELETE or GET request. The header ``X-Upload-Handle`` must contain a
+            valid handle previously registered by the form wizard.
+        file_name: The name of the file to retrieve or delete
+
+    Returns:
+        HttpResponse:
+            204 on successful DELETE; for GET, redirects to the file's media path in development,
+            or returns an X-Accel-Redirect to the file's media path in production. 404 if the file
+            or session cannot be resolved.
+    """
+    session = resolve_handle(request, request.headers.get(UPLOAD_HANDLE_HEADER, ""))
+
+    if request.method == "DELETE":
+        return _handle_uploaded_file_delete(session, file_name)
+
+    return _handle_uploaded_file_get(session, file_name)
+
+
+@require_http_methods(["GET"])
+def uploaded_file_by_name_readonly(request: HttpRequest, file_name: str) -> HttpResponse:
     """Get a file that has been uploaded in a given upload session.
 
     This view is suitable for viewing files when file uploads are disabled. Otherwise, not having a
     DELETE request will make it so that users can't remove files from the upload files part of the
-    form. Use ``uploaded_file`` for that instead.
+    form. Use ``uploaded_file_by_name`` for that instead.
 
     Args:
         request: The HTTP request
-        session_token: The upload session token from the URL
-        file_name: The name of the file to delete
+        file_name: The name of the file to retrieve
 
     Returns:
         HttpResponse:
             Redirects to the file's media path in development, or returns an X-Accel-Redirect to
             the file's media path if in production.
     """
-    if request.user.is_staff:
-        session = UploadSession.objects.filter(token=session_token).first()
-    else:
-        session = UploadSession.objects.filter(token=session_token, user=request.user).first()
-
+    session = resolve_handle(request, request.headers.get(UPLOAD_HANDLE_HEADER, ""))
     return _handle_uploaded_file_get(session, file_name)
-
-
-@require_http_methods(["DELETE", "GET"])
-def uploaded_file(request: HttpRequest, session_token: str, file_name: str) -> HttpResponse:
-    """Get or delete a file that has been uploaded in a given upload session.
-
-    Args:
-        request: The HTTP request
-        session_token: The upload session token from the URL
-        file_name: The name of the file to delete
-
-    Returns:
-        HttpResponse:
-            In the case of deletion, returns a 204 response when successfully deleted. In the case
-            of getting a file, redirects to the file's media path in development, or returns an
-            X-Accel-Redirect to the file's media path if in production.
-    """
-    if request.user.is_staff:
-        session = UploadSession.objects.filter(token=session_token).first()
-    else:
-        session = UploadSession.objects.filter(token=session_token, user=request.user).first()
-
-    if request.method == "DELETE":
-        return _handle_uploaded_file_delete(session, file_name)
-    else:
-        return _handle_uploaded_file_get(session, file_name)
 
 
 def _handle_uploaded_file_delete(session: Optional[UploadSession], file_name: str) -> HttpResponse:
     if not session:
         return JsonResponse(
-            {"error": gettext("Invalid filename or upload session token")},
+            {"error": gettext("Invalid upload session")},
             status=404,
         )
 
     try:
         session.remove_temp_file_by_name(file_name)
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
+        LOGGER.error(
+            "Tried to remove a non-existent file '%s' from session '%s'",
+            file_name,
+            session.token,
+            exc_info=exc,
+        )
         return JsonResponse(
-            {"error": gettext("File not found in upload session")},
+            {"error": gettext("The uploaded file could not be found")},
             status=404,
         )
-    except ValueError:
+    except ValueError as exc:
+        LOGGER.error(
+            "An error occurred while trying to remove the file '%s' from session '%s'",
+            file_name,
+            session.token,
+            exc_info=exc,
+        )
         return JsonResponse(
-            {"error": gettext("Cannot remove file from upload session")},
+            {"error": gettext("The uploaded file could not be deleted")},
             status=400,
         )
     return HttpResponse(status=204)
@@ -262,8 +315,32 @@ def _handle_uploaded_file_get(session: Optional[UploadSession], file_name: str) 
 
     try:
         uploaded_file = session.get_file_by_name(file_name)
-    except (FileNotFoundError, ValueError) as exc:
-        raise Http404("The uploaded file could not be found") from exc
+    except FileNotFoundError as exc:
+        LOGGER.error(
+            "Tried to get a non-existent file '%s' from session '%s'",
+            file_name,
+            session.token,
+            exc_info=exc,
+        )
+        raise Http404(gettext("The uploaded file could not be found")) from exc
+    except ValueError as exc:
+        LOGGER.error(
+            "An error occurred while trying to get the file '%s' from session '%s'",
+            file_name,
+            session.token,
+            exc_info=exc,
+        )
+        raise Http404(gettext("The uploaded file could not be found")) from exc
 
-    file_url = uploaded_file.get_file_media_url()
+    try:
+        file_url = uploaded_file.get_file_media_url()
+    except FileNotFoundError as exc:
+        LOGGER.error(
+            "Tried to get a non-existent file '%s' from session '%s'",
+            file_name,
+            session.token,
+            exc_info=exc,
+        )
+        raise Http404(gettext("The uploaded file could not be found")) from exc
+
     return serve_media_file(file_url)

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -272,27 +272,6 @@ def uploaded_file_by_name(request: HttpRequest, file_name: str) -> HttpResponse:
     return _handle_uploaded_file_get(session, file_name)
 
 
-@require_http_methods(["GET"])
-def uploaded_file_by_name_readonly(request: HttpRequest, file_name: str) -> HttpResponse:
-    """Get a file that has been uploaded in a given upload session.
-
-    This view is suitable for viewing files when file uploads are disabled. Otherwise, not having a
-    DELETE request will make it so that users can't remove files from the upload files part of the
-    form. Use ``uploaded_file_by_name`` for that instead.
-
-    Args:
-        request: The HTTP request
-        file_name: The name of the file to retrieve
-
-    Returns:
-        HttpResponse:
-            Redirects to the file's media path in development, or returns an X-Accel-Redirect to
-            the file's media path if in production.
-    """
-    session = resolve_handle(request, request.headers.get(UPLOAD_HANDLE_HEADER, ""))
-    return _handle_uploaded_file_get(session, file_name)
-
-
 def _handle_uploaded_file_delete(session: Optional[UploadSession], file_name: str) -> HttpResponse:
     if not session:
         return JsonResponse(

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -29,6 +29,37 @@ LOGGER = logging.getLogger(__name__)
 UPLOAD_HANDLE_HEADER = "X-Upload-Handle"
 
 
+class FileUploadResponse(JsonResponse):
+    """Structured JSON response to send to a client when a file is uploaded."""
+
+    def __init__(
+        self,
+        accepted: bool,
+        error: str | None = None,
+        verbose_error: str | None = None,
+        file: str | None = None,
+        url: str | None = None,
+        status: int = 200,
+        **kwargs,
+    ):
+        if accepted:
+            content = {
+                "accepted": accepted,
+                "file": file,
+                "url": url,
+            }
+        else:
+            content = {
+                "accepted": accepted,
+                "error": error,
+                "verboseError": verbose_error or error,
+                "file": file,
+                "url": url,
+            }
+
+        super().__init__(content, status=status, **kwargs)
+
+
 @require_http_methods(["GET", "POST"])
 def upload_or_list_files(request: HttpRequest) -> JsonResponse:
     """Upload a single file to the server list the files uploaded in a given upload session.
@@ -45,16 +76,19 @@ def upload_or_list_files(request: HttpRequest) -> JsonResponse:
         session_token: The upload session token from the URL
 
     Returns:
-        JsonResponse: If the list or upload operation was successful, the session token
-        `uploadSessionToken` is included in the response. If not successful, the error description
-        `error` is included.
+        JsonResponse:
+            If the response is not successful, the error message ``error`` is included in the
+            response. When getting files, the ``files`` key is returned. When uploading files, the
+            ``file`` and ``url`` keys are returned when successful, along with ``accepted``, which
+            indicates whether the file was accepted.
     """
     try:
         session = resolve_handle(request, request.headers.get(UPLOAD_HANDLE_HEADER, ""))
 
         if not session:
-            return JsonResponse(
-                {"error": gettext("Invalid or expired upload session")},
+            return FileUploadResponse(
+                accepted=False,
+                error=gettext("Invalid or expired upload session"),
                 status=400,
             )
 
@@ -81,28 +115,32 @@ def _handle_list_files(session: UploadSession) -> JsonResponse:
     return JsonResponse({"files": file_metadata}, status=200)
 
 
-def _handle_upload_file(request: HttpRequest, session: UploadSession) -> JsonResponse:
+def _handle_upload_file(request: HttpRequest, session: UploadSession) -> FileUploadResponse:
     _file = request.FILES.get("file")
     if not _file:
-        return JsonResponse(
-            {
-                "uploadSessionToken": session.token,
-                "error": gettext("No file was uploaded"),
-            },
+        return FileUploadResponse(
+            accepted=False,
+            error=gettext("No file was uploaded"),
             status=400,
         )
 
     file_check = accept_file(_file.name, _file.size, _file)
     if not file_check["accepted"]:
-        return JsonResponse(
-            {"file": _file.name, "uploadSessionToken": session.token, **file_check},
+        return FileUploadResponse(
+            accepted=False,
+            error=file_check.get("error") or gettext("The file was not accepted"),
+            verbose_error=file_check.get("verboseError"),
+            file=_file.name,
             status=400,
         )
 
     session_check = accept_session(_file.name, _file.size, session)
     if not session_check["accepted"]:
-        return JsonResponse(
-            {"file": _file.name, "uploadSessionToken": session.token, **session_check},
+        return FileUploadResponse(
+            accepted=False,
+            error=session_check.get("error") or gettext("The file was not accepted in session"),
+            verbose_error=session_check.get("verboseError"),
+            file=_file.name,
             status=400,
         )
 
@@ -110,37 +148,26 @@ def _handle_upload_file(request: HttpRequest, session: UploadSession) -> JsonRes
         check_for_malware(_file)
     except ValidationError as exc:
         LOGGER.error("Malware was found in the file %s", _file.name, exc_info=exc)
-        return JsonResponse(
-            {
-                "file": _file.name,
-                "accepted": False,
-                "uploadSessionToken": session.token,
-                "error": gettext('Malware was detected in the file "%(name)s"')
-                % {"name": _file.name},
-            },
+        return FileUploadResponse(
+            accepted=False,
+            error=gettext("Malware was detected in the file"),
+            file=_file.name,
             status=400,
         )
     except ValueError as exc:
         LOGGER.error("File too large for malware scanning: %s", _file.name, exc_info=exc)
-        return JsonResponse(
-            {
-                "file": _file.name,
-                "accepted": False,
-                "uploadSessionToken": session.token,
-                "error": gettext('File "%(name)s" is too large to scan for malware')
-                % {"name": _file.name},
-            },
+        return FileUploadResponse(
+            accepted=False,
+            error=gettext("The file was too large to be scanned for malware"),
+            file=_file.name,
             status=400,
         )
     except ConnectionError as exc:
         LOGGER.error("ClamAV connection error for file %s", _file.name, exc_info=exc)
-        return JsonResponse(
-            {
-                "file": _file.name,
-                "accepted": False,
-                "uploadSessionToken": session.token,
-                "error": gettext("Unable to scan file for malware due to scanner error"),
-            },
+        return FileUploadResponse(
+            accepted=False,
+            error=gettext("There was an error while scanning the file. Please try again later."),
+            file=_file.name,
             status=500,
         )
 
@@ -148,13 +175,10 @@ def _handle_upload_file(request: HttpRequest, session: UploadSession) -> JsonRes
         _file = sanitize_html_file(_file)
     except Exception as exc:
         LOGGER.error("Error sanitizing HTML file %s", _file.name, exc_info=exc)
-        return JsonResponse(
-            {
-                "file": _file.name,
-                "accepted": False,
-                "uploadSessionToken": session.token,
-                "error": gettext("There was an error processing the file"),
-            },
+        return FileUploadResponse(
+            accepted=False,
+            error=gettext("There was an error processing the file. Please try again later."),
+            file=_file.name,
             status=500,
         )
 
@@ -162,25 +186,19 @@ def _handle_upload_file(request: HttpRequest, session: UploadSession) -> JsonRes
         uploaded_file = session.add_temp_file(_file)
     except ValueError as exc:
         LOGGER.error("Error adding file to session: %s", str(exc), exc_info=exc)
-        return JsonResponse(
-            {
-                "file": _file.name,
-                "accepted": False,
-                "uploadSessionToken": session.token,
-                "error": gettext("There was an error uploading the file"),
-            },
+        return FileUploadResponse(
+            accepted=False,
+            error=gettext("There was an error uploading the file. Please try again later."),
+            file=_file.name,
             status=500,
         )
 
-    file_url = uploaded_file.get_file_access_url()
-
-    return JsonResponse(
-        {
-            "file": _file.name,
-            "accepted": True,
-            "uploadSessionToken": session.token,
-            "url": file_url,
-        },
+    # All OK!
+    return FileUploadResponse(
+        accepted=True,
+        error=None,
+        file=_file.name,
+        url=uploaded_file.get_file_access_url(),
         status=200,
     )
 

--- a/docs/code/upload/handles.rst
+++ b/docs/code/upload/handles.rst
@@ -1,0 +1,7 @@
+upload.handles - Opaque Upload Handles
+======================================
+
+.. automodule:: upload.handles
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/code/upload/index.rst
+++ b/docs/code/upload/index.rst
@@ -10,6 +10,8 @@ The ``upload`` app is responsible for accepting file uploads, and validating tho
     check
     clam
     constants
+    handles
+    html
     managers
     mime
     models


### PR DESCRIPTION
Removes the upload session token from all URLs.

Stores an upload "handle" in the request session that is associated with an upload session. This handle expires after 1 hour of inactivity. If an in-progress submission is loaded and the handle has expired, a new handle is assigned. The handle is sent to the JS via the context and is sent to the backend via the `X-Upload-Handle` header.

Adds a UUID field to files so files are accessed by file UUID when getting the file's access URL instead of by token and name. This is used on the review step and from the admin backend.

Old URLs:

- `upload-session/<session_token>/files/<file_name>/` (Upload/list files)
- `upload-session/<session_token>/files/` (See file, or delete it)

New URLs:

- `upload-session/files/` (Upload/list files, requires a valid handle)
- `upload-session/files/<file_name>/` (See file, or delete it, requires a valid handle)
- `uploaded-files/<uuid>/` (See file, does not require a handle)